### PR TITLE
Fix typo in transform-symbol-member example

### DIFF
--- a/packages/metro-react-native-babel-preset/src/transforms/transform-symbol-member.js
+++ b/packages/metro-react-native-babel-preset/src/transforms/transform-symbol-member.js
@@ -21,7 +21,7 @@
  *
  * Transformed to:
  *
- *   typeof Symbol.iterator === 'function' ? Symbol.iterator : '@@iterator';
+ *   typeof Symbol === 'function' ? Symbol.iterator : '@@iterator';
  */
 module.exports = function symbolMember(babel) {
   const t = babel.types;


### PR DESCRIPTION
**Summary**

There was a typo in the example describing the wrong behavior.

**Test plan**

Look at the comment 😄 
