### PR TITLE
[metro] add $FlowExpectedError annotation for optional visualizer dep

### DIFF
--- a/packages/metro/src/index.js
+++ b/packages/metro/src/index.js
@@ -118,6 +118,7 @@ exports.runServer = async (
     let initializeVisualizerMiddleware;
     try {
       // eslint-disable-next-line import/no-extraneous-dependencies
+      // $FlowExpectedError
       ({initializeVisualizerMiddleware} = require('metro-visualizer'));
     } catch (e) {
       console.warn(


### PR DESCRIPTION
This adds a `$FlowExpectedError` comment annotation for the optional `metro-visualizer` dependency, resolves the following issue:

![image](https://user-images.githubusercontent.com/5347038/46366676-9ea5ba00-c673-11e8-8cbc-6442904bff70.png)


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

![image](https://user-images.githubusercontent.com/5347038/46366922-32778600-c674-11e8-9a21-4c65e4fba210.png)
