### PR TITLE
metro-memory-fs: fix createWriteStream autoClose behavior

### DIFF
--- a/packages/metro-memory-fs/src/__tests__/index-test.js
+++ b/packages/metro-memory-fs/src/__tests__/index-test.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+jest.useRealTimers();
+
 const MemoryFs = require('../index');
 
 let fs;

--- a/packages/metro-memory-fs/src/index.js
+++ b/packages/metro-memory-fs/src/index.js
@@ -497,20 +497,16 @@ class MemoryFs {
         }
         callback();
       },
-      final: callback => {
-        try {
-          if (autoClose !== false) {
-            this.closeSync(ffd);
-            rst.emit('close');
-          }
-        } catch (error) {
-          callback(error);
-          return;
-        }
-        callback();
-      },
     });
     st = rst;
+    if (autoClose !== false) {
+      const doClose = () => {
+        this.closeSync(ffd);
+        rst.emit('close');
+      };
+      rst.on('finish', doClose);
+      rst.on('error', doClose);
+    }
     (st: any).path = filePath;
     (st: any).bytesWritten = 0;
     return st;


### PR DESCRIPTION
In Node v6 there is no `final` function: https://nodejs.org/docs/v6.13.1/api/stream.html#stream_simplified_construction.

It's not a problem however because we can preferentially use the `finish` event, that makes it more consistent with how `createReadStream` is implemented. I also added closing the fs on `error` events, as specified in the docs.

**Test plan**

    yarn jest
