### PR TITLE
Bump react-deep-force-update

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6090,8 +6090,8 @@ rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-deep-force-update@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz#3d2ae45c2c9040cbb1772be52f8ea1ade6ca2ee1"
 
 react-dom@^16.4.1:
   version "16.4.2"


### PR DESCRIPTION
I just cut a patch for compat with some future changes in React. It's backwards compatible.

Haven't tested, but would appreciate if you could verify this didn't break hot reloading.