### PR TITLE
Add custom serializer

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -64,6 +64,7 @@ Object {
   },
   "serializer": Object {
     "createModuleIdFactory": [Function],
+    "customSerializer": null,
     "experimentalSerializerHook": [Function],
     "getModulesRunBeforeMainModule": [Function],
     "getPolyfills": [Function],
@@ -184,6 +185,7 @@ Object {
   },
   "serializer": Object {
     "createModuleIdFactory": [Function],
+    "customSerializer": null,
     "experimentalSerializerHook": [Function],
     "getModulesRunBeforeMainModule": [Function],
     "getPolyfills": [Function],

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -26,6 +26,7 @@ import type {TransformVariants} from 'metro/src/ModuleGraph/types.flow.js';
 import type {DynamicRequiresBehavior} from 'metro/src/ModuleGraph/worker/collectDependencies';
 import type Server from 'metro/src/Server';
 import type {Reporter} from 'metro/src/lib/reporting';
+import type {Options} from 'metro/src/DeltaBundler/Serializers/plainJSBundle';
 
 export type PostMinifyProcess = ({
   code: string,
@@ -115,6 +116,12 @@ type ResolverConfigT = {|
 
 type SerializerConfigT = {|
   createModuleIdFactory: () => (path: string) => number,
+  customSerializer: ?(
+    entryPoint: string,
+    preModules: $ReadOnlyArray<Module<>>,
+    graph: Graph<>,
+    options: Options,
+  ) => string,
   experimentalSerializerHook: (graph: Graph<>, delta: DeltaResult<>) => mixed,
   getModulesRunBeforeMainModule: (entryFilePath: string) => Array<string>,
   getPolyfills: ({platform: ?string}) => $ReadOnlyArray<string>,

--- a/packages/metro-config/src/convertConfig.js
+++ b/packages/metro-config/src/convertConfig.js
@@ -111,6 +111,7 @@ async function convertOldToNew({
       useWatchman: true,
     },
     serializer: {
+      customSerializer: defaultConfig.serializer.customSerializer,
       createModuleIdFactory:
         createModuleIdFactory || defaultConfig.serializer.createModuleIdFactory,
       polyfillModuleNames: getPolyfillModuleNames(),

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -54,6 +54,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     processModuleFilter: module => true,
     createModuleIdFactory: defaultCreateModuleIdFactory,
     experimentalSerializerHook: () => {},
+    customSerializer: null,
   },
 
   server: {

--- a/packages/metro/src/DeltaBundler/Serializers/plainJSBundle.js
+++ b/packages/metro/src/DeltaBundler/Serializers/plainJSBundle.js
@@ -17,7 +17,7 @@ const {isJsModule, wrapModule} = require('./helpers/js');
 import type {ModuleMap} from '../../lib/bundle-modules/types.flow';
 import type {Graph, Module, SerializerOptions} from '../types.flow';
 
-type Options =
+export type Options =
   | {|
       ...SerializerOptions,
       embedDelta: false,

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -664,6 +664,7 @@ class Server {
           }));
 
       const options = {
+        customSerializer: this._config.serializer.customSerializer,
         processModuleFilter: this._config.serializer.processModuleFilter,
         createModuleId: this._createModuleId,
         getRunModuleStatement: this._config.serializer.getRunModuleStatement,
@@ -677,7 +678,7 @@ class Server {
         inlineSourceMap: serializerOptions.inlineSourceMap,
       };
 
-      const bundle = plainJSBundle(
+      const serializerArguments = [
         entryFile,
         revision.prepend,
         revision.graph,
@@ -689,7 +690,13 @@ class Server {
               revisionId: revision.id,
             })
           : Object.assign({}, options, {embedDelta: false}),
-      );
+      ];
+      let bundle;
+      if (options.customSerializer) {
+        bundle = options.customSerializer(...serializerArguments);
+      } else {
+        bundle = plainJSBundle(...serializerArguments);
+      }
 
       return {
         numModifiedFiles: delta.reset

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -664,7 +664,6 @@ class Server {
           }));
 
       const options = {
-        customSerializer: this._config.serializer.customSerializer,
         processModuleFilter: this._config.serializer.processModuleFilter,
         createModuleId: this._createModuleId,
         getRunModuleStatement: this._config.serializer.getRunModuleStatement,
@@ -692,8 +691,9 @@ class Server {
           : Object.assign({}, options, {embedDelta: false}),
       ];
       let bundle;
-      if (options.customSerializer) {
-        bundle = options.customSerializer(...serializerArguments);
+      const possibleCustomSerializer = this._config.serializer.customSerializer;
+      if (possibleCustomSerializer) {
+        bundle = possibleCustomSerializer(...serializerArguments);
       } else {
         bundle = plainJSBundle(...serializerArguments);
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
We would like to bundle an entryfile differently than it is currently done in Metro, specifically in development. Without a pluggable serializer, we wouldn't be able to perform bundle splitting in development, which is impactful to our development speed. 

This PR alleviates bundle sizing problem by introducing a customSerializer instead of using the `plainJSBundle`.

Some minor question, do I have to implement this in the `build` public method in the server? 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
- Wrote a `customSerializer` and test it against the new change in metro. Our bundle was able to do what we needed it to accomplish.