### PR TITLE
[visualizer] make metro visualizer an optional dependency

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -77,7 +77,6 @@
     "metro-react-native-babel-preset": "0.45.2",
     "metro-resolver": "0.45.2",
     "metro-source-map": "0.45.2",
-    "metro-visualizer": "0.45.2",
     "mime-types": "2.1.11",
     "mkdirp": "^0.5.1",
     "node-fetch": "^2.2.0",
@@ -97,6 +96,7 @@
   },
   "devDependencies": {
     "metro-memory-fs": "0.45.2",
+    "metro-visualizer": "0.45.2",
     "sinon": "^2.2.0"
   },
   "license": "MIT"

--- a/packages/metro/src/index.js
+++ b/packages/metro/src/index.js
@@ -115,8 +115,18 @@ exports.runServer = async (
   serverApp.use(middleware);
 
   if (config.server.enableVisualizer) {
-    const {initializeVisualizerMiddleware} = require('metro-visualizer');
-    serverApp.use('/visualizer', initializeVisualizerMiddleware(metroServer));
+    let initializeVisualizerMiddleware;
+    try {
+      // eslint-disable-next-line import/no-extraneous-dependencies
+      ({initializeVisualizerMiddleware} = require('metro-visualizer'));
+    } catch (e) {
+      console.warn(
+        "'config.server.enableVisualizer' is enabled but the 'metro-visualizer' package was not found - have you installed it?",
+      );
+    }
+    if (initializeVisualizerMiddleware) {
+      serverApp.use('/visualizer', initializeVisualizerMiddleware(metroServer));
+    }
   }
 
   let httpServer;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This makes `metro-visualizer` an optional package of `metro` as currently it's quite heavy on dependencies and takes up a majority percentage of React Native's package install size; 

![image](https://user-images.githubusercontent.com/5347038/45516977-abd23600-b7a4-11e8-9bd2-2c677afaf855.png)

And: https://twitter.com/jamonholmgren/status/1040260845857656833?s=21

This will try require the package if the config option is enabled and warn if the visualizer package could not be found, but, still gracefully continues. This means its now up to user-land code whether to include this package in their project.

**Test plan**

All tests pass locally:

![image](https://user-images.githubusercontent.com/5347038/45517195-403c9880-b7a5-11e8-9f49-e133e6cd0146.png)

