### PR TITLE
feat: add `resolver.moduleSystem` config property

### DIFF
--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -247,6 +247,12 @@ export type InputConfigT = {
     assetExts?: Array<string>,
 
     /**
+     * This property overrides the `require()` polyfill.
+     * It must be an absolute path.
+     */
+    moduleSystem?: string,
+
+    /**
      * Specify any additional platforms to be used by the packager.
      * For example, if you want to add a "custom" platform, and use modules
      * ending in .custom.js, you would return ['custom'] here.

--- a/packages/metro/src/lib/getPrependedScripts.js
+++ b/packages/metro/src/lib/getPrependedScripts.js
@@ -52,8 +52,11 @@ async function getPrependedScripts(
     type: 'script',
   };
 
+  const moduleSystem = config.resolver &&
+    config.resolver.moduleSystem || defaults.moduleSystem;
+
   const graph = await deltaBundler.buildGraph(
-    [defaults.moduleSystem, ...polyfillModuleNames],
+    [moduleSystem, ...polyfillModuleNames],
     {
       resolve: await transformHelpers.getResolveDependencyFn(
         bundler,


### PR DESCRIPTION
Using a locally developed Metro triggers a complaint about the `require` polyfill not existing in the project root.

To avoid this, you must copy the `require` polyfill into your project root and set the `resolver.moduleSystem` property (in your `metro.config.js` module) to an absolute path.