### PR TITLE
Pass numWorkers instead of maxWorkers to jest-worker

### DIFF
--- a/packages/metro/src/JSTransformer/index.js
+++ b/packages/metro/src/JSTransformer/index.js
@@ -148,7 +148,7 @@ module.exports = class Transformer {
       computeWorkerKey,
       exposedMethods,
       forkOptions: {execArgv},
-      maxWorkers,
+      numWorkers: maxWorkers,
     });
   }
 

--- a/packages/metro/src/JSTransformer/index.js
+++ b/packages/metro/src/JSTransformer/index.js
@@ -132,7 +132,7 @@ module.exports = class Transformer {
     }
   }
 
-  _makeFarm(workerPath, computeWorkerKey, exposedMethods, maxWorkers) {
+  _makeFarm(workerPath, computeWorkerKey, exposedMethods, numWorkers) {
     // We whitelist only what would work. For example `--inspect` doesn't work
     // in the workers because it tries to open the same debugging port. Feel
     // free to add more cases to the RegExp. A whitelist is preferred, to
@@ -148,7 +148,7 @@ module.exports = class Transformer {
       computeWorkerKey,
       exposedMethods,
       forkOptions: {execArgv},
-      numWorkers: maxWorkers,
+      numWorkers,
     });
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Jest Worker accepts parameter `numWorkers`, not `maxWorkers`, see:
https://github.com/facebook/jest/tree/master/packages/jest-worker#numworkers-number-optional

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
