### PR TITLE
[assets] Adds support for publicPath to enable serving assets from different locations.

### DIFF
--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -79,6 +79,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     postMinifyProcess: x => x,
     transformVariants: {default: {}},
     workerPath: 'metro/src/DeltaBundler/Worker',
+    publicPath: '/assets',
   },
   cacheStores: [
     new FileStore({

--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -177,8 +177,9 @@ async function getAssetData(
   localPath: string,
   assetDataPlugins: $ReadOnlyArray<string>,
   platform: ?string = null,
+  publicPath: ?string = '/assets',
 ): Promise<AssetData> {
-  let assetUrlPath = path.join('/assets', path.dirname(localPath));
+  let assetUrlPath = `${publicPath}/${path.dirname(localPath)}`;
 
   // On Windows, change backslashes to slashes to get proper URL path from file path.
   if (path.sep === '\\') {

--- a/packages/metro/src/DeltaBundler/Transformer.js
+++ b/packages/metro/src/DeltaBundler/Transformer.js
@@ -48,6 +48,7 @@ class Transformer {
         enableBabelRCLookup: this._config.transformer.enableBabelRCLookup,
         minifierPath: this._config.transformer.minifierPath,
         optimizationSizeLimit: this._config.transformer.optimizationSizeLimit,
+        publicPath: this._config.transformer.publicPath,
       },
     };
 

--- a/packages/metro/src/JSTransformer/worker.js
+++ b/packages/metro/src/JSTransformer/worker.js
@@ -84,6 +84,7 @@ export type JsTransformerConfig = {|
   +enableBabelRCLookup: boolean,
   +minifierPath: string,
   +optimizationSizeLimit: number,
+  +publicPath: string,
 |};
 
 export type CustomTransformOptions = {[string]: mixed, __proto__: null};
@@ -179,6 +180,7 @@ class JsTransformer {
         // is used by other tooling, and this would affect it.
         inlineRequires: false,
         projectRoot: this._projectRoot,
+        publicPath: this._config.publicPath,
       },
       plugins: [],
       src: sourceCode,

--- a/packages/metro/src/assetTransformer.js
+++ b/packages/metro/src/assetTransformer.js
@@ -36,6 +36,7 @@ async function transform(
     filename,
     assetDataPlugins,
     options.platform,
+    options.publicPath,
   );
 
   return {


### PR DESCRIPTION
Opening this PR to get some feedback/direction on the approach. Our use case requires that we serve our js/maps/image/css assets from `/static/`, which breaks some of the assumptions in the metro bundler.

This is a start toward allowing us to configure the path that compiled assets are served from. I think that publicPath makes the most sense as a server option, but it'll be needed by transformers and serializers to enable support for assets and source maps.