### PR TITLE
Fix npm deps

### DIFF
--- a/packages/metro-babylon7/package.json
+++ b/packages/metro-babylon7/package.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.27.0",
+  "name": "metro-babylon7",
+  "description": "🚇 Metro babylon v7 wrapper",
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/metro.git"
+  },
+  "scripts": {
+    "prepare-release": "test -d build && rm -rf src.real && mv src src.real && mv build src",
+    "cleanup-release": "test ! -e build && mv src build && mv src.real src"
+  },
+  "dependencies": {
+    "babylon": "^7.0.0-beta"
+  }
+}
+  

--- a/packages/metro-babylon7/src/index.js
+++ b/packages/metro-babylon7/src/index.js
@@ -1,0 +1,3 @@
+const babylon = require('babylon');
+
+module.exports = babylon;

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -53,7 +53,6 @@
     "babel-preset-react-native": "^4.0.0",
     "babel-register": "^6.24.1",
     "babylon": "^6.18.0",
-    "babylon7": "npm:babylon@^7.0.0-beta",
     "chalk": "^1.1.1",
     "concat-stream": "^1.6.0",
     "connect": "^3.6.5",

--- a/packages/metro/src/babel-bridge.js
+++ b/packages/metro/src/babel-bridge.js
@@ -42,7 +42,7 @@ const babelGenerate7 = require('@babel/generator').default;
 const babelTemplate7 = require('@babel/template').default;
 const babelTraverse7 = require('@babel/traverse').default;
 const babelTypes7 = require('@babel/types');
-const babylon7 = require('babylon7');
+const babylon7 = require('metro-babylon7');
 
 const externalHelpersPlugin7 = require('babel-plugin-external-helpers');
 const inlineRequiresPlugin7 = require('babel-preset-fbjs/plugins/inline-requires');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,14 +1432,13 @@ babel-types@^6.19.0, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-"babylon7@npm:babylon@^7.0.0-beta", babylon@7.0.0-beta.38:
-  name babylon7
-  version "7.0.0-beta.38"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.38.tgz#9b3a33e571a47464a2d20cb9dd5a570f00e3f996"
-
 babylon@7.0.0-beta.36:
   version "7.0.0-beta.36"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.36.tgz#3a3683ba6a9a1e02b0aa507c8e63435e39305b9e"
+
+babylon@^7.0.0-beta, babylon@7.0.0-beta.38:
+  version "7.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.38.tgz#9b3a33e571a47464a2d20cb9dd5a570f00e3f996"
 
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.18.0:
   version "6.18.0"


### PR DESCRIPTION
**Summary**

This should fix install of the metro with npm (issue #142).
We can't have both babylon@6 and babylon@7 as deps for metro package, so as @jeanlauliac suggested in https://github.com/facebook/metro/issues/142#issuecomment-368217279 lets create wrapper-package `metro-babylon7` and reexport babylon@7 from it.

**Test plan**

I do manually `yarn && yarn test` - all checks passed.
