### PR TITLE
Enable babel-runtime by default in react-native-babel-preset

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -147,7 +147,7 @@ const getPreset = (src, options) => {
     extraPlugins.push(reactJsxSource);
   }
 
-  if (options && options.enableBabelRuntime) {
+  if (!options || options.enableBabelRuntime !== false) {
     extraPlugins.push(babelRuntime);
   }
 


### PR DESCRIPTION
**Summary**

When using a custom .babelrc file in a project we need to specify `["module:metro-react-native-babel-preset", {"enableBabelRuntime": true}]` otherwise `@babel/runtime` won't be used. This flips the check so it is enabled by default so the option is no longer needed unless explicitly disabled.

**Test plan**

Tested in a project that babel runtime gets added when no option is passed and that it doesn't get added if `enableBabelRuntime` is `false`.
