### PR TITLE
Create inlineSourceMaps when no URL is specified

### DIFF
--- a/packages/metro/src/index.js
+++ b/packages/metro/src/index.js
@@ -230,7 +230,7 @@ exports.runBuild = async (
     const requestOptions: RequestOptions = {
       dev,
       entryFile: entry,
-      inlineSourceMap: sourceMap && !!sourceMapUrl,
+      inlineSourceMap: sourceMap && !sourceMapUrl,
       minify,
       platform,
       sourceMapUrl: sourceMap === false ? undefined : sourceMapUrl,


### PR DESCRIPTION
Expected bahavior is to create inline source maps, when `sourceMaps: true` and `sourceMapUrl` is not set. However, the current logic creates inline source maps when `sourceMapUrl` evaluates to true.

This PR fixes this logic to create inline source maps, when no sourceMapUrl is specified.