### PR TITLE
babel-preset: Add "modules" option to allow passing through of ES6/ha…

### DIFF
--- a/packages/metro-react-native-babel-preset/README.md
+++ b/packages/metro-react-native-babel-preset/README.md
@@ -24,6 +24,21 @@ Then, create a file called `.babelrc` in your project's root directory. The exis
 }
 ```
 
+## Options ##
+
+### `modules`
+
+`"commonjs" | false`, defaults to `"commonjs"`
+
+Enable transformation of ES6 module syntax to CommonJS. E.g:
+```
+{
+  "presets": [
+    ["metro-react-native-babel-preset", { "modules": false }]
+  ]
+}
+```
+
 You can further customize your Babel configuration by specifying plugins and other options. See [Babel's `.babelrc` documentation](https://babeljs.io/docs/usage/babelrc/) to learn more.
 
 ## Help and Support

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -30,16 +30,16 @@ const defaultPlugins = [
   [require('@babel/plugin-transform-regenerator')],
   [require('@babel/plugin-transform-sticky-regex')],
   [require('@babel/plugin-transform-unicode-regex')],
-  [
-    require('@babel/plugin-transform-modules-commonjs'),
-    {
-      strict: false,
-      strictMode: false, // prevent "use strict" injections
-      allowTopLevelThis: true, // dont rewrite global `this` -> `undefined`
-    },
-  ],
 ];
 
+const commonJsModules = [
+  require('@babel/plugin-transform-modules-commonjs'),
+  {
+    strict: false,
+    strictMode: false, // prevent "use strict" injections
+    allowTopLevelThis: true, // dont rewrite global `this` -> `undefined`
+  },
+];
 const es2015ArrowFunctions = [
   require('@babel/plugin-transform-arrow-functions'),
 ];
@@ -77,6 +77,9 @@ const getPreset = (src, options) => {
 
   const extraPlugins = [];
 
+  if (options && options.modules !== false) {
+    extraPlugins.push(commonJsModules);
+  }
   if (hasClass) {
     extraPlugins.push(es2015Classes);
   }
@@ -127,17 +130,18 @@ const getPreset = (src, options) => {
   };
 };
 
-const base = getPreset(null);
-const devTools = getPreset(null, {dev: true});
-
-module.exports = options => {
+module.exports = (api, options = {}) => {
+  const presetOptions = {};
+  if (options.modules === false) {
+    presetOptions.modules = false;
+  }
   if (options.withDevTools == null) {
     const env = process.env.BABEL_ENV || process.env.NODE_ENV;
     if (!env || env === 'development') {
-      return devTools;
+      presetOptions.dev = true;
     }
   }
-  return base;
+  return getPreset(null, presetOptions);
 };
 
 module.exports.getPreset = getPreset;


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Motivation

Since the majority of react-native code is written using ES6 modules, it is possible to do static analysis to achieve some new things:
 * Eliminate dead code, since if an ES6 export is never imported from the application, it cannot run
 * Identify programmer errors faster, since it is possible to detect and warn when the programmer imports a value that was not exported from a module.

Using [haul](https://github.com/callstack/haul) (which uses babel-preset-react-native by default) is it possible to compile a react-native project with [webpack](https://webpack.js.org/). Webpack natively supports ES6 modules, and will [generate a warning or error](https://github.com/webpack/webpack/pull/4348) if user code imports a value that was not exported. This only works for ES6 imports/exports however, so it does not work if babel transpiles all the imports/exports to CommonJS before webpack bundles them.


**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I tested a similar change on `babel-preset-react-native` 4.0.0 for this PR: https://github.com/facebook/react-native/pull/17693

Unfortunately I don't have a project set up that works with babel 7 + react-native, so I haven't directly tested this commit. The change is very simple though - if the `modules` options is not used, there is no change, and if it is and is set to `false`, the commonJs transform is not included in the preset.