### PR TITLE
Drop console.warning when module is defined twice

### DIFF
--- a/packages/metro/src/lib/polyfills/require.js
+++ b/packages/metro/src/lib/polyfills/require.js
@@ -103,10 +103,6 @@ function define(
       // called with inverseDependencies, we can hot reload it.
       if (inverseDependencies) {
         global.__accept(moduleId, factory, dependencyMap, inverseDependencies);
-      } else {
-        console.warn(
-          `Trying to define twice module ID ${moduleId} in the same bundle`,
-        );
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
We break down our entrypoint by dynamic import, henceforth, this console warning creates a lot of noise for us. We don't only use one giant entrypoint as a bundle. This will be less relevant as metro starts supporting breaking down entrypoint to many segments.

**Test plan**
- Make sure the console warning isn't spamming in the browser