### PR TITLE
ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /coverage
 lerna-debug.log
 npm-debug.log*
+packages/*/build/


### PR DESCRIPTION
When running `yarn` it compiles all the packages files into `build` folders. We should probably ignore this to avoid them ending up checked-in on the repo.
