### PR TITLE
Fix entryFile always is assumed to end with `.js` extension

### DIFF
--- a/packages/metro/src/HmrServer/__tests__/HmrServer-test.js
+++ b/packages/metro/src/HmrServer/__tests__/HmrServer-test.js
@@ -12,6 +12,10 @@
 const HmrServer = require('..');
 
 const getGraphId = require('../../lib/getGraphId');
+jest.mock('../../lib/transformHelpers', () => ({
+  getResolveDependencyFn: () => (from, to) =>
+    `${from.replace(/\.$/, '')}${to}.js`,
+}));
 
 describe('HmrServer', () => {
   let hmrServer;
@@ -74,6 +78,7 @@ describe('HmrServer', () => {
           deleted: new Set(),
         },
       }),
+      getBundler() {},
     };
     createModuleIdMock = path => {
       return path + '-id';

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -25,6 +25,7 @@ const debug = require('debug')('Metro:Server');
 const formatBundlingError = require('./lib/formatBundlingError');
 const mime = require('mime-types');
 const parseOptionsFromUrl = require('./lib/parseOptionsFromUrl');
+const transformHelpers = require('./lib/transformHelpers');
 const parsePlatformFilePath = require('./node-haste/lib/parsePlatformFilePath');
 const path = require('path');
 const serializeDeltaJSBundle = require('./DeltaBundler/Serializers/helpers/serializeDeltaJSBundle');
@@ -424,7 +425,6 @@ class Server {
           protocol: 'http',
           host: req.headers.host,
         }),
-        this._config.projectRoot,
         new Set(this._config.resolver.platforms),
       );
       const {
@@ -432,7 +432,20 @@ class Server {
         transformOptions,
         serializerOptions,
       } = splitBundleOptions(bundleOptions);
-      const graphId = getGraphId(entryFile, transformOptions);
+
+      /**
+       * `entryFile` is relative to projectRoot, we need to use resolution function
+       * to find the appropriate file with supported extensions.
+       */
+      const resolutionFn = await transformHelpers.getResolveDependencyFn(
+        this._bundler.getBundler(),
+        transformOptions.platform,
+      );
+      const resolvedEntryFilePath = resolutionFn(
+        `${this._config.projectRoot}/.`,
+        entryFile,
+      );
+      const graphId = getGraphId(resolvedEntryFilePath, transformOptions);
       const buildID = this.getNewBuildID();
 
       let onProgress = null;
@@ -458,7 +471,7 @@ class Server {
       this._reporter.update({
         buildID,
         bundleDetails: {
-          entryFile,
+          entryFile: resolvedEntryFilePath,
           platform: transformOptions.platform,
           dev: transformOptions.dev,
           minify: transformOptions.minify,
@@ -473,7 +486,7 @@ class Server {
         revisionId,
         buildID,
         bundleOptions,
-        entryFile,
+        entryFile: resolvedEntryFilePath,
         transformOptions,
         serializerOptions,
         onProgress,
@@ -867,7 +880,6 @@ class Server {
   async _sourceMapForURL(reqUrl: string): Promise<MetroSourceMap> {
     const {options} = parseOptionsFromUrl(
       reqUrl,
-      this._config.projectRoot,
       new Set(this._config.resolver.platforms),
     );
 
@@ -878,12 +890,25 @@ class Server {
       onProgress,
     } = splitBundleOptions(options);
 
-    const graphId = getGraphId(entryFile, transformOptions);
+    /**
+     * `entryFile` is relative to projectRoot, we need to use resolution function
+     * to find the appropriate file with supported extensions.
+     */
+    const resolutionFn = await transformHelpers.getResolveDependencyFn(
+      this._bundler.getBundler(),
+      transformOptions.platform,
+    );
+    const resolvedEntryFilePath = resolutionFn(
+      `${this._config.projectRoot}/.`,
+      entryFile,
+    );
+
+    const graphId = getGraphId(resolvedEntryFilePath, transformOptions);
     let revision;
     const revPromise = this._bundler.getRevisionByGraphId(graphId);
     if (revPromise == null) {
       ({revision} = await this._bundler.initializeGraph(
-        entryFile,
+        resolvedEntryFilePath,
         transformOptions,
         {onProgress},
       ));

--- a/packages/metro/src/lib/__tests__/parseOptionsFromUrl-test.js
+++ b/packages/metro/src/lib/__tests__/parseOptionsFromUrl-test.js
@@ -18,39 +18,24 @@ jest.mock('../parseCustomTransformOptions', () => () => ({}));
 describe('parseOptionsFromUrl', () => {
   it.each([['map'], ['delta'], ['bundle']])('detects %s requests', type => {
     expect(
-      parseOptionsFromUrl(
-        `http://localhost/my/bundle.${type}`,
-        '/',
-        new Set([]),
-      ).options,
+      parseOptionsFromUrl(`http://localhost/my/bundle.${type}`, new Set([]))
+        .options,
     ).toMatchObject({bundleType: type});
-  });
-
-  it('resolves the entry file from the project root', () => {
-    expect(
-      parseOptionsFromUrl(
-        'http://localhost/my/bundle.bundle.includeRequire.runModule.assets',
-        '/static/bundles/',
-        new Set([]),
-      ).options,
-    ).toMatchObject({entryFile: '/static/bundles/my/bundle.js'});
   });
 
   it('removes extraneous options from the pathname', () => {
     expect(
       parseOptionsFromUrl(
         'http://localhost/my/bundle.bundle.includeRequire.runModule.assets',
-        '/',
         new Set([]),
       ).options,
-    ).toMatchObject({entryFile: '/my/bundle.js'});
+    ).toMatchObject({entryFile: './my/bundle'});
   });
 
   it('retrieves the platform from the query parameters', () => {
     expect(
       parseOptionsFromUrl(
         'http://localhost/my/bundle.bundle?platform=ios',
-        '/',
         new Set([]),
       ).options,
     ).toMatchObject({platform: 'ios'});
@@ -60,7 +45,6 @@ describe('parseOptionsFromUrl', () => {
     expect(
       parseOptionsFromUrl(
         'http://localhost/my/bundle.test.bundle',
-        '/',
         new Set(['test']),
       ).options,
     ).toMatchObject({platform: 'test'});
@@ -70,7 +54,6 @@ describe('parseOptionsFromUrl', () => {
     expect(
       parseOptionsFromUrl(
         'http://localhost/my/bundle.delta?revisionId=XXX',
-        '/',
         new Set([]),
       ),
     ).toMatchObject({revisionId: 'XXX'});
@@ -78,7 +61,6 @@ describe('parseOptionsFromUrl', () => {
     expect(
       parseOptionsFromUrl(
         'http://localhost/my/bundle.delta?deltaBundleId=XXX',
-        '/',
         new Set([]),
       ),
     ).toMatchObject({revisionId: 'XXX'});
@@ -86,12 +68,12 @@ describe('parseOptionsFromUrl', () => {
 
   it('infers the source map url from the pathname', () => {
     expect(
-      parseOptionsFromUrl('http://localhost/my/bundle.bundle', '/', new Set([]))
+      parseOptionsFromUrl('http://localhost/my/bundle.bundle', new Set([]))
         .options,
     ).toMatchObject({sourceMapUrl: '//localhost/my/bundle.map'});
 
     expect(
-      parseOptionsFromUrl('http://localhost/my/bundle.delta', '/', new Set([]))
+      parseOptionsFromUrl('http://localhost/my/bundle.delta', new Set([]))
         .options,
     ).toMatchObject({sourceMapUrl: '//localhost/my/bundle.map'});
   });
@@ -100,7 +82,6 @@ describe('parseOptionsFromUrl', () => {
     expect(
       parseOptionsFromUrl(
         'http://localhost/my/bundle.bundle?platform=ios',
-        '/',
         new Set(['ios']),
       ).options,
     ).toMatchObject({
@@ -110,7 +91,6 @@ describe('parseOptionsFromUrl', () => {
     expect(
       parseOptionsFromUrl(
         'http://localhost/my/bundle.bundle?platform=android',
-        '/',
         new Set(['android']),
       ).options,
     ).toMatchObject({
@@ -120,7 +100,7 @@ describe('parseOptionsFromUrl', () => {
 
   it('always sets the `hot` option to `true`', () => {
     expect(
-      parseOptionsFromUrl('http://localhost/my/bundle.bundle', '/', new Set([]))
+      parseOptionsFromUrl('http://localhost/my/bundle.bundle', new Set([]))
         .options,
     ).toMatchObject({hot: true});
   });
@@ -134,11 +114,8 @@ describe('parseOptionsFromUrl', () => {
   ])('boolean option `%s`', (optionName, defaultValue) => {
     it(`defaults to \`${String(defaultValue)}\``, () => {
       expect(
-        parseOptionsFromUrl(
-          'http://localhost/my/bundle.bundle',
-          '/',
-          new Set([]),
-        ).options,
+        parseOptionsFromUrl('http://localhost/my/bundle.bundle', new Set([]))
+          .options,
       ).toMatchObject({[optionName]: defaultValue});
     });
 
@@ -146,7 +123,6 @@ describe('parseOptionsFromUrl', () => {
       expect(
         parseOptionsFromUrl(
           `http://localhost/my/bundle.bundle?${optionName}=true`,
-          '/',
           new Set([]),
         ).options,
       ).toMatchObject({[optionName]: true});
@@ -154,7 +130,6 @@ describe('parseOptionsFromUrl', () => {
       expect(
         parseOptionsFromUrl(
           `http://localhost/my/bundle.bundle?${optionName}=false`,
-          '/',
           new Set([]),
         ).options,
       ).toMatchObject({[optionName]: false});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
When making a request to metro server with `.bundle` suffix, if this source file was named with `.jsx` or `.ts`, metro isn't able to find the resource. Instead, an error message is shown indicating there isn't such file associated with `.js` extension. 

This PR addresses this issue by passing the entryFile name in the URL into the module resolution system, which will handle various extensions gracefully.

**Test plan**
- Test in the application, making a request to a source file with `.jsx` extension.
