### PR TITLE
Clarify advice on resetting bundler cache

### DIFF
--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -210,8 +210,8 @@ class ModuleResolver<TModule: Moduleish, TPackage: Packageish> {
         `To resolve try the following:\n` +
         `  1. Clear watchman watches: \`watchman watch-del-all\`.\n` +
         `  2. Delete the \`node_modules\` folder: \`rm -rf node_modules && npm install\`.\n` +
-        '  3. Reset Metro Bundler cache: `rm -rf $TMPDIR/react-*` or `npm start -- --reset-cache`.' +
-        '  4. Remove haste cache: `rm -rf $TMPDIR/haste-map-react-native-packager-*`.',
+        '  3. Reset Metro Bundler cache: `rm -rf /tmp/metro-bundler-cache-*` or `npm start -- --reset-cache`.' +
+        '  4. Remove haste cache: `rm -rf /tmp/haste-map-react-native-packager-*`.',
     );
   }
 


### PR DESCRIPTION
**Summary**

The cache dir name now starts with `metro-bundler-cache-` but the message still refers to `react-`.

This just wasted a bit of my time before I realized and that's not the first time this happens either.

Also I don't have `$TMPDIR` defined on vanilla ubuntu, I think using that instead of `/tmp` creates more confusion than helps.

**Test plan**

Just a change in a string constant.


I signed the CLA.