### PR TITLE
Minor fixes to aid in the adoption of Babel 7

### DIFF
--- a/packages/metro/src/babel-bridge.js
+++ b/packages/metro/src/babel-bridge.js
@@ -107,51 +107,11 @@ module.exports = {
   getPreset: IS_BABEL7 ? getPreset7 : getPreset6,
 };
 
+// Plugin not functional in Babel 7, is deprecated, and no replacement exists.
 function makeMakeHMRConfig7() {
-  // from: babel-preset-react-native/configs/hmr
-  /**
-   * Copyright (c) 2015-present, Facebook, Inc.
-   * All rights reserved.
-   *
-   * This source code is licensed under the BSD-style license found in the
-   * LICENSE file in the root directory of this source tree. An additional grant
-   * of patent rights can be found in the PATENTS file in the same directory.
-   */
-  'use strict';
-
-  var path = require('path');
-  var hmrTransform = 'react-transform-hmr/lib/index.js';
-  var transformPath = require.resolve(hmrTransform);
-
-  return function(options: mixed, filename?: string) {
-    return {}; // Plugin not functional in Babel 7, is deprecated, and no replacement exists.
-
-    var transform = filename
-      ? './' + path.relative(path.dirname(filename), transformPath) // packager can't handle absolute paths
-      : hmrTransform;
-
-    // Fix the module path to use '/' on Windows.
-    if (path.sep === '\\') {
-      transform = transform.replace(/\\/g, '/');
-    }
-
-    return {
-      plugins: resolvePlugins7([
-        [
-          'react-transform',
-          {
-            transforms: [
-              {
-                transform,
-                imports: ['react'],
-                locals: ['module'],
-              },
-            ],
-          },
-        ],
-      ]),
-    };
-  };
+  return function() {
+    return {};
+  }
 }
 
 function getPreset7() {

--- a/packages/metro/src/babel-bridge.js
+++ b/packages/metro/src/babel-bridge.js
@@ -109,9 +109,9 @@ module.exports = {
 
 // Plugin not functional in Babel 7, is deprecated, and no replacement exists.
 function makeMakeHMRConfig7() {
-  return function() {
+  return function(options: mixed, filename?: string) {
     return {};
-  }
+  };
 }
 
 function getPreset7() {

--- a/packages/metro/src/babel-bridge.js
+++ b/packages/metro/src/babel-bridge.js
@@ -46,7 +46,7 @@ const babelTraverse7 = require('@babel/traverse').default;
 const babelTypes7 = require('@babel/types');
 const babylon7 = require('babylon7');
 
-const externalHelpersPlugin7 = require('babel-plugin-external-helpers');
+const externalHelpersPlugin7 = require('@babel/plugin-external-helpers');
 const inlineRequiresPlugin7 = require('babel-preset-fbjs/plugins/inline-requires');
 const makeHMRConfig7 = makeMakeHMRConfig7();
 function resolvePlugins7(plugins: Array<any>) {
@@ -124,6 +124,8 @@ function makeMakeHMRConfig7() {
   var transformPath = require.resolve(hmrTransform);
 
   return function(options: mixed, filename?: string) {
+    return {}; // Plugin not functional in Babel 7, is deprecated, and no replacement exists.
+
     var transform = filename
       ? './' + path.relative(path.dirname(filename), transformPath) // packager can't handle absolute paths
       : hmrTransform;


### PR DESCRIPTION
**Summary**

With great effort, I was able to get Babel 7 to work with Metro 0.26.0. I should probably write about it, but before I can do that, I'd like for you to consider these two changes that I made locally to get Metro to play nicely with the new Babel.

The first change (for the external helpers plugin) corrects what appears to be a minor oversight.

The second change no-ops a code-path that I cannot imagine has ever worked. The maintainer of [`babel-plugin-react-transform`](https://github.com/gaearon/babel-plugin-react-transform#this-project-is-deprecated) insists its deprecated, so there's no point in making it work with Babel 7. I'm not sure what this means for HMR, but HMR is something I can do without if it means I can access the new transforms in Babel 7.

**Test plan**

Something that seemed totally borked is now less broken 😇 