### PR TITLE
Resolves transformerPath before attempting to read contents.

### DIFF
--- a/packages/metro/src/DeltaBundler/Transformer/getTransformCacheKey.js
+++ b/packages/metro/src/DeltaBundler/Transformer/getTransformCacheKey.js
@@ -47,7 +47,7 @@ function getTransformCacheKey(opts: {|
     VERSION,
     opts.cacheVersion,
     path.relative(path.join(__dirname, '../../../..'), opts.projectRoot),
-    getKeyFromFiles([transformerPath]),
+    getKeyFromFiles([require.resolve(transformerPath)]),
     transformerKey,
   ];
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Configuration paths are now supposed to be relative to allow them to be shared
on different paths/machines. This change makes sure that the new relative
transformerPath is require.resolved before being passed to fs.readFileSync.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
I edited node_modules directly in metro-sample-app to ensure that the fix got
me passed the unable to resolve error.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
