### PR TITLE
Migrate away from deprecated new Buffer

### DIFF
--- a/packages/metro-cache/src/stores/__tests__/FileStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/FileStore-test.js
@@ -28,7 +28,7 @@ describe('FileStore', () => {
 
   it('sets and writes into the cache', () => {
     const fileStore = new FileStore({root: '/root'});
-    const cache = new Buffer([0xfa, 0xce, 0xb0, 0x0c]);
+    const cache = Buffer.from([0xfa, 0xce, 0xb0, 0x0c]);
 
     fileStore.set(cache, {foo: 42});
     expect(fileStore.get(cache)).toEqual({foo: 42});
@@ -36,7 +36,7 @@ describe('FileStore', () => {
 
   it('returns null when reading a non-existing file', () => {
     const fileStore = new FileStore({root: '/root'});
-    const cache = new Buffer([0xfa, 0xce, 0xb0, 0x0c]);
+    const cache = Buffer.from([0xfa, 0xce, 0xb0, 0x0c]);
 
     expect(fileStore.get(cache)).toEqual(null);
   });

--- a/packages/metro-memory-fs/src/__tests__/index-test.js
+++ b/packages/metro-memory-fs/src/__tests__/index-test.js
@@ -86,8 +86,8 @@ describe('posix support', () => {
   });
 
   it('can write then read a file as buffer', () => {
-    fs.writeFileSync('/foo.txt', new Buffer([1, 2, 3, 4]));
-    expect(fs.readFileSync('/foo.txt')).toEqual(new Buffer([1, 2, 3, 4]));
+    fs.writeFileSync('/foo.txt', Buffer.from([1, 2, 3, 4]));
+    expect(fs.readFileSync('/foo.txt')).toEqual(Buffer.from([1, 2, 3, 4]));
   });
 
   it('can write a file with a relative path', () => {
@@ -232,7 +232,7 @@ describe('posix support', () => {
 
     it('reads a file as buffer', done => {
       const st = fs.createReadStream('/foo.txt');
-      let buffer = new Buffer(0);
+      let buffer = Buffer.alloc(0);
       st.on('data', chunk => {
         buffer = Buffer.concat([buffer, chunk]);
       });
@@ -613,13 +613,13 @@ describe('posix support', () => {
   });
 
   it('throws when trying to write to an inexistent file descriptor', () => {
-    expectFsError('EBADF', () => fs.writeSync(42, new Buffer([1])));
+    expectFsError('EBADF', () => fs.writeSync(42, Buffer.from([1])));
   });
 
   it('throws when trying to write to a read-only file descriptor', () => {
     fs.writeFileSync('/foo.txt', 'test');
     const fd = fs.openSync('/foo.txt', 'r');
-    expectFsError('EBADF', () => fs.writeSync(fd, new Buffer([1])));
+    expectFsError('EBADF', () => fs.writeSync(fd, Buffer.from([1])));
   });
 
   it('throws when trying to open too many files', () => {

--- a/packages/metro-memory-fs/src/index.js
+++ b/packages/metro-memory-fs/src/index.js
@@ -382,14 +382,14 @@ class MemoryFs {
     const fd = this._open(pathStr(filePath), flag || 'r');
     const chunks = [];
     try {
-      const buffer = new Buffer(1024);
+      const buffer = Buffer.alloc(1024);
       let bytesRead;
       do {
         bytesRead = this.readSync(fd, buffer, 0, buffer.length, null);
         if (bytesRead === 0) {
           continue;
         }
-        const chunk = new Buffer(bytesRead);
+        const chunk = Buffer.alloc(bytesRead);
         buffer.copy(chunk, 0, 0, bytesRead);
         chunks.push(chunk);
       } while (bytesRead > 0);
@@ -638,12 +638,12 @@ class MemoryFs {
     filePath: FilePath,
     options?:
       | {
-          autoClose?: ?boolean,
-          encoding?: ?Encoding,
+          autoClose?: boolean,
+          encoding?: Encoding,
           fd?: ?number,
-          flags?: ?string,
-          mode?: ?number,
-          start?: ?number,
+          flags?: string,
+          mode?: number,
+          start?: number,
         }
       | Encoding,
   ) => {
@@ -740,7 +740,7 @@ class MemoryFs {
         throw makeError('ENOENT', filePath, 'no such file or directory');
       }
       node = {
-        content: new Buffer(0),
+        content: Buffer.alloc(0),
         gid: getgid(),
         id: this._getId(),
         mode,
@@ -759,7 +759,7 @@ class MemoryFs {
         throw makeError('EISDIR', filePath, 'cannot read/write to a directory');
       }
       if (truncate) {
-        node.content = new Buffer(0);
+        node.content = Buffer.alloc(0);
       }
       nodePath = dirPath.concat([[basename, node]]);
     }
@@ -939,7 +939,7 @@ class MemoryFs {
     }
     const {node} = desc;
     if (node.content.length < position + length) {
-      const newBuffer = new Buffer(position + length);
+      const newBuffer = Buffer.alloc(position + length);
       node.content.copy(newBuffer, 0, 0, node.content.length);
       node.content = newBuffer;
     }
@@ -1101,10 +1101,10 @@ class ReadFileSteam extends stream.Readable {
     this.path = options.filePath;
     this._readSync = options.readSync;
     this._fd = fd;
-    this._buffer = new Buffer(1024);
+    this._buffer = Buffer.alloc(1024);
     const {start, end} = options;
     if (start != null) {
-      this._readSync(fd, new Buffer(0), 0, 0, start);
+      this._readSync(fd, Buffer.alloc(0), 0, 0, start);
     }
     if (end != null) {
       this._positions = {current: start || 0, last: end + 1};
@@ -1153,7 +1153,7 @@ class WriteFileStream extends stream.Writable {
     fd: number,
     filePath: FilePath,
     writeSync: WriteSync,
-    start: ?number,
+    start?: number,
   }) {
     super();
     this.path = opts.filePath;
@@ -1161,7 +1161,7 @@ class WriteFileStream extends stream.Writable {
     this._fd = opts.fd;
     this._writeSync = opts.writeSync;
     if (opts.start != null) {
-      this._writeSync(opts.fd, new Buffer(0), 0, 0, opts.start);
+      this._writeSync(opts.fd, Buffer.alloc(0), 0, 0, opts.start);
     }
   }
 

--- a/packages/metro-source-map/src/B64Builder.js
+++ b/packages/metro-source-map/src/B64Builder.js
@@ -35,7 +35,7 @@ class B64Builder {
   hasSegment: boolean;
 
   constructor() {
-    this.buffer = new Buffer(ONE_MEG);
+    this.buffer = Buffer.alloc(ONE_MEG);
     this.pos = 0;
     this.hasSegment = false;
   }
@@ -99,7 +99,7 @@ class B64Builder {
 
   _realloc() {
     const {buffer} = this;
-    this.buffer = new Buffer(buffer.length * 2);
+    this.buffer = Buffer.alloc(buffer.length * 2);
     buffer.copy(this.buffer);
   }
 }

--- a/packages/metro/src/ModuleGraph/output/__tests__/multiple-files-ram-bundle-test.js
+++ b/packages/metro/src/ModuleGraph/output/__tests__/multiple-files-ram-bundle-test.js
@@ -46,7 +46,7 @@ beforeAll(() => {
 });
 
 it('does not start the bundle file with the magic number (not a binary one)', () => {
-  expect(new Buffer(code).readUInt32LE(0)).not.toBe(0xfb0bd1e5);
+  expect(Buffer.from(code).readUInt32LE(0)).not.toBe(0xfb0bd1e5);
 });
 
 it('contains the startup code on the main file', () => {

--- a/packages/metro/src/ModuleGraph/output/multiple-files-ram-bundle.js
+++ b/packages/metro/src/ModuleGraph/output/multiple-files-ram-bundle.js
@@ -33,7 +33,7 @@ function asMultipleFilesRamBundle({
   const [startup, deferred] = partition(modules, preloadedModules);
   const startupModules = Array.from(concat(startup, requireCalls));
   const deferredModules = deferred.map(m => toModuleTransport(m, idsForPath));
-  const magicFileContents = new Buffer(4);
+  const magicFileContents = Buffer.alloc(4);
 
   // Just concatenate all startup modules, one after the other.
   const code = startupModules.map(m => getModuleCode(m, idForPath)).join('\n');

--- a/packages/metro/src/ModuleGraph/worker/__tests__/optimize-module-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/optimize-module-test.js
@@ -33,7 +33,7 @@ describe('optimizing JS modules', () => {
     platform: 'android',
     postMinifyProcess: x => x,
   };
-  const originalCode = new Buffer(
+  const originalCode = Buffer.from(
     `if (Platform.OS !== 'android') {
       require('arbitrary-dev');
     } else {
@@ -47,7 +47,7 @@ describe('optimizing JS modules', () => {
     const trOpts = {asyncRequireModulePath, filename, sourceExts, transformer};
     const result = transformModule(originalCode, trOpts);
     invariant(result.type === 'code', 'result must be code');
-    transformResult = new Buffer(
+    transformResult = Buffer.from(
       JSON.stringify({type: 'code', details: result.details}),
       'utf8',
     );
@@ -143,7 +143,7 @@ describe('optimizing JS modules', () => {
   it('passes through non-code data unmodified', () => {
     const data = {type: 'asset', details: {arbitrary: 'data'}};
     expect(
-      optimizeModule(new Buffer(JSON.stringify(data), 'utf8'), {
+      optimizeModule(Buffer.from(JSON.stringify(data), 'utf8'), {
         dev: true,
         platform: '',
         minifierPath: defaults.DEFAULT_METRO_MINIFIER_PATH,

--- a/packages/metro/src/ModuleGraph/worker/__tests__/transform-module-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/transform-module-test.js
@@ -271,7 +271,7 @@ describe('transforming JS modules:', () => {
 
     it('throws on empty images', () => {
       expect(() =>
-        transformModule(new Buffer(0), {...options(), filename: 'foo.png'}),
+        transformModule(Buffer.alloc(0), {...options(), filename: 'foo.png'}),
       ).toThrowErrorMatchingSnapshot();
     });
   });
@@ -309,5 +309,5 @@ function findColumnAndLine(text, string) {
 }
 
 function toBuffer(str) {
-  return new Buffer(str, 'utf8');
+  return Buffer.from(str, 'utf8');
 }

--- a/packages/metro/src/shared/output/meta.js
+++ b/packages/metro/src/shared/output/meta.js
@@ -57,6 +57,5 @@ function asBuffer(x, encoding): Buffer {
   if (typeof x !== 'string') {
     return x;
   }
-  // remove `Buffer.from` calls when RN drops support for Node 4
-  return Buffer.from ? Buffer.from(x, encoding) : Buffer.from(x, encoding);
+  return Buffer.from(x, encoding);
 }

--- a/packages/metro/src/shared/output/meta.js
+++ b/packages/metro/src/shared/output/meta.js
@@ -32,9 +32,7 @@ module.exports = function(
   const hash = crypto.createHash('sha1');
   hash.update(buffer);
   const digest = hash.digest('buffer');
-  const signature = Buffer.alloc
-    ? Buffer.alloc(digest.length + 1)
-    : new Buffer(digest.length + 1);
+  const signature = Buffer.alloc(digest.length + 1);
   digest.copy(signature);
   signature.writeUInt8(
     constantFor(tryAsciiPromotion(buffer, encoding)),
@@ -59,6 +57,6 @@ function asBuffer(x, encoding): Buffer {
   if (typeof x !== 'string') {
     return x;
   }
-  // remove `new Buffer` calls when RN drops support for Node 4
-  return Buffer.from ? Buffer.from(x, encoding) : new Buffer(x, encoding);
+  // remove `Buffer.from` calls when RN drops support for Node 4
+  return Buffer.from ? Buffer.from(x, encoding) : Buffer.from(x, encoding);
 }

--- a/packages/metro/src/shared/output/unbundle/as-assets.js
+++ b/packages/metro/src/shared/output/unbundle/as-assets.js
@@ -105,8 +105,7 @@ function writeModules(modules, modulesDir, encoding) {
 }
 
 function writeMagicFlagFile(outputDir) {
-  /* global Buffer: true */
-  const buffer = new Buffer(4);
+  const buffer = Buffer.alloc(4);
   buffer.writeUInt32LE(MAGIC_UNBUNDLE_NUMBER, 0);
   return writeFile(path.join(outputDir, MAGIC_UNBUNDLE_FILENAME), buffer);
 }

--- a/packages/metro/src/shared/output/unbundle/as-indexed-file.js
+++ b/packages/metro/src/shared/output/unbundle/as-indexed-file.js
@@ -84,9 +84,9 @@ function saveAsIndexedFile(
 
 /* global Buffer: true */
 
-const fileHeader = new Buffer(4);
+const fileHeader = Buffer.alloc(4);
 fileHeader.writeUInt32LE(MAGIC_UNBUNDLE_FILE_HEADER, 0);
-const nullByteBuffer: Buffer = new Buffer(1).fill(0);
+const nullByteBuffer: Buffer = Buffer.alloc(1).fill(0);
 
 function writeBuffers(stream, buffers: Array<Buffer>) {
   buffers.forEach(buffer => stream.write(buffer));
@@ -98,7 +98,7 @@ function writeBuffers(stream, buffers: Array<Buffer>) {
 }
 
 function nullTerminatedBuffer(contents, encoding) {
-  return Buffer.concat([new Buffer(contents, encoding), nullByteBuffer]);
+  return Buffer.concat([Buffer.from(contents, encoding), nullByteBuffer]);
 }
 
 function moduleToBuffer(id, code, encoding) {
@@ -127,7 +127,7 @@ function buildModuleTable(startupCode, moduleBuffers, moduleGroups) {
   const moduleIds = Array.from(moduleGroups.modulesById.keys());
   const maxId = moduleIds.reduce((max, id) => Math.max(max, id));
   const numEntries = maxId + 1;
-  const table: Buffer = new Buffer(entryOffset(numEntries)).fill(0);
+  const table: Buffer = Buffer.alloc(entryOffset(numEntries)).fill(0);
 
   // num_entries
   table.writeUInt32LE(numEntries, 0);


### PR DESCRIPTION
**Summary**

Gets rid of Buffer warnings on Node 10.
`new Buffer()` constructor was deprecated in Node 10. Since Metro is supporting Node 8+ now, we can migrate to `Buffer.from` and `Buffer.alloc` (added in v5.10). 

**Test plan**

Existing tests + Flow should pass.
