### PR TITLE
Use `error.message` to set the `description` property of a nested error payload

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -47,6 +47,7 @@
     "mkdirp": "^0.5.1",
     "request": "^2.79.0",
     "rimraf": "^2.5.4",
+    "serialize-error": "^2.1.0",
     "source-map": "^0.5.6",
     "temp": "0.8.3",
     "throat": "^4.1.0",

--- a/packages/metro/src/HmrServer/__tests__/HmrServer-test.js
+++ b/packages/metro/src/HmrServer/__tests__/HmrServer-test.js
@@ -158,6 +158,7 @@ describe('HmrServer', () => {
         message: 'test syntax error',
         errors: [
           {
+            description: 'test syntax error',
             filename: 'EntryPoint.js',
             lineNumber: 123,
           },

--- a/packages/metro/src/HmrServer/__tests__/HmrServer-test.js
+++ b/packages/metro/src/HmrServer/__tests__/HmrServer-test.js
@@ -42,7 +42,7 @@ describe('HmrServer', () => {
         return deltaBundlerMock;
       },
     };
-    getDeltaTransformerMock.reporterMock = {
+    reporterMock = {
       update: jest.fn(),
     };
 
@@ -120,6 +120,48 @@ describe('HmrServer', () => {
           sourceURLs: {},
           sourceMappingURLs: {},
         },
+      });
+      expect(JSON.parse(sendMessage.mock.calls[2][0])).toEqual({
+        type: 'update-done',
+      });
+      done();
+    }, 30);
+  });
+
+  it('should return error messages when there is a transform error', async done => {
+    jest.useRealTimers();
+    const sendMessage = jest.fn();
+
+    await hmrServer.onClientConnect(
+      '/hot?bundleEntry=EntryPoint.js&platform=ios',
+      sendMessage,
+    );
+
+    deltaTransformerMock.getDelta.mockImplementation(async () => {
+      const transformError = new SyntaxError('test syntax error');
+      transformError.type = 'TransformError';
+      transformError.filename = 'EntryPoint.js';
+      transformError.lineNumber = 123;
+      throw transformError;
+    });
+
+    deltaTransformerMock.emit('change');
+
+    setTimeout(function() {
+      expect(JSON.parse(sendMessage.mock.calls[0][0])).toEqual({
+        type: 'update-start',
+      });
+      const sentErrorMessage = JSON.parse(sendMessage.mock.calls[1][0]);
+      expect(sentErrorMessage).toMatchObject({type: 'error'});
+      expect(sentErrorMessage.body).toMatchObject({
+        type: 'TransformError',
+        message: 'test syntax error',
+        errors: [
+          {
+            filename: 'EntryPoint.js',
+            lineNumber: 123,
+          },
+        ],
       });
       expect(JSON.parse(sendMessage.mock.calls[2][0])).toEqual({
         type: 'update-done',

--- a/packages/metro/src/JSTransformer/__tests__/Transformer-test.js
+++ b/packages/metro/src/JSTransformer/__tests__/Transformer-test.js
@@ -87,7 +87,6 @@ describe('Transformer', function() {
         const babelError = new SyntaxError(message);
 
         babelError.type = 'SyntaxError';
-        babelError.description = message;
         babelError.loc = {line: 2, column: 15};
         babelError.codeFrame = snippet;
 

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -320,6 +320,7 @@ describe('processRequest', () => {
             message: 'test syntax error',
           });
           expect(body.errors).toContainEqual({
+            description: 'test syntax error',
             filename: 'testFile.js',
             lineNumber: 123,
           });

--- a/packages/metro/src/lib/__tests__/__snapshots__/getTransformCacheKeyFn-test.js.snap
+++ b/packages/metro/src/lib/__tests__/__snapshots__/getTransformCacheKeyFn-test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getTransformCacheKeyFn Should return always the same key for the same params 1`] = `"19a529ca8ec00ec50dbbf2de5278262868c1a04f32be6252a9bc5b8df65171914db10f84"`;
+exports[`getTransformCacheKeyFn Should return always the same key for the same params 1`] = `"19a529ca8ec00ec50dbbf2de5278262868c1a04f22073b63c802f6d42d41280131b93e42"`;

--- a/packages/metro/src/lib/formatBundlingError.js
+++ b/packages/metro/src/lib/formatBundlingError.js
@@ -24,7 +24,6 @@ const {
 export type CustomError = Error & {|
   status?: number,
   type?: string,
-  description?: string,
   filename?: string,
   lineNumber?: number,
   errors?: Array<{
@@ -63,7 +62,7 @@ function formatBundlingError(
   ) {
     error.errors = [
       {
-        description: error.description,
+        description: error.message,
         filename: error.filename,
         lineNumber: error.lineNumber,
       },

--- a/packages/metro/src/lib/formatBundlingError.js
+++ b/packages/metro/src/lib/formatBundlingError.js
@@ -12,6 +12,8 @@
 
 'use strict';
 
+const serializeError = require('serialize-error');
+
 const {
   UnableToResolveError,
 } = require('../node-haste/DependencyGraph/ModuleResolution');
@@ -67,7 +69,7 @@ function formatBundlingError(
       },
     ];
 
-    return error;
+    return serializeError(error);
   } else {
     return {
       type: 'InternalError',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4869,6 +4869,10 @@ send@0.13.2:
     range-parser "~1.0.3"
     statuses "~1.2.1"
 
+serialize-error@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
+
 serve-favicon@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/serve-favicon/-/serve-favicon-2.3.2.tgz#dd419e268de012ab72b319d337f2105013f9381f"


### PR DESCRIPTION
Depends on #124.

---

**Summary**
Metro reports errors using a JSON payload that has an `errors` array. Each item in this array has a `description` field. For transform errors, this field was set using the value in `error.description` -- however, JS Error objects only have a `message` field. (Grepping the Metro code, no errors (except in one test) ever get a `description` field.) This commit uses `error.message` instead of `error.description` when creating JSON payloads.

```
$ git grep description -- 'packages/**/*.js'
packages/metro/src/JSTransformer/__tests__/Transformer-test.js:        babelError.description = message;
packages/metro/src/lib/formatBundlingError.js:    description: string,
packages/metro/src/lib/formatBundlingError.js:): {type: string, message: string, errors: Array<{description: string}>} {
packages/metro/src/lib/formatBundlingError.js:      errors: [{description: message}],
packages/metro/src/lib/formatBundlingError.js:        description: error.message,
packages/metro/src/node-haste/__tests__/Module-test.js:  description: "A require('foo') story",
```

**Test Plan**
Added a unit test to check that the description field is set for transform errors (with the delta bundler).

Also in a test RN app, inspected the error payload that is received by RN when there's a syntax error with HMR turned on and verified that `data.body.errors[0].description` was set.