### PR TITLE
fix: ensure "json" exists in `resolver.sourceExts`

### DIFF
--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -245,6 +245,12 @@ async function loadConfig(
     argv,
   );
 
+  // The resolver breaks if "json" is missing from `resolver.sourceExts`
+  const {sourceExts} = overriddenConfig.resolver;
+  if (!sourceExts.includes('json')) {
+    sourceExts.push('json');
+  }
+
   // Set the watchfolders to include the projectRoot, as Metro assumes that is
   // the case
   overriddenConfig.watchFolders = [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The resolver breaks when `json` is accidentally omitted from the `resolver.sourceExts` array, because Haste FS fails to recognize `package.json` files, which is crucial for module resolution.

**Test plan**

None yet.