### PR TITLE
Handle the case where transformSync returns null

### DIFF
--- a/packages/metro/src/reactNativeTransformer.js
+++ b/packages/metro/src/reactNativeTransformer.js
@@ -144,14 +144,19 @@ function transform({filename, options, src, plugins}: BabelTransformerArgs) {
 
   try {
     const babelConfig = buildBabelConfig(filename, options, plugins);
-    const {ast} = transformSync(src, {
+    const result = transformSync(src, {
       // ES modules require sourceType='module' but OSS may not always want that
       sourceType: 'unambiguous',
       ...babelConfig,
       ast: true,
     });
 
-    return {ast};
+    // The result from `transformSync` can be null (if the file is ignored)
+    if (!result) {
+      return {ast: null};
+    }
+
+    return {ast: result.ast};
   } finally {
     process.env.BABEL_ENV = OLD_BABEL_ENV;
   }


### PR DESCRIPTION
**Summary**

Fixes a bug when ignoring a file in the babel config: https://github.com/facebook/metro/issues/255#issuecomment-423819590

**Test plan**

Couldn't find any obvious tests that test this part of the code. Happy to add some tests if someone can point me in the right direction.