### PR TITLE
Only set isTSX to true when extension is .tsx

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -10,7 +10,11 @@
 'use strict';
 
 function isTypeScriptSource(fileName) {
-  return !!fileName && (fileName.endsWith('.ts') || fileName.endsWith('.tsx'));
+  return !!fileName && fileName.endsWith('.ts');
+}
+
+function isTSXSource(fileName) {
+  return !!fileName && fileName.endsWith('.tsx');
 }
 
 const defaultPlugins = [
@@ -154,6 +158,12 @@ const getPreset = (src, options) => {
     overrides: [
       {
         test: isTypeScriptSource,
+        plugins: [
+          [require('@babel/plugin-transform-typescript'), {isTSX: false}],
+        ],
+      },
+      {
+        test: isTSXSource,
         plugins: [
           [require('@babel/plugin-transform-typescript'), {isTSX: true}],
         ],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

There are some syntax incompatibilities between TS and TSX, particularly around casting. See the official TypeScript handbook for more information:

https://www.typescriptlang.org/docs/handbook/jsx.html

This change will allow TS-style casting when the file extension is `.ts` (and disallow JSX syntax), and allow JSX syntax but disallow TS-style casting when the file extension is `.tsx`.

We ran into this issue in our project because our reducers are all `.ts` files and many of them use the old casting syntax.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

There are no existing tests that I can find for `metro-react-native-babel-preset`, but you can try it out with some basic TypeScript files:

> `test1.ts`
```typescript
const a: string | number = 'test';
const b = <string> a;
```

> `test2.tsx`
```typescript
import {View} from 'react-native';
const foo: React.SFC<{}> = () => <View></View>;
```