### PR TITLE
Add `safari10: true` to Uglify options

### DIFF
--- a/packages/metro-minify-uglify/src/minifier.js
+++ b/packages/metro-minify-uglify/src/minifier.js
@@ -36,7 +36,12 @@ function withSourceMap(
 
 function minify(inputCode: string, inputMap: ?BabelSourceMap) {
   const result = uglify.minify(inputCode, {
-    mangle: {toplevel: true},
+    mangle: {
+      toplevel: true,
+      // JSC has issues with block-scoped variables.
+      // https://github.com/mishoo/UglifyJS2/issues/1753#issuecomment-324814782
+      safari10: true,
+    },
     output: {
       ascii_only: true,
       quote_style: 3,


### PR DESCRIPTION
**Summary**

JSCore has known issues with block-scoped variables which were not addressed until iOS 11.

These problems are generally masked by an over-zealous Babel configuration that removes all block scoping. If you modernize your Babel configuration to retain some ES6 features, you'll quickly run into
'illegal duplicate declaration' issues on Android and iOS 10.

This is a quick-and-simple fix that ensures the code emitted by Uglify will work properly on these platforms.

**Test Plan**

This fixes issues I was encountering in the wild. Let me know if you feel this needs automated testing.