### PR TITLE
Sometimes you should remove the haste map in the temp. area in order …

### DIFF
--- a/packages/metro-bundler/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro-bundler/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -301,7 +301,8 @@ class ModuleResolver<TModule: Moduleish, TPackage: Packageish> {
         `To resolve try the following:\n` +
         `  1. Clear watchman watches: \`watchman watch-del-all\`.\n` +
         `  2. Delete the \`node_modules\` folder: \`rm -rf node_modules && npm install\`.\n` +
-        '  3. Reset packager cache: `rm -fr $TMPDIR/react-*` or `npm start -- --reset-cache`.',
+        '  3. Reset packager cache: `rm -fr $TMPDIR/react-*` or `npm start -- --reset-cache`.\n' +
+        '  4. Remove haste cache: `rm -rf $TMPDIR/haste-map-react-native-packager-*`.',
     );
   }
 


### PR DESCRIPTION
…to fix the issue

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Sometimes the packager exits with an error with 3 suggestions on what can be done. Sometimes however, the suggested methods are not sufficient, and the haste map in the temp area should be removed to fix the issue. This pull request adds this to the error message

**Test plan**

I'm not sure how to reproduce the error (it was fixed after I removed the files), but if there's any test that checks the error message then it should be updated.
