### PR TITLE
fix config in babel 7

### DIFF
--- a/packages/metro/src/transformer.js
+++ b/packages/metro/src/transformer.js
@@ -111,6 +111,10 @@ function buildBabelConfig(filename, options, plugins?: BabelPlugins = []) {
     config = Object.assign({}, config, hmrConfig);
   }
 
+  if (process.env.BABEL_VERSION === '7') {
+    config = Object.assign({}, config, {ast: true});
+  }
+
   return Object.assign({}, babelRC, config);
 }
 

--- a/packages/metro/src/transformer.js
+++ b/packages/metro/src/transformer.js
@@ -112,7 +112,7 @@ function buildBabelConfig(filename, options, plugins?: BabelPlugins = []) {
   }
 
   if (process.env.BABEL_VERSION === '7') {
-    config = Object.assign({}, config, {ast: true});
+    config = Object.assign({}, config, {ast: true, sourceType: 'unambiguous'});
   }
 
   return Object.assign({}, babelRC, config);


### PR DESCRIPTION
**Summary**

* Fix ast is null in babel 7, see https://github.com/facebook/react-native/commit/f8d6b97140cffe8d18b2558f94570c8d1b410d5c#r28647044.

* change sourceType to "unambiguous", see https://github.com/facebook/react-native/commit/f8d6b97140cffe8d18b2558f94570c8d1b410d5c#r28569395.

With those change, react native can fix all jest test.
```
Test Suites: 2 skipped, 100 passed, 100 of 102 total
Tests:       4 skipped, 553 passed, 557 total
Snapshots:   37 passed, 37 total
Time:        78.455s
Ran all test suites.
Done in 79.46s.
```

**Test plan**

pass react native test-ci task.
