### PR TITLE
do not inject es6 `default` syntax into dynamically imported modules

### DIFF
--- a/packages/metro/src/lib/bundle-modules/asyncRequire.js
+++ b/packages/metro/src/lib/bundle-modules/asyncRequire.js
@@ -13,5 +13,5 @@
 // eslint-disable-next-line lint/flow-no-fixme
 const dynamicRequire = (require: $FlowFixMe);
 module.exports = function(moduleID: mixed): Promise<mixed> {
-  return Promise.resolve().then(() => ({default: dynamicRequire(moduleID)}));
+  return Promise.resolve().then(() => dynamicRequire(moduleID));
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

I believe there is a bug in the `asyncRequire` module.  It should resolve the promise with exactly what was returned from the `require(moduleID)` call.  It should not nest the module under another `default` key.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`babel-plugin-dynamic-import-node` rewrites `import(...)` statements in this way.  Here is some example output from some test fixtures: https://github.com/airbnb/babel-plugin-dynamic-import-node/blob/master/test/fixtures/dynamic-argument/expected.es2015.js


There is a snippet here https://developers.google.com/web/updates/2017/11/dynamic-import that shows explicit usage of dynamic import with an `es6` module.  The spe
```js
  (async () => {
    const moduleSpecifier = './utils.mjs';
    const module = await import(moduleSpecifier)
    module.default();
    // → logs 'Hi from the default export!'
    module.doStuff();
    // → logs 'Doing stuff…'
  })();
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I have a line of code in a project i am working on.
```js
import('./migrations/accordion/accordion.2.0.0').then((module) => module.default)
```
the module at `'./migrations/accordion/accordion.2.0.0'` looks something like:
```js
export default function foo() { /* ... */ }
```

Without the patch in this PR, the import(...) call returns something like:
```js
{
  default: {
    default: [Function foo]
  }
}
```

With this patch, the import(...) call will return properly:
```js
{
  default: [Function foo]
}
```