### PR TITLE
feat: symlinks in node_modules

### DIFF
--- a/packages/metro-resolver/src/FailedToResolveNameError.js
+++ b/packages/metro-resolver/src/FailedToResolveNameError.js
@@ -13,25 +13,17 @@
 const path = require('path');
 
 class FailedToResolveNameError extends Error {
-  dirPaths: $ReadOnlyArray<string>;
-  extraPaths: $ReadOnlyArray<string>;
+  modulePaths: $ReadOnlyArray<string>;
 
-  constructor(
-    dirPaths: $ReadOnlyArray<string>,
-    extraPaths: $ReadOnlyArray<string>,
-  ) {
-    const displayDirPaths = dirPaths.concat(extraPaths);
-    const hint = displayDirPaths.length ? ' or in these directories:' : '';
+  constructor(modulePaths: $ReadOnlyArray<string>) {
+    const hint = modulePaths.length ? ' or at these locations:' : '';
     super(
       `Module does not exist in the Haste module map${hint}\n` +
-        displayDirPaths
-          .map(dirPath => `  ${path.dirname(dirPath)}\n`)
-          .join(', ') +
+        modulePaths.map(modulePath => `  ${modulePath}\n`).join(', ') +
         '\n',
     );
 
-    this.dirPaths = dirPaths;
-    this.extraPaths = extraPaths;
+    this.modulePaths = modulePaths;
   }
 }
 

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -90,45 +90,74 @@ function resolve(
         return resolution;
       }
     } catch (error) {}
-  }
-
-  const dirPaths = [];
-  for (
-    let currDir = path.dirname(originModulePath);
-    currDir !== '.' && currDir !== path.parse(originModulePath).root;
-    currDir = path.dirname(currDir)
-  ) {
-    const searchPath = path.join(currDir, 'node_modules');
-    dirPaths.push(path.join(searchPath, realModuleName));
-  }
-
-  const extraPaths = [];
-  const {extraNodeModules} = context;
-  if (extraNodeModules) {
-    let bits = path.normalize(moduleName).split(path.sep);
-    let packageName;
-    // Normalize packageName and bits for scoped modules
-    if (bits.length >= 2 && bits[0].startsWith('@')) {
-      packageName = bits.slice(0, 2).join('/');
-      bits = bits.slice(1);
-    } else {
-      packageName = bits[0];
-    }
-    if (extraNodeModules[packageName]) {
-      bits[0] = extraNodeModules[packageName];
-      extraPaths.push(path.join.apply(path, bits));
+    if (isDirectImport) {
+      throw new Error('Failed to resolve module: ' + realModuleName);
     }
   }
 
-  const allDirPaths = dirPaths.concat(extraPaths);
-  for (let i = 0; i < allDirPaths.length; ++i) {
-    const realModuleName = context.redirectModulePath(allDirPaths[i]);
-    const result = resolveFileOrDir(context, realModuleName, platform);
+  const modulePaths = [];
+  for (let modulePath of genModulePaths(context, realModuleName)) {
+    modulePath = context.redirectModulePath(modulePath);
+
+    const result = resolveFileOrDir(context, modulePath, platform);
     if (result.type === 'resolved') {
       return result.resolution;
     }
+
+    modulePaths.push(modulePath);
   }
-  throw new FailedToResolveNameError(dirPaths, extraPaths);
+  throw new FailedToResolveNameError(modulePaths);
+}
+
+/** Generate the potential module paths */
+function* genModulePaths(
+  context: ResolutionContext,
+  toModuleName: string,
+): Iterable<string> {
+  const {extraNodeModules, follow, originModulePath} = context;
+
+  /**
+   * Extract the scope and package name from the module name.
+   */
+  let bits = path.normalize(toModuleName).split(path.sep);
+  let packageName, scopeName;
+  if (bits.length >= 2 && bits[0].startsWith('@')) {
+    packageName = bits.slice(0, 2).join('/');
+    scopeName = bits[0];
+    bits = bits.slice(2);
+  } else {
+    packageName = bits.shift();
+  }
+
+  /**
+   * Find the nearest "node_modules" directory that contains
+   * the imported package.
+   */
+  const {root} = path.parse(originModulePath);
+  let parent = originModulePath;
+  do {
+    parent = path.dirname(parent);
+    if (path.basename(parent) !== 'node_modules') {
+      yield path.join(
+        follow(path.join(parent, 'node_modules', packageName)),
+        ...bits,
+      );
+    }
+  } while (parent !== root);
+
+  /**
+   * Check the user-provided `extraNodeModules` module map for a
+   * direct mapping to a directory that contains the imported package.
+   */
+  if (extraNodeModules) {
+    parent =
+      extraNodeModules[packageName] ||
+      (scopeName ? extraNodeModules[scopeName] : void 0);
+
+    if (parent) {
+      yield path.join(follow(path.join(parent, packageName)), ...bits);
+    }
+  }
 }
 
 /**

--- a/packages/metro-resolver/src/types.js
+++ b/packages/metro-resolver/src/types.js
@@ -48,6 +48,7 @@ export type FileCandidates =
  */
 export type DoesFileExist = (filePath: string) => boolean;
 export type IsAssetFile = (fileName: string) => boolean;
+export type FollowFn = (filePath: string) => string;
 
 /**
  * Given a directory path and the base asset name, return a list of all the
@@ -111,6 +112,7 @@ export type ResolutionContext = ModulePathContext &
     extraNodeModules: ?{[string]: string},
     originModulePath: string,
     resolveRequest?: ?CustomResolver,
+    follow: FollowFn,
   };
 
 export type CustomResolver = (

--- a/packages/metro/src/ModuleGraph/node-haste/node-haste.js
+++ b/packages/metro/src/ModuleGraph/node-haste/node-haste.js
@@ -143,6 +143,7 @@ exports.createResolveFn = function(options: ResolveOptions): ResolveFn {
     dirExists: (filePath: string): boolean => hasteFS.dirExists(filePath),
     doesFileExist: (filePath: string): boolean => hasteFS.exists(filePath),
     extraNodeModules,
+    follow: (filePath: string): string => hasteFS.follow(filePath),
     isAssetFile: (filePath: string): boolean => helpers.isAssetFile(filePath),
     mainFields: options.mainFields,
     moduleCache,

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -143,6 +143,7 @@ class DependencyGraph extends EventEmitter {
 
   _createModuleResolver() {
     this._moduleResolver = new ModuleResolver({
+      follow: (filePath: string) => this._hasteFS.follow(filePath),
       dirExists: (filePath: string) => {
         try {
           return fs.lstatSync(filePath).isDirectory();

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -117,9 +117,9 @@ class DependencyGraph extends EventEmitter {
   }
 
   _getClosestPackage(filePath: string): ?string {
-    const parsedPath = path.parse(filePath);
-    const root = parsedPath.root;
-    let dir = parsedPath.dir;
+    const {root} = path.parse(filePath);
+    // The `filePath` may be a directory.
+    let dir = filePath;
     do {
       const candidate = path.join(dir, 'package.json');
       if (this._hasteFS.exists(candidate)) {

--- a/packages/metro/src/node-haste/types.js
+++ b/packages/metro/src/node-haste/types.js
@@ -13,6 +13,7 @@
 // TODO(cpojer): Create a jest-types repo.
 export type HasteFS = {
   exists(filePath: string): boolean,
+  follow(filePath: string): string,
   getAllFiles(): Array<string>,
   getFileIterator(): Iterator<string>,
   getModuleName(filePath: string): ?string,


### PR DESCRIPTION
- resolve symlinks inside "node_modules" directories
- add `follow` function to `ResolutionContext` type
- move "node_modules" logic into the `yieldPotentialPaths` function
- feat: scope-only keys in `extraNodeModules` map
- fix: always preserve scope when checking `extraNodeModules` map
- fix: throw an error if `resolveRequest` fails to resolve a direct import
- [BREAKING] refactor the `FailedToResolveNameError` class

**Summary**

This commit adds support for symlinks in any `node_modules` directory. This includes scoped packages. Also, PNPM users rejoice!

The `yieldPotentialPaths` function avoids extra work by lazily generating the potential module paths for indirect imports. Also, the resolver now skips over module paths that contain `/node_modules/node_modules/`.

The `extraNodeModules` map now has support for keys like `@babel` to act as a fallback for all modules starting with `@babel/`.

Previously, if the `resolveRequest` function failed to resolve a direct import, we would continue onto the "node_modules" search logic. The correct behavior is to throw an error.

Partially fixes: #1

Depends on: https://github.com/facebook/jest/pull/7549

**Test plan**

None yet. Not familiar with Metro's test suite, and I assume you'll want some changes, or deny this altogether in favor of a more informed direction.

I've tested this manually with arbitrary symlinks and PNPM installations.