### PR TITLE
Fix 404 on front page 'Learn more' link

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -79,7 +79,7 @@ class HomeSplash extends React.Component {
                         siteConfig.baseUrl +
                         'docs/' +
                         this.props.language +
-                        '/getting-started.html'
+                        '/api.html'
                       }
                     >
                       <translate>Get Started</translate>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Currently index.js points to snapshot-testing which doesn't exist. Perhaps the intent was to link to the API page so that is what I changed.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

front page 'learn more' link should work

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
