### PR TITLE
Add stable id option to bundler

### DIFF
--- a/packages/metro-bundler/src/Bundler/__tests__/Bundler-test.js
+++ b/packages/metro-bundler/src/Bundler/__tests__/Bundler-test.js
@@ -50,6 +50,7 @@ var commonOptions = {
   sourceExts: defaults.sourceExts,
   transformModulePath: '/path/to/transformer.js',
   watch: false,
+  makeStableId: (m, id) => id,
 };
 
 describe('Bundler', function() {
@@ -151,7 +152,7 @@ describe('Bundler', function() {
         mainModuleId: 'foo',
         dependencies: modules,
         options: transformOptions,
-        getModuleId: () => 123,
+        getModuleId: () => ({id: 123, stable: 123}),
         getResolvedDependencyPairs: () => [],
       }),
     );

--- a/packages/metro-bundler/src/Bundler/index.js
+++ b/packages/metro-bundler/src/Bundler/index.js
@@ -389,9 +389,11 @@ class Bundler {
     const onResolutionResponse = (
       response: ResolutionResponse<Module, BundlingOptions>,
     ) => {
-      /* $FlowFixMe: looks like ResolutionResponse is monkey-patched
-       * with `getModuleId`. */
-      bundle.setMainModuleId(response.getModuleId(getMainModule(response)).stable);
+      bundle.setMainModuleId(
+        /* $FlowFixMe: looks like ResolutionResponse is monkey-patched
+         * with `getModuleId`. */
+        response.getModuleId(getMainModule(response)).stable,
+      );
       if (entryModuleOnly && entryFile) {
         response.dependencies = response.dependencies.filter(module =>
           module.path.endsWith(entryFile || ''),
@@ -642,7 +644,9 @@ class Bundler {
       {dev, platform, recursive},
       bundlingOptions,
       onProgress,
-      isolateModuleIDs ? createModuleIdFactory(this._opts.makeStableId) : this._getModuleId,
+      isolateModuleIDs
+        ? createModuleIdFactory(this._opts.makeStableId)
+        : this._getModuleId,
     );
     return response;
   }
@@ -917,7 +921,9 @@ export type ModuleIdObj = {
   stable: number | string,
 };
 
-function createModuleIdFactory(makeStableId: (m: Module, id: number) => string | number) {
+function createModuleIdFactory(
+  makeStableId: (m: Module, id: number) => string | number,
+) {
   const fileToIdMap = Object.create(null);
   let nextId = 0;
   return (m: Module): ModuleIdObj => {

--- a/packages/metro-bundler/src/Resolver/__tests__/Resolver-test.js
+++ b/packages/metro-bundler/src/Resolver/__tests__/Resolver-test.js
@@ -452,11 +452,11 @@ describe('Resolver', function() {
     });
   });
 
-  function createGetModuleId(getStable) {
+  function createGetModuleId() {
     let nextId = 1;
     const knownIds = new Map();
     function createId(path) {
-      const obj = { id: nextId, stable: getStable(path) };
+      const obj = { id: nextId, stable: nextId };
       nextId += 1;
       knownIds.set(path, obj);
       return obj;

--- a/packages/metro-bundler/src/Resolver/__tests__/Resolver-test.js
+++ b/packages/metro-bundler/src/Resolver/__tests__/Resolver-test.js
@@ -237,7 +237,7 @@ describe('Resolver', function() {
           .map(([importId, module]) => [
             importId,
             padRight(
-              resolutionResponse.getModuleId(module),
+              resolutionResponse.getModuleId(module).id,
               importId.length + 2,
             ),
           ]),
@@ -268,7 +268,7 @@ describe('Resolver', function() {
               "require( 'z' )",
               'require( "a")',
               'require("b" )',
-              `}, ${resolutionResponse.getModuleId(module)});`,
+              `}, ${resolutionResponse.getModuleId(module).stable});`,
             ].join('\n'),
           );
         });
@@ -298,7 +298,7 @@ describe('Resolver', function() {
                 code,
               `}, ${resolutionResponse.getModuleId(
                 module,
-              )}, null, "test module");`,
+              ).stable}, null, "test module");`,
             ].join('\n'),
           ),
         );
@@ -374,7 +374,7 @@ describe('Resolver', function() {
                 `__d(/* ${id} */function(global, require, module, exports) {`,
                 `module.exports = ${code}\n}, ${resolutionResponse.getModuleId(
                   module,
-                )});`,
+                ).stable});`,
               ].join(''),
             ),
           );
@@ -409,7 +409,7 @@ describe('Resolver', function() {
         expect.assertions(1);
         const wrappedCode = `__d(/* ${id} */function(global, require, module, exports) {${code}\n}, ${resolutionResponse.getModuleId(
           module,
-        )});`;
+        ).stable});`;
         return depResolver
           .wrapModule({
             resolutionResponse,

--- a/packages/metro-bundler/src/Resolver/__tests__/Resolver-test.js
+++ b/packages/metro-bundler/src/Resolver/__tests__/Resolver-test.js
@@ -56,7 +56,7 @@ describe('Resolver', function() {
     constructor({dependencies, mainModuleId}) {
       this.dependencies = dependencies;
       this.mainModuleId = mainModuleId;
-      this.getModuleId = createGetModuleId();
+      this.getModuleId = createGetModuleId(f => f);
     }
 
     prependDependency(dependency) {
@@ -156,7 +156,7 @@ describe('Resolver', function() {
             {dev: false},
             undefined,
             undefined,
-            createGetModuleId(),
+            createGetModuleId(f => f),
           ),
         )
         .then(result => {
@@ -452,14 +452,14 @@ describe('Resolver', function() {
     });
   });
 
-  function createGetModuleId() {
+  function createGetModuleId(getStable) {
     let nextId = 1;
     const knownIds = new Map();
     function createId(path) {
-      const id = nextId;
+      const obj = { id: nextId, stable: getStable(path) };
       nextId += 1;
-      knownIds.set(path, id);
-      return id;
+      knownIds.set(path, obj);
+      return obj;
     }
 
     return ({path}) => knownIds.get(path) || createId(path);

--- a/packages/metro-bundler/src/Resolver/index.js
+++ b/packages/metro-bundler/src/Resolver/index.js
@@ -188,8 +188,10 @@ class Resolver {
       .getResolvedDependencyPairs(module)
       .forEach(([depName, depModule]) => {
         if (depModule) {
-          /* $FlowFixMe: `getModuleId` is monkey-patched so may not exist */
-          resolvedDeps[depName] = JSON.stringify(resolutionResponse.getModuleId(depModule).stable);
+          resolvedDeps[depName] = JSON.stringify(
+            /* $FlowFixMe: `getModuleId` is monkey-patched so may not exist */
+            resolutionResponse.getModuleId(depModule).stable,
+          );
         }
       });
 

--- a/packages/metro-bundler/src/Resolver/index.js
+++ b/packages/metro-bundler/src/Resolver/index.js
@@ -189,7 +189,7 @@ class Resolver {
       .forEach(([depName, depModule]) => {
         if (depModule) {
           /* $FlowFixMe: `getModuleId` is monkey-patched so may not exist */
-          resolvedDeps[depName] = resolutionResponse.getModuleId(depModule);
+          resolvedDeps[depName] = JSON.stringify(resolutionResponse.getModuleId(depModule).stable);
         }
       });
 
@@ -241,7 +241,7 @@ class Resolver {
       code = definePolyfillCode(code);
     } else {
       /* $FlowFixMe: `getModuleId` is monkey-patched so may not exist */
-      const moduleId = resolutionResponse.getModuleId(module);
+      const moduleId = resolutionResponse.getModuleId(module).stable;
       code = this.resolveRequires(
         resolutionResponse,
         module,

--- a/packages/metro-bundler/src/Resolver/polyfills/require.js
+++ b/packages/metro-bundler/src/Resolver/polyfills/require.js
@@ -145,7 +145,9 @@ function identity(id) {
   return id;
 }
 
-const getNumericModuleId = USING_STABLE_IDS ? convertStableIdToModuleId : identity;
+const getNumericModuleId = USING_STABLE_IDS
+  ? convertStableIdToModuleId
+  : identity;
 
 function loadModuleImplementation(moduleId, module) {
   const nativeRequire = global.nativeRequire;

--- a/packages/metro-bundler/src/Server/index.js
+++ b/packages/metro-bundler/src/Server/index.js
@@ -41,6 +41,7 @@ import type {
   PostProcessModules,
   PostMinifyProcess,
   PostProcessBundleSourcemap,
+  ModuleIdObj,
 } from '../Bundler';
 import type {TransformCache} from '../lib/TransformCaching';
 import type {GlobalTransformCache} from '../lib/GlobalTransformCache';
@@ -95,6 +96,7 @@ export type Options = {|
   transformTimeoutInterval?: number,
   watch?: boolean,
   workerPath: ?string,
+  makeStableId: (m: Module, id: number) => string | number,
 |};
 
 export type BundleOptions = {
@@ -157,6 +159,7 @@ class Server {
     transformTimeoutInterval: ?number,
     watch: boolean,
     workerPath: ?string,
+    makeStableId: (m: Module, id: number) => string | number,
   };
   _projectRoots: $ReadOnlyArray<string>;
   _bundles: {};
@@ -211,6 +214,7 @@ class Server {
       transformTimeoutInterval: options.transformTimeoutInterval,
       watch: options.watch || false,
       workerPath: options.workerPath,
+      makeStableId: options.makeStableId,
     };
 
     const processFileChange = ({type, filePath}) =>

--- a/packages/metro-bundler/src/index.js
+++ b/packages/metro-bundler/src/index.js
@@ -157,5 +157,6 @@ function toServerOptions(options: Options): ServerOptions {
     transformTimeoutInterval: options.transformTimeoutInterval,
     watch: typeof options.watch === 'boolean' ? options.watch : !!options.nonPersistent,
     workerPath: options.workerPath,
+    makeStableId: options.makeStableId,
   };
 }

--- a/packages/metro-bundler/src/integration_tests/__tests__/__snapshots__/basic_bundle-test.js.snap
+++ b/packages/metro-bundler/src/integration_tests/__tests__/__snapshots__/basic_bundle-test.js.snap
@@ -41,8 +41,10 @@ function define(factory, moduleId, dependencyMap) {
   }
 }
 
+var USING_STABLE_IDS = !!global.__requireModuleIdMap;
+
 function _require(moduleId) {
-  if (__DEV__ && typeof moduleId === 'string') {
+  if (__DEV__ && typeof moduleId === 'string' && (!USING_STABLE_IDS || !(moduleId in global.__requireModuleIdMap))) {
     var _verboseName2 = moduleId;
     moduleId = verboseNamesToModuleIds[_verboseName2];
     if (moduleId == null) {
@@ -80,10 +82,20 @@ function guardedLoadModule(moduleId, module) {
   }
 }
 
+function convertStableIdToModuleId(stableId) {
+  return global.__requireModuleIdMap[stableId];
+}
+
+function identity(id) {
+  return id;
+}
+
+var getNumericModuleId = USING_STABLE_IDS ? convertStableIdToModuleId : identity;
+
 function loadModuleImplementation(moduleId, module) {
   var nativeRequire = global.nativeRequire;
   if (!module && nativeRequire) {
-    nativeRequire(moduleId);
+    nativeRequire(getNumericModuleId(moduleId));
     module = modules[moduleId];
   }
 
@@ -314,8 +326,10 @@ function define(factory, moduleId, dependencyMap) {
   }
 }
 
+var USING_STABLE_IDS = !!global.__requireModuleIdMap;
+
 function _require(moduleId) {
-  if (__DEV__ && typeof moduleId === 'string') {
+  if (__DEV__ && typeof moduleId === 'string' && (!USING_STABLE_IDS || !(moduleId in global.__requireModuleIdMap))) {
     var _verboseName2 = moduleId;
     moduleId = verboseNamesToModuleIds[_verboseName2];
     if (moduleId == null) {
@@ -353,10 +367,20 @@ function guardedLoadModule(moduleId, module) {
   }
 }
 
+function convertStableIdToModuleId(stableId) {
+  return global.__requireModuleIdMap[stableId];
+}
+
+function identity(id) {
+  return id;
+}
+
+var getNumericModuleId = USING_STABLE_IDS ? convertStableIdToModuleId : identity;
+
 function loadModuleImplementation(moduleId, module) {
   var nativeRequire = global.nativeRequire;
   if (!module && nativeRequire) {
-    nativeRequire(moduleId);
+    nativeRequire(getNumericModuleId(moduleId));
     module = modules[moduleId];
   }
 

--- a/packages/metro-bundler/src/integration_tests/__tests__/basic_bundle-test.js
+++ b/packages/metro-bundler/src/integration_tests/__tests__/basic_bundle-test.js
@@ -101,6 +101,7 @@ describe('basic_bundle', () => {
         transformCache: Packager.TransformCaching.none(),
         transformModulePath: require.resolve('../../transformer'),
         nonPersistent: true,
+        makeStableId: (m, id) => id,
       },
       {
         dev: false,
@@ -120,6 +121,7 @@ describe('basic_bundle', () => {
         transformCache: Packager.TransformCaching.none(),
         transformModulePath: require.resolve('../../transformer'),
         nonPersistent: true,
+        makeStableId: (m, id) => id,
       },
       {
         dev: false,

--- a/packages/metro-bundler/src/shared/output/unbundle/index.js
+++ b/packages/metro-bundler/src/shared/output/unbundle/index.js
@@ -35,8 +35,19 @@ function saveUnbundle(
 ): Promise<mixed> {
   // we fork here depending on the platform:
   // while android is pretty good at loading individual assets, ios has a large
-  // overhead when reading hundreds pf assets from disk
-  return options.platform === 'android' && !options.indexedUnbundle ?
+  // overhead when reading hundreds pf assets from disk. As a result, indexedUnbundle
+  // is the default for iOS, while assetUnbundle is the default for Android.
+  // That said, there still may be some reason why someone would want to build
+  // either format for either platform, so provide the ability to force
+  // either one.
+  let useAssetBundle = false;
+  if (options.platform === 'android' && !options.indexedUnbundle) {
+    useAssetBundle = true;
+  }
+  if (options.platform === 'ios' && options.assetUnbundle) {
+    useAssetBundle = true;
+  }
+  return useAssetBundle ?
     asAssets(bundle, options, log) :
     asIndexedFile(bundle, options, log);
 }

--- a/packages/metro-bundler/src/shared/types.flow.js
+++ b/packages/metro-bundler/src/shared/types.flow.js
@@ -33,6 +33,8 @@ export type OutputOptions = {
   sourcemapOutput?: string,
   sourcemapSourcesRoot?: string,
   sourcemapUseAbsolutePath?: boolean,
+  indexedUnbundle?: boolean,
+  assetUnbundle?: boolean
 };
 
 export type RequestOptions = {|


### PR DESCRIPTION
**Summary**

This PR adds an option to the bundler for a `makeStableId` function of type `(m: Module, id: number) => string | number`. The purpose of this option is to allow people to specify module ids that are stable and are based on the identity of the module, rather than it's index in the topological sorting of the dependency graph (which is how it works now).

The numeric module ids are important and necessary for the RAMBundle format, however one can create a mapping from `stable id => module id` that can be used in tandem with this and the RAMBundle format.

At Airbnb we need this in order to provide diffs from one build to another. Without a stable id, a single line change can result in every file in the code base requiring a diff (ie, inserting a module will create a +1 offset on all of the modules.

The `makeStableId` function could be provided in the `rn-cli.config.js`. The default will simply be: `(m, id) => id` which will preserve the current functionality and make this a non-breaking and backwards compatible change.

This change has been requested and discussed in the following issues: #6 and #35 

I urge the metro bundler team to consider such a change. Let me know if there is anything I can do or need to prove in order to make this accepted.


**Test plan**

I've been using this code locally and it works. I'll make sure that tests and stuff pass but if there's anything you want me to show or verify, let me know.
