### PR TITLE
Add back support for the assetPlugin option

### DIFF
--- a/packages/metro/src/DeltaBundler/DeltaCalculator.js
+++ b/packages/metro/src/DeltaBundler/DeltaCalculator.js
@@ -159,6 +159,7 @@ class DeltaCalculator extends EventEmitter {
     } = this._bundler.getGlobalTransformOptions();
 
     const transformOptionsForBlacklist = {
+      assetDataPlugins: this._options.assetPlugins,
       enableBabelRCLookup,
       dev: this._options.dev,
       hot: this._options.hot,

--- a/packages/metro/src/DeltaBundler/Serializers.js
+++ b/packages/metro/src/DeltaBundler/Serializers.js
@@ -238,7 +238,12 @@ async function getAssets(
           module.path,
         );
 
-        return getAssetData(module.path, localPath, options.platform);
+        return getAssetData(
+          module.path,
+          localPath,
+          options.assetPlugins,
+          options.platform,
+        );
       }
       return null;
     }),

--- a/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js
@@ -297,6 +297,7 @@ describe('DeltaCalculator', () => {
   describe('getTransformerOptions()', () => {
     it('should calculate the transform options correctly', async () => {
       expect(await deltaCalculator.getTransformerOptions()).toEqual({
+        assetDataPlugins: [],
         dev: true,
         enableBabelRCLookup: false,
         hot: true,
@@ -315,6 +316,7 @@ describe('DeltaCalculator', () => {
       );
 
       expect(await deltaCalculator.getTransformerOptions()).toEqual({
+        assetDataPlugins: [],
         dev: true,
         enableBabelRCLookup: false,
         hot: true,
@@ -333,6 +335,7 @@ describe('DeltaCalculator', () => {
       );
 
       expect(await deltaCalculator.getTransformerOptions()).toEqual({
+        assetDataPlugins: [],
         dev: true,
         enableBabelRCLookup: false,
         hot: true,

--- a/packages/metro/src/DeltaBundler/__tests__/Serializers-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/Serializers-test.js
@@ -78,11 +78,13 @@ describe('Serializers', () => {
       },
     };
 
-    getAssetData.mockImplementation((path, localPath, platform) => ({
-      path,
-      platform,
-      assetData: true,
-    }));
+    getAssetData.mockImplementation(
+      (path, localPath, assetDataPlugins, platform) => ({
+        path,
+        platform,
+        assetData: true,
+      }),
+    );
 
     toLocalPath.mockImplementation((roots, path) => path.replace(roots[0], ''));
 

--- a/packages/metro/src/JSTransformer/worker/index.js
+++ b/packages/metro/src/JSTransformer/worker/index.js
@@ -61,6 +61,7 @@ export type Transformer<ExtraOptions: {} = {}> = {
 };
 
 export type TransformOptionsStrict = {|
+  +assetDataPlugins: $ReadOnlyArray<string>,
   +enableBabelRCLookup: boolean,
   +dev: boolean,
   +hot: boolean,
@@ -71,6 +72,7 @@ export type TransformOptionsStrict = {|
 |};
 
 export type TransformOptions = {
+  +assetDataPlugins: $ReadOnlyArray<string>,
   +enableBabelRCLookup?: boolean,
   +dev?: boolean,
   +hot?: boolean,
@@ -200,7 +202,11 @@ function transformCode(
   };
 
   const transformResult = isAsset(filename, assetExts)
-    ? assetTransformer.transform(transformerArgs, assetRegistryPath)
+    ? assetTransformer.transform(
+        transformerArgs,
+        assetRegistryPath,
+        options.assetDataPlugins,
+      )
     : transformer.transform(transformerArgs);
 
   const postTransformArgs = [

--- a/packages/metro/src/ModuleGraph/worker/__tests__/transform-module-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/transform-module-test.js
@@ -86,6 +86,7 @@ describe('transforming JS modules:', () => {
   });
 
   const defaults = {
+    assetDataPlugins: [],
     dev: false,
     hot: false,
     inlineRequires: false,

--- a/packages/metro/src/ModuleGraph/worker/transform-module.js
+++ b/packages/metro/src/ModuleGraph/worker/transform-module.js
@@ -48,6 +48,7 @@ export type TransformOptions<ExtraOptions> = {|
 
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 const defaultTransformOptions = {
+  assetDataPlugins: [],
   dev: false,
   hot: false,
   inlineRequires: false,

--- a/packages/metro/src/assetTransformer.js
+++ b/packages/metro/src/assetTransformer.js
@@ -27,6 +27,7 @@ type Params = {
 async function transform(
   {filename, localPath, options, src}: Params,
   assetRegistryPath: string,
+  assetDataPlugins: $ReadOnlyArray<string>,
 ): Promise<{ast: Ast}> {
   options = options || {
     platform: '',
@@ -35,7 +36,12 @@ async function transform(
     minify: false,
   };
 
-  const data = await getAssetData(filename, localPath, options.platform);
+  const data = await getAssetData(
+    filename,
+    localPath,
+    assetDataPlugins,
+    options.platform,
+  );
 
   return {
     ast: generateAssetCodeFileAst(assetRegistryPath, data),

--- a/packages/metro/src/lib/__tests__/__snapshots__/getTransformCacheKeyFn-test.js.snap
+++ b/packages/metro/src/lib/__tests__/__snapshots__/getTransformCacheKeyFn-test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getTransformCacheKeyFn Should return always the same key for the same params 1`] = `"4f055d9baf74ca63c449a03d12d3ea5e06dce486012af2c6d0afa156e0a3350ab9187479"`;
+exports[`getTransformCacheKeyFn Should return always the same key for the same params 1`] = `"78c7c4254ad9c8290da4f45eec858cee4466daae22073b63c802f6d42d41280131b93e42"`;

--- a/packages/metro/src/transformer.js
+++ b/packages/metro/src/transformer.js
@@ -122,6 +122,7 @@ type Params = {
 
 function transform({filename, options, src, plugins}: Params) {
   options = options || {
+    assetDataPlugins: [],
     platform: '',
     projectRoot: '',
     inlineRequires: false,


### PR DESCRIPTION
**Summary**
Metro used to have support for "asset plugins", which allowed developers to specify arbitrary JS modules that could export a function for adding more fields to asset data objects. Some of this functionality was removed in the delta bundler work -- this PR adds it back.

**Test plan**
Made existing unit tests pass and added unit tests to test asset plugin behavior. Also tested E2E in a React Native project by adding `assetPlugin=/path/to/pluginModule` to a JS bundle URL and ensuring that the plugin ran.