### PR TITLE
Fix out of memory error in projects with a lot of assets

### DIFF
--- a/packages/metro/src/node-haste/Module.js
+++ b/packages/metro/src/node-haste/Module.js
@@ -140,9 +140,11 @@ class Module {
   }
 
   getName(): string {
-    const name = this._getHasteName();
-    if (name != null) {
-      return name;
+    if (this.isHaste()) {
+      const name = this._getHasteName();
+      if (name != null) {
+        return name;
+      }
     }
 
     const p = this.getPackage();


### PR DESCRIPTION
**Summary**

Metro crashed with "Allocation failed - JavaScript heap out of memory" when trying to build a project with a lot of assets. (Repro: https://github.com/fson/metro-out-of-memory, `yarn start` and open the app.)

By looking at a heap snapshot, I found out the reason was that `node-haste` was reading the contents of asset files and parsing them in search of the `@providesModule` docblock field, although it should only do this for source files. I fixed this by checking that `isHaste()` evaluates to `true` before attempting to read the docblock. (`AssetModule` always returns `false` for `isHaste()`.)

**Test plan**

* Ran the [repro](https://github.com/fson/metro-out-of-memory) before the fix. It crashed with `FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory`
  * Heap snapshot: <img width="1440" alt="screen shot 2018-01-03 at 17 31 53" src="https://user-images.githubusercontent.com/497214/34571809-33ee8dfc-f178-11e7-93f9-3fd80e62c188.png">
* After implementing the fix, ensured that the process didn't crash anymore and the heap didn't grow significantly during the build: 
![screen shot 2018-01-04 at 17 39 26](https://user-images.githubusercontent.com/497214/34571848-622818aa-f178-11e7-9972-9f54146a83ee.png)