### PR TITLE
Fix constant-folding-plugin for default export function

### DIFF
--- a/packages/metro/src/JSTransformer/worker/__tests__/constant-folding-plugin-test.js
+++ b/packages/metro/src/JSTransformer/worker/__tests__/constant-folding-plugin-test.js
@@ -276,4 +276,15 @@ describe('constant expressions', () => {
       'var plusZero=0;var zero=0;var minusZero=-0;',
     );
   });
+
+  it('does not mess up default exports', () => {
+    let code = `export default function () {}`;
+    expect(fold('arbitrary.js', code)).toEqual('export default function(){}');
+    code = `export default () => {}`;
+    expect(fold('arbitrary.js', code)).toEqual('export default(()=>{});');
+    code = `export default class {}`;
+    expect(fold('arbitrary.js', code)).toEqual('export default class{}');
+    code = `export default 1`;
+    expect(fold('arbitrary.js', code)).toEqual('export default 1;');
+  });
 });

--- a/packages/metro/src/JSTransformer/worker/constant-folding-plugin.js
+++ b/packages/metro/src/JSTransformer/worker/constant-folding-plugin.js
@@ -32,7 +32,8 @@ function constantFoldingPlugin(context: {types: BabelTypes}) {
 
   const FunctionDeclaration = {
     exit(path: Object, state: Object) {
-      const binding = path.scope.getBinding(path.node.id.name);
+      const binding =
+        path.node.id !== null && path.scope.getBinding(path.node.id.name);
 
       if (binding && !binding.referenced) {
         state.stripped = true;


### PR DESCRIPTION
**Summary**

When using ES modules it is possible that a function id is null, for example `export default function() {}` so we need to add a check to avoid an error.

Fixes #177

**Test plan**

Added a test and made sure it failed before the fix and passes after. Also tested by applying the fix locally in an app where I found the bug.
