### PR TITLE
Fix typescript constructor parameter properties

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -138,13 +138,18 @@ const getPreset = (src, options) => {
   return {
     comments: false,
     compact: true,
-    plugins: defaultPlugins.concat(extraPlugins),
     overrides: [
+      {
+        plugins: defaultPlugins,
+      },
       {
         test: isTypeScriptSource,
         plugins: [
           [require('@babel/plugin-transform-typescript'), {isTSX: true}],
         ],
+      },
+      {
+        plugins: extraPlugins,
       },
     ],
   };

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/build-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/build-test.js.snap
@@ -22,6 +22,7 @@ Object {
     "type": "foo",
   },
   "TypeScript": Object {
+    "B": [Function],
     "test": true,
     "type": "TypeScript",
   },

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/rambundle-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/rambundle-test.js.snap
@@ -22,6 +22,7 @@ Object {
     "type": "foo",
   },
   "TypeScript": Object {
+    "B": [Function],
     "test": true,
     "type": "TypeScript",
   },

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/server-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/server-test.js.snap
@@ -22,6 +22,7 @@ Object {
     "type": "foo",
   },
   "TypeScript": Object {
+    "B": [Function],
     "test": true,
     "type": "TypeScript",
   },

--- a/packages/metro/src/integration_tests/basic_bundle/TypeScript.ts
+++ b/packages/metro/src/integration_tests/basic_bundle/TypeScript.ts
@@ -10,3 +10,7 @@ export const test = true as boolean
 
 // Exporting default interface was broken before Babel 7.0.0-beta.56
 export default interface A {}
+
+export class B {
+  constructor(public name: string){}
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

issue https://github.com/facebook/metro/issues/258. 
metro-react-native-babel-preset don't recognize typescript constructor parameter properties, currently.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

not yet.