### PR TITLE
Process locally scoped requires when they are likely part of a UMD module

### DIFF
--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -122,7 +122,10 @@ function collectDependencies(
         processImportCall(path, state);
       }
 
-      if (callee.isIdentifier({name}) && !path.scope.getBinding(name)) {
+      if (
+        callee.isIdentifier({name}) &&
+        (!path.scope.getBinding(name) || path.scope.getBinding('exports'))
+      ) {
         visited.add(processRequireCall(path, state).node);
       }
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Per the discussion in https://github.com/facebook/metro/issues/225, this would fix the dependency collection worker script so that it would properly interpret require calls in UMD modules. Even if a `require` is bound to a local variable, if it exists with an `exports` local variable binding in the same scope, it is likely to be a normal `require` call in a UMD module.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I've updated the test for collecting dependencies to add a require call in a scope similar to one that would exist in a UMD module. I ran `lerna bootstrap` and `npm test` and everything passes for me locally. I also tested a similar change in the environment in which I reproduced the bug discussed in the  linked issue (this was an older version of Metro), and it allowed the UMD module to be properly bundled and executed without any other issues.