### PR TITLE
[metro-babel-register] Ignore babel.config.js files in addition to .babelrc

### DIFF
--- a/packages/metro-babel-register/src/babel-register.js
+++ b/packages/metro-babel-register/src/babel-register.js
@@ -32,7 +32,7 @@ function registerOnly(onlyList) {
   // This prevents `babel-register` from transforming the code of the
   // plugins/presets that we are require-ing themselves before setting up the
   // actual config.
-  require('@babel/register')({only: [], babelrc: false});
+  require('@babel/register')({only: [], babelrc: false, configFile: false});
   require('@babel/register')(config(onlyList));
 }
 
@@ -40,6 +40,7 @@ function config(onlyList) {
   _only = _only.concat(onlyList);
   return {
     babelrc: false,
+    configFile: false,
     ignore: null,
     only: _only,
     plugins: PLUGINS,


### PR DESCRIPTION
**Summary**

This adds support for projects using `metro-babel-register` with Babel 7's babel.config.js files. The `metro-babel-register` package is designed to apply a static, hardcoded list of Babel plugins. It intentionally ignores .babelrc files by setting `babelrc: false`.

Babel 7 added a new configuration file called babel.config.js, with similar but slightly different loading semantics. To disable babel.config.js lookup, there is a new option called `configFile` instead of `babelrc`. See https://babeljs.io/docs/en/next/config-files#project-wide-configuration.

Fixes https://github.com/facebook/react-native/issues/21052

**Test plan**

In a React Native project with babel.config.js and an error about `regeneratorRuntime` missing when starting the CLI, said error goes away with this `metro-babel-register` patch.
