### PR TITLE
[Docs] Copypasta / typo

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -9,4 +9,4 @@ Uh oh, something went wrong? Use this guide to resolve issues with Metro.
 
 ### Still unresolved?
 
-See [Help](/jest/help.html).
+See [Help](/metro/help.html).


### PR DESCRIPTION
**Summary**

Just noticed this link in the docs is pointing to the Jest help page - presumably a remnant from project boilerplate or copypasta :) 

**Test plan**

Docs update only
