### PR TITLE
Use `declare module.exports` syntax for flow libdefs

### DIFF
--- a/flow-typed/babel.js.flow
+++ b/flow-typed/babel.js.flow
@@ -132,8 +132,8 @@ type RawMapping = {
 
 declare module 'babel-generator' {
   declare type RawMapping = RawMapping;
-  declare function exports(
+  declare module.exports: (
     ast: Ast,
     options?: GeneratorOptions,
-  ): TransformResult & {rawMappings: ?Array<RawMapping>};
+  ) => TransformResult & {rawMappings: ?Array<RawMapping>};
 }


### PR DESCRIPTION
**Summary**

We added this to Flow in v0.25 (about 2 years ago), but never actually
deprecated the legacy `declare var exports` syntax. Hoping to do that
soon, so clearing up uses that I can find.

**Test plan**

flow