### PR TITLE
Add TypeScript support to React Native

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/convertConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/convertConfig-test.js.snap
@@ -74,6 +74,8 @@ Object {
     "sourceExts": Array [
       "js",
       "json",
+      "ts",
+      "tsx",
     ],
     "transformModulePath": "",
     "watch": false,

--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -57,6 +57,8 @@ Object {
     "sourceExts": Array [
       "js",
       "json",
+      "ts",
+      "tsx",
     ],
   },
   "serializer": Object {
@@ -151,6 +153,8 @@ Object {
     "sourceExts": Array [
       "js",
       "json",
+      "ts",
+      "tsx",
     ],
   },
   "serializer": Object {

--- a/packages/metro-config/src/defaults/defaults.js
+++ b/packages/metro-config/src/defaults/defaults.js
@@ -43,7 +43,7 @@ exports.assetExts = [
   'ttf',
 ];
 
-exports.sourceExts = ['js', 'json'];
+exports.sourceExts = ['js', 'json', 'ts', 'tsx'];
 
 exports.moduleSystem = require.resolve('metro/src/lib/polyfills/require.js');
 

--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -44,6 +44,7 @@
     "@babel/plugin-transform-spread": "7.0.0-beta.54",
     "@babel/plugin-transform-sticky-regex": "7.0.0-beta.54",
     "@babel/plugin-transform-template-literals": "7.0.0-beta.54",
+    "@babel/plugin-transform-typescript": "7.0.0-beta.54",
     "@babel/plugin-transform-unicode-regex": "7.0.0-beta.54",
     "@babel/template": "7.0.0-beta.54",
     "metro-babel7-plugin-react-transform": "0.43.2"

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -9,6 +9,10 @@
 
 'use strict';
 
+function isTypeScriptSource(fileName) {
+  return !!fileName && (fileName.endsWith('.ts') || fileName.endsWith('.tsx'));
+}
+
 const defaultPlugins = [
   [require('@babel/plugin-proposal-optional-catch-binding')],
   [require('@babel/plugin-transform-block-scoping')],
@@ -124,6 +128,14 @@ const getPreset = (src, options) => {
     comments: false,
     compact: true,
     plugins: defaultPlugins.concat(extraPlugins),
+    overrides: [
+      {
+        test: isTypeScriptSource,
+        plugins: [
+          [require('@babel/plugin-transform-typescript'), {isTSX: true}],
+        ],
+      },
+    ],
   };
 };
 

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/basic_bundle-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/basic_bundle-test.js.snap
@@ -154,11 +154,14 @@ __d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
 
   var Foo = _$$_REQUIRE(_dependencyMap[1]);
 
+  var TypeScript = _$$_REQUIRE(_dependencyMap[2]);
+
   module.exports = {
     Foo: Foo,
-    Bar: Bar
+    Bar: Bar,
+    TypeScript: TypeScript
   };
-},0,[1,2]);
+},0,[1,2,5]);
 __d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
   'use strict';
 
@@ -194,6 +197,16 @@ __d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
 __d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
   'use strict';
 },4,[]);
+__d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
+  Object.defineProperty(exports, \\"__esModule\\", {
+    value: true
+  });
+  exports.test = exports.type = undefined;
+  var type = 'TypeScript';
+  exports.type = type;
+  var test = true;
+  exports.test = test;
+},5,[]);
 require(0);"
 `;
 
@@ -337,11 +350,14 @@ __d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
 
   var Foo = _$$_REQUIRE(_dependencyMap[1]);
 
+  var TypeScript = _$$_REQUIRE(_dependencyMap[2]);
+
   module.exports = {
     Foo: Foo,
-    Bar: Bar
+    Bar: Bar,
+    TypeScript: TypeScript
   };
-},0,[1,2]);
+},0,[1,2,5]);
 __d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
   'use strict';
 
@@ -377,5 +393,15 @@ __d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
 __d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
   'use strict';
 },4,[]);
+__d(function (global, _$$_REQUIRE, module, exports, _dependencyMap) {
+  Object.defineProperty(exports, \\"__esModule\\", {
+    value: true
+  });
+  exports.test = exports.type = undefined;
+  var type = 'TypeScript';
+  exports.type = type;
+  var test = true;
+  exports.test = test;
+},5,[]);
 require(0);"
 `;

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/buildGraph-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/buildGraph-test.js.snap
@@ -11,9 +11,12 @@ Array [
 
   var Foo = _$$_REQUIRE(_dependencyMap[1]);
 
+  var TypeScript = _$$_REQUIRE(_dependencyMap[2]);
+
   module.exports = {
     Foo: Foo,
-    Bar: Bar
+    Bar: Bar,
+    TypeScript: TypeScript
   };
 });",
       "map": Array [
@@ -78,59 +81,98 @@ Array [
         Array [
           8,
           0,
-          16,
+          17,
           0,
-          "module",
         ],
         Array [
           8,
-          9,
-          16,
-          7,
-          "exports",
-        ],
-        Array [
-          8,
-          16,
-          16,
-          0,
+          6,
+          17,
+          6,
+          "TypeScript",
         ],
         Array [
           8,
           19,
-          16,
           17,
+          19,
+          "require",
         ],
         Array [
-          9,
+          8,
+          49,
+          17,
           0,
-          16,
-          18,
-          "Foo",
-        ],
-        Array [
-          9,
-          12,
-          16,
-          17,
         ],
         Array [
           10,
           0,
-          16,
-          23,
-          "Bar",
+          19,
+          0,
+          "module",
         ],
         Array [
-          11,
-          0,
+          10,
+          9,
+          19,
+          7,
+          "exports",
+        ],
+        Array [
+          10,
           16,
+          19,
+          0,
+        ],
+        Array [
+          10,
+          19,
+          19,
           17,
         ],
         Array [
           11,
+          0,
+          19,
+          18,
+          "Foo",
+        ],
+        Array [
+          11,
+          12,
+          19,
+          17,
+        ],
+        Array [
+          12,
+          0,
+          19,
+          23,
+          "Bar",
+        ],
+        Array [
+          12,
+          12,
+          19,
+          17,
+        ],
+        Array [
+          13,
+          0,
+          19,
+          28,
+          "TypeScript",
+        ],
+        Array [
+          14,
+          0,
+          19,
+          17,
+        ],
+        Array [
+          14,
           3,
-          16,
+          19,
           0,
         ],
       ],

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/server-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/server-test.js.snap
@@ -3,11 +3,12 @@
 exports[`should create a server 1`] = `
 "var __DEV__=false,__BUNDLE_START_TIME__=this.nativePerformanceNow?nativePerformanceNow():Date.now(),process=this.process||{};process.env=process.env||{};process.env.NODE_ENV=\\"production\\";
 !(function(r){'use strict';r.require=i,r.__d=function(r,i,n){if(null!=e[i])return;e[i]={dependencyMap:n,publicModule:{exports:void 0},factory:r,hasError:!1,isInitialized:!1}};var e='number'==typeof __NUM_MODULES__?Array(0|__NUM_MODULES__):Object.create(null);function i(r){var i=r,n=e[i];return n&&n.isInitialized?n.publicModule.exports:t(i,n)}var n=!1;function t(e,i){if(!n&&r.ErrorUtils){var t;n=!0;try{t=d(e,i)}catch(e){r.ErrorUtils.reportFatalError(e)}return n=!1,t}return d(e,i)}var o=16,u=65535;function a(r){return{segmentId:r>>>o,localId:r&u}}function d(n,t){!t&&r.__defineModule&&(r.__defineModule(n),t=e[n]);var o=r.nativeRequire;if(!t&&o){var u=a(n),d=u.segmentId;o(u.localId,d),t=e[n]}if(!t)throw Error('Requiring unknown module \\"'+n+'\\".');if(t.hasError)throw c(n,t.error);t.isInitialized=!0;var l={},p=t,s=p.factory,f=p.dependencyMap;try{var _=t.publicModule={exports:l};return s(r,i,_,l,f),t.factory=void 0,t.dependencyMap=void 0,_.exports}catch(r){throw t.hasError=!0,t.error=r,t.isInitialized=!1,t.publicModule.exports=void 0,r}}function c(r,e){return Error('Requiring module \\"'+r+'\\", which threw an exception: '+e)}i.unpackModuleId=a,i.packModuleId=function(r){return r.segmentId<<o+r.localId}})(this);
-__d(function(g,r,m,e,d){'use strict';var o=r(d[0]),t=r(d[1]);m.exports={Foo:t,Bar:o}},0,[1,2]);
+__d(function(g,r,m,e,d){'use strict';var t=r(d[0]),o=r(d[1]),c=r(d[2]);m.exports={Foo:o,Bar:t,TypeScript:c}},0,[1,2,5]);
 __d(function(g,r,m,e,d){'use strict';var t=r(d[0]);m.exports={type:'bar',foo:t.type}},1,[2]);
 __d(function(g,r,m,e,d){'use strict';var t=r(d[0]);m.exports={type:'foo',asset:t}},2,[3]);
 __d(function(g,r,m,e,d){m.exports=r(d[0]).registerAsset({__packager_asset:!0,httpServerLocation:\\"/assets\\",width:8,height:8,scales:[1],hash:\\"77d45c1f7fa73c0f6c444a830dc42f67\\",name:\\"test\\",type:\\"png\\"})},3,[4]);
 __d(function(g,r,m,e,d){'use strict'},4,[]);
+__d(function(g,r,m,e,d){Object.defineProperty(e,\\"__esModule\\",{value:!0}),e.test=e.type=void 0;e.type='TypeScript';e.test=!0},5,[]);
 require(0);
 //# sourceMappingURL=/TestBundle.map?platform=ios&dev=false&minify=true"
 `;

--- a/packages/metro/src/integration_tests/__tests__/buildGraph-test.js
+++ b/packages/metro/src/integration_tests/__tests__/buildGraph-test.js
@@ -45,6 +45,7 @@ it('should build the dependency graph', async () => {
     {file: 'Foo.js', types: ['js/module']},
     {file: 'test.png', types: ['js/module/asset']},
     {file: 'AssetRegistry.js', types: ['js/module']},
+    {file: 'TypeScript.ts', types: ['js/module']},
   ]);
 
   expect(graph.dependencies.get(entryPoint)).toEqual(

--- a/packages/metro/src/integration_tests/basic_bundle/TestBundle.js
+++ b/packages/metro/src/integration_tests/basic_bundle/TestBundle.js
@@ -13,4 +13,7 @@
 const Bar = require('./Bar');
 const Foo = require('./Foo');
 
-module.exports = {Foo, Bar};
+// $FlowFixMe: Flow doesn't understand TypeScript
+const TypeScript = require('./TypeScript');
+
+module.exports = {Foo, Bar, TypeScript};

--- a/packages/metro/src/integration_tests/basic_bundle/TypeScript.ts
+++ b/packages/metro/src/integration_tests/basic_bundle/TypeScript.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const type = 'TypeScript' as string
+export const test = true as boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,6 +357,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.54"
 
+"@babel/plugin-syntax-typescript@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.0.0-beta.54.tgz#7b01ddebccba8f78693bf2898e1f695bb8a76a7e"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.54"
+
 "@babel/plugin-transform-arrow-functions@7.0.0-beta.54":
   version "7.0.0-beta.54"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.54.tgz#44a977b8e61e4efcc7658bbbe260f204ca1bcf72"
@@ -510,6 +516,13 @@
   dependencies:
     "@babel/helper-annotate-as-pure" "7.0.0-beta.54"
     "@babel/helper-plugin-utils" "7.0.0-beta.54"
+
+"@babel/plugin-transform-typescript@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.0.0-beta.54.tgz#7b614ba0dbea88b70ae82df9c429e128928c9251"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.54"
+    "@babel/plugin-syntax-typescript" "7.0.0-beta.54"
 
 "@babel/plugin-transform-unicode-regex@7.0.0-beta.54":
   version "7.0.0-beta.54"


### PR DESCRIPTION
**Summary**

This PR adds support for TypeScript out-of-the-box. Existing codebases should work as before, but React Native should be able to pick up `.ts` and `.tsx` files automatically, and transpile them using Babel.

Note that no actual type-checking will be done, this is in line with how the current Flow support is working. The user can run `tsc --noEmit` to type-check the project.

**Test plan**

I'm currently working on this. I haven't been able to figure out how to test these changes in a local RN application.

I'll be meeting up with @kelset today, hopefully he can help me with this 💌 

With these changes, the following RN project should be able to work without further configuration: https://github.com/LinusU/react-native-babel-typescript-test