### PR TITLE
Prevent throwing an exception during evaluation in constantFoldingPlu…

### DIFF
--- a/packages/metro/src/JSTransformer/worker/__tests__/constant-folding-plugin-test.js
+++ b/packages/metro/src/JSTransformer/worker/__tests__/constant-folding-plugin-test.js
@@ -336,4 +336,12 @@ describe('constant expressions', () => {
 
     nonChanged.forEach(test => compare([constantFoldingPlugin], test, test));
   });
+
+  it('will not throw on evaluate exception', () => {
+    const nonChanged = `
+      Object({ 'toString': 0 } + '');
+    `;
+
+    compare([constantFoldingPlugin], nonChanged, nonChanged);
+  });
 });

--- a/packages/metro/src/JSTransformer/worker/constant-folding-plugin.js
+++ b/packages/metro/src/JSTransformer/worker/constant-folding-plugin.js
@@ -27,7 +27,11 @@ function constantFoldingPlugin(context: {types: BabelTypes}) {
       state,
     );
 
-    return state.safe ? path.evaluate() : {confident: false, value: null};
+    try {
+      return state.safe ? path.evaluate() : {confident: false, value: null};
+    } catch (err) {
+      return {confident: false, value: null};
+    }
   };
 
   const FunctionDeclaration = {


### PR DESCRIPTION
…gin.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

This pull request is in response to issue [#281](https://github.com/facebook/metro/issues/281) and implements @rafeca's recommended fix along with a test demonstrating the new behavior.

Code from the [`lodash-compat`](https://github.com/lodash-archive/lodash-compat) library caused a `TypeError: Cannot convert object to primitive value` exception to be thrown when evaluating the following line:
`Object({ 'toString': 0 } + '');`
This pull request prevents the exception from throwing and breaking the packaging.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->