### PR TITLE
Handle scoped modules from extraNodeModules config

### DIFF
--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -106,7 +106,7 @@ function resolve(
     let bits = path.normalize(moduleName).split(path.sep);
     let packageName;
     // Normalize packageName and bits for scoped modules
-    if (bits[0] && bits[0][0] === '@') {
+    if (bits.length >= 2 && bits[0].startsWith('@')) {
       packageName = bits.slice(0, 2).join('/');
       bits = bits.slice(1);
     } else {

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -103,8 +103,15 @@ function resolve(
   const extraPaths = [];
   const {extraNodeModules} = context;
   if (extraNodeModules) {
-    const bits = path.normalize(moduleName).split(path.sep);
-    const packageName = bits[0];
+    let bits = path.normalize(moduleName).split(path.sep);
+    let packageName;
+    // Normalize packageName and bits for scoped modules
+    if (bits[0] && bits[0][0] === '@') {
+      packageName = bits.slice(0, 2).join('/');
+      bits = bits.slice(1);
+    } else {
+      packageName = bits[0];
+    }
     if (extraNodeModules[packageName]) {
       bits[0] = extraNodeModules[packageName];
       extraPaths.push(path.join.apply(path, bits));

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/traverseDependencies-integration-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/traverseDependencies-integration-test.js.snap
@@ -278,6 +278,24 @@ Array [
 ]
 `;
 
+exports[`traverseDependencies get sync dependencies (posix) should be able to resolve scoped \`extraNodeModules\` 1`] = `
+Array [
+  Object {
+    "dependencies": Array [
+      Object {
+        "isAsync": false,
+        "name": "@org/bar/lib/foo",
+      },
+    ],
+    "path": "/root/index.js",
+  },
+  Object {
+    "dependencies": Array [],
+    "path": "/root/provides-bar/lib/foo.js",
+  },
+]
+`;
+
 exports[`traverseDependencies get sync dependencies (posix) should default main package to index.js 1`] = `
 Array [
   Object {

--- a/packages/metro/src/DeltaBundler/__tests__/traverseDependencies-integration-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/traverseDependencies-integration-test.js
@@ -1745,6 +1745,34 @@ describe('traverseDependencies', function() {
         expect(deps).toMatchSnapshot();
       });
     });
+
+    it('should be able to resolve scoped `extraNodeModules`', async () => {
+      var root = '/root';
+      setMockFileSystem({
+        [root.slice(1)]: {
+          'index.js': 'require("@org/bar/lib/foo")',
+          'provides-bar': {
+            'package.json': '{}',
+            lib: {'foo.js': ''},
+          },
+        },
+      });
+
+      const opts = {
+        ...defaults,
+        watchFolders: [root],
+        extraNodeModules: {
+          '@org/bar': root + '/provides-bar',
+        },
+      };
+      await processDgraph(opts, async dgraph => {
+        const deps = await getOrderedDependenciesAsJSON(
+          dgraph,
+          '/root/index.js',
+        );
+        expect(deps).toMatchSnapshot();
+      });
+    });
   });
 
   describe('get sync dependencies (win32)', () => {


### PR DESCRIPTION
**Summary**

Metro allows configuring `extraNodeModules` for additional module resolution mappings. It chokes on scoped module names (e.g. `@org/module`), because it doesn't compute the path correctly

**Test plan**

```
// In metro.config.js
extraNodeModules: {
  '@org/module': path.resolve(__dirname, "wherever")
}

// In consuming code
import module from '@org/module'
```

Assuming the module is neither in `node_modules` nor comes from the Haste map, the former code will fail without this patch
