### PR TITLE
Replace Node v9 with Node v10 on CircleCI tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,10 +33,11 @@ jobs:
       - run: yarn --no-progress
       - save-cache: *save-cache
       - run: yarn run test-ci
-  test-node-9:
+
+  test-node-10:
     working_directory: ~/metro
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
     steps:
       - checkout
       - restore-cache: *restore-cache
@@ -71,6 +72,7 @@ jobs:
       - run:
           working_directory: ~/metro
           command: npm run publish
+
   test-and-deploy-website:
     working_directory: ~/metro
     docker:
@@ -91,7 +93,7 @@ workflows:
     jobs:
       - run-js-checks
       - test-node-8
-      - test-node-9
+      - test-node-10
       - test-and-deploy-website
       - publish-to-npm:
           filters:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

After upgrading to `jest` v24 the circleCI tests have started failing because a dependency of `jest` does not have node v9 as a supported engine ([more info on the circleCI logs](https://circleci.com/gh/facebook/metro/3376)).

This diff replaces node v9 by node v10, which is already stable

**Test plan**

CircleCI tests
