### PR TITLE
Uglify terser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@
 'use strict';
 
 module.exports = {
-	root: true,
   env: {
     node: true,
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@
 'use strict';
 
 module.exports = {
+	root: true,
   env: {
     node: true,
   },

--- a/packages/metro-minify-terser/.npmignore
+++ b/packages/metro-minify-terser/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+build
+src.real
+yarn.lock

--- a/packages/metro-minify-terser/__tests__/minify-test.js
+++ b/packages/metro-minify-terser/__tests__/minify-test.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @emails oncall+js_foundation
+ */
+'use strict';
+
+import type {BabelSourceMap} from '@babel/core';
+
+jest.mock('terser', () => ({
+  minify: jest.fn(code => {
+    return {
+      code: code.replace(/(^|\W)\s+/g, '$1'),
+      map: {},
+    };
+  }),
+}));
+
+const minify = require('..');
+const {objectContaining} = jasmine;
+
+function getFakeMap(): BabelSourceMap {
+  return {
+    version: 3,
+    sources: ['?'],
+    mappings: '',
+    names: [],
+  };
+}
+
+describe('Minification:', () => {
+  const filename = '/arbitrary/file.js';
+  const code = 'arbitrary(code)';
+  let map: BabelSourceMap;
+  let terser;
+
+  beforeEach(() => {
+    terser = require('terser');
+    terser.minify.mockClear();
+    terser.minify.mockReturnValue({code: '', map: '{}'});
+    map = getFakeMap();
+  });
+
+  it('passes file name, code, and source map to `terser`', () => {
+    minify.withSourceMap(code, map, filename);
+    expect(terser.minify).toBeCalledWith(
+      code,
+      objectContaining({
+        sourceMap: {
+          content: map,
+          includeSources: false,
+        },
+      }),
+    );
+  });
+
+  it('passes code to `terser` when minifying without source map', () => {
+    minify.noSourceMap(code);
+    expect(terser.minify).toBeCalledWith(
+      code,
+      objectContaining({
+        sourceMap: {
+          content: undefined,
+          includeSources: false,
+        },
+      }),
+    );
+  });
+
+  it('returns the code provided by terser', () => {
+    terser.minify.mockReturnValue({code, map: '{}'});
+    const result = minify.withSourceMap('', getFakeMap(), '');
+    expect(result.code).toBe(code);
+    expect(minify.noSourceMap('')).toBe(code);
+  });
+
+  it('parses the source map object provided by terser and sets the sources property', () => {
+    terser.minify.mockReturnValue({map: JSON.stringify(map), code: ''});
+    const result = minify.withSourceMap('', getFakeMap(), filename);
+    expect(result.map).toEqual({...map, sources: [filename]});
+  });
+});

--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "metro-minify-uglify": "^0.45.2",
     "terser": "^3.8.2"
   },
   "devDependencies": {}

--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "metro-minify-terser",
+  "version": "0.45.2",
+  "description": "🚇 Terser-based minifier alternative for Metro",
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/metro.git"
+  },
+  "scripts": {
+    "prepare-release": "test -d build && rm -rf src.real && mv src src.real && mv build src",
+    "cleanup-release": "test ! -e build && mv src build && mv src.real src"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "terser": "^3.8.2"
+  },
+  "devDependencies": {}
+}

--- a/packages/metro-minify-terser/src/index.js
+++ b/packages/metro-minify-terser/src/index.js
@@ -18,7 +18,7 @@ import type {
 } from './types';
 import type {BabelSourceMap} from '@babel/core';
 
-const minifier = require('metro-minify-uglify/minifier');
+const minifier = require('metro-minify-uglify/src/minifier');
 const terser = require('terser');
 
 export type {MetroMinifier} from './types.js.flow';

--- a/packages/metro-minify-terser/src/index.js
+++ b/packages/metro-minify-terser/src/index.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {
+  MetroMinifier,
+  MinifyOptions,
+  ResultWithMap,
+  ResultWithoutMap,
+} from './types';
+import type {BabelSourceMap} from '@babel/core';
+
+const minifier = require('metro-minify-uglify/minifier');
+const terser = require('terser');
+
+export type {MetroMinifier} from './types.js.flow';
+export type {ResultWithMap} from './types.js.flow';
+export type {ResultWithoutMap} from './types.js.flow';
+
+function noSourceMap(
+  code: string,
+  options?: MinifyOptions = {},
+): ResultWithoutMap {
+  return minifier.noSourceMap(code, options, terser);
+}
+
+function withSourceMap(
+  code: string,
+  sourceMap: ?BabelSourceMap,
+  filename: string,
+  options?: MinifyOptions = {},
+): ResultWithMap {
+  return minifier.withSourceMap(code, sourceMap, filename, options, terser);
+}
+
+const metroMinifier: MetroMinifier = {
+  noSourceMap,
+  withSourceMap,
+};
+
+module.exports = metroMinifier;

--- a/packages/metro-minify-terser/src/types.js.flow
+++ b/packages/metro-minify-terser/src/types.js.flow
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import type {BabelSourceMap} from '@babel/core';
+import type {MinifyOptions} from 'metro/src/JSTransformer/worker';
+
+export type {MinifyOptions};
+
+export type ResultWithMap = {
+  code: string,
+  map: BabelSourceMap,
+  options?: MinifyOptions,
+};
+
+export type ResultWithoutMap = string;
+
+type MinifierWithSourceMap = (
+  code: string,
+  inputMap?: ?BabelSourceMap,
+  filename: string,
+  options?: MinifyOptions,
+) => ResultWithMap;
+
+type MinifierWithoutSourceMap = (
+  code: string,
+  options?: MinifyOptions,
+) => ResultWithoutMap;
+
+export type MetroMinifier = {
+  noSourceMap: MinifierWithoutSourceMap,
+  withSourceMap: MinifierWithSourceMap,
+};

--- a/packages/metro-minify-uglify/src/minifier.js
+++ b/packages/metro-minify-uglify/src/minifier.js
@@ -23,8 +23,9 @@ import type {BabelSourceMap} from '@babel/core';
 function noSourceMap(
   code: string,
   options?: MinifyOptions = {},
+  uglifyModule: ?Object,
 ): ResultWithoutMap {
-  return minify(code, undefined, options).code;
+  return minify(code, undefined, options, uglifyModule).code;
 }
 
 function withSourceMap(
@@ -32,8 +33,9 @@ function withSourceMap(
   sourceMap: ?BabelSourceMap,
   filename: string,
   options?: MinifyOptions = {},
+  uglifyModule: ?Object,
 ): ResultWithMap {
-  const result = minify(code, sourceMap, options);
+  const result = minify(code, sourceMap, options, uglifyModule);
   const map: BabelSourceMap = JSON.parse(result.map);
 
   map.sources = [filename];
@@ -45,8 +47,9 @@ function minify(
   inputCode: string,
   inputMap: ?BabelSourceMap,
   options: MinifyOptions,
+  uglifyModule: ?Object,
 ) {
-  const result = uglify.minify(inputCode, {
+  const result = (uglifyModule || uglify).minify(inputCode, {
     mangle: {
       toplevel: false,
       reserved: options.reserved,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Add support for using [terser](https://github.com/fabiosantoscode/terser/). `terser` is a fork of `uglify-es`, which is not really maintained; and maintains API compatibility with `uglify-es`.

In order to avoid duplicating configuration like default options in `metro-minify-uglify`, this PR adds a parameter to `metro-minify-uglify` that allows passing in an alternative minifier module, and the new package `metro-minify-terser` calls this, passing in `terser`.

This is based on discussion in https://github.com/facebook/metro/issues/230.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The tests are simply copied from `metro-minify-uglify`, since the API is and the results should be identical.