### PR TITLE
Allow custom BABEL_ENV for transformer

### DIFF
--- a/packages/metro/src/reactNativeTransformer.js
+++ b/packages/metro/src/reactNativeTransformer.js
@@ -156,7 +156,8 @@ function transform({filename, options, src, plugins}: Params) {
   /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an error
    * found when Flow v0.68 was deployed. To see the error delete this comment
    * and run Flow. */
-  process.env.BABEL_ENV = process.env.METRO_BABEL_ENV || (options.dev ? 'development' : 'production');
+  process.env.BABEL_ENV =
+    process.env.METRO_BABEL_ENV || (options.dev ? 'development' : 'production');
 
   try {
     const babelConfig = buildBabelConfig(filename, options, plugins);

--- a/packages/metro/src/reactNativeTransformer.js
+++ b/packages/metro/src/reactNativeTransformer.js
@@ -156,7 +156,7 @@ function transform({filename, options, src, plugins}: Params) {
   /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an error
    * found when Flow v0.68 was deployed. To see the error delete this comment
    * and run Flow. */
-  process.env.BABEL_ENV = options.dev ? 'development' : 'production';
+  process.env.BABEL_ENV = process.env.METRO_BABEL_ENV || (options.dev ? 'development' : 'production');
 
   try {
     const babelConfig = buildBabelConfig(filename, options, plugins);


### PR DESCRIPTION
I have a complex .babelrc.js configuration (for server, for web and also for react-native (metro)).

It would be nice to allow for developers to provide its own `BABEL_ENV` name.
For now, it is forced to be `production` or `development`. And it's bad developer experience.

Of course `METRO_BABEL_ENV` is not a good solution. Better will be to use already defined BABEL_ENV variable from process, but if it not defined use `production` or `development` as a fallback.

With proposed changes it can be used in following manner:
```bash
$ METRO_BABEL_ENV=native_dev node node_modules/react-native/local-cli/cli.js start
```
or even better will be (but it may introduce some problems in existing apps)
```bash
$ BABEL_ENV=native_dev node node_modules/react-native/local-cli/cli.js start
```

Thoughts?