### PR TITLE
Improve circleci configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,90 +1,96 @@
-aliases:
-  - &restore-cache
-    keys:
-      - dependencies-{{ .Branch }}-{{ checksum "package.json" }}
-      # Fallback in case checksum fails
-      - dependencies-{{ .Branch }}-
+commands:
+  yarn_install:
+    description: "A wrapper to yarn install with caching"
+    parameters:
+      working_directory:
+        type: string
+        default: ""
+    steps:
+      - restore_cache:
+          keys:
+            - dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            # Fallback in case checksum fails
+            - dependencies-{{ .Branch }}-
+      - run:
+          command: NPM_TOKEN= yarn --no-progress
+          working_directory: << parameters.working_directory >>
+      - save_cache:
+          paths:
+            - node_modules
+          key: dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
-  - &save-cache
-    paths:
-      - node_modules
-    key: dependencies-{{ .Branch }}-{{ checksum "package.json" }}
+  yarn_run:
+    description: "A wrapper to execute yarn commands in a safe way"
+    parameters:
+      working_directory:
+        type: string
+        default: ""
+      command:
+        type: string
+    steps:
+      - run:
+          command: NPM_TOKEN= yarn run << parameters.command >>
+          working_directory: << parameters.working_directory >>
 
-  - &deploy-website
-    command: |
-      # Deploy Metro website
-      git config --global user.email "metro-bot@users.noreply.github.com"
-      git config --global user.name "Website Deployment Script"
-      echo "machine github.com login metro-bot password $GITHUB_TOKEN" > ~/.netrc
-      # install Docusaurus and generate file of English strings
-      cd website && yarn && yarn run write-translations
-      # build and publish website
-      GIT_USER=metro-bot yarn run publish-gh-pages
+  deploy_website:
+    steps:
+      - run: git config --global user.email "metro-bot@users.noreply.github.com"
+      - run: git config --global user.name "Website Deployment Script"
+      - run: echo "machine github.com login metro-bot password $GITHUB_TOKEN" > ~/.netrc
+      - yarn_install:
+          working_directory: website
+      - yarn_run:
+          command: write-translations
+          working_directory: website
+      - yarn_run:
+          command: publish-gh-pages
+          working_directory: website
 
-version: 2
+version: 2.1
 jobs:
   run-js-checks:
-    working_directory: ~/metro
     docker:
       - image: circleci/node:8
     steps:
       - checkout
-      - restore-cache: *restore-cache
-      - run: yarn --no-progress
-      - save-cache: *save-cache
-      - run: yarn run test-ci
+      - yarn_install
+      - yarn_run:
+          command: test-ci
 
   test-node-10:
-    working_directory: ~/metro
     docker:
       - image: circleci/node:10
     steps:
       - checkout
-      - restore-cache: *restore-cache
-      - run: yarn --no-progress
-      - save-cache: *save-cache
-      - run: yarn run jest
+      - yarn_install
+      - yarn_run:
+          command: jest
 
   test-node-8:
-    working_directory: ~/metro
     docker:
       - image: circleci/node:8
     steps:
       - checkout
-      - restore-cache: *restore-cache
-      - run: yarn --no-progress
-      - save-cache: *save-cache
-      - run: yarn run jest
+      - yarn_install
+      - yarn_run:
+          command: jest
 
   publish-to-npm:
-    working_directory: ~/metro
     docker:
       - image: circleci/node:8
     steps:
       - checkout
-      - restore-cache: *restore-cache
-      - run:
-          working_directory: packages/metro
-          command: yarn --no-progress
-      - save-cache: *save-cache
-      - run:
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      - run:
-          working_directory: ~/metro
-          command: npm run publish
+      - yarn_install
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run: npm run publish
+      - run: rm ~/.npmrc
 
   test-and-deploy-website:
-    working_directory: ~/metro
     docker:
       - image: circleci/node:8
     steps:
       - checkout
-      - restore-cache: *restore-cache
-      - run: |
-          cd website
-          yarn --no-progress
-      - save-cache: *save-cache
-      - deploy: *deploy-website
+      - deploy_website
 
 # Workflows enables us to run multiple jobs in parallel
 workflows:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lint": "eslint . --cache",
     "lint-fix": "eslint . --fix --cache",
     "postinstall": "node ./scripts/build.js",
+    "preinstall": "node ./scripts/preinstall.js",
     "publish": "yarn run build-clean && yarn run build && lerna run prepare-release && lerna exec -- npm publish",
     "postpublish": "lerna run cleanup-release",
     "test-ci": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest-coverage -i && node scripts/mapCoverage.js && codecov",

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * Note: cannot use prettier here because this file is ran as-is
+ */
+
+if (process.env.NPM_TOKEN) {
+  console.error([
+    'yarn has been executed with a NPM_TOKEN environment variable set. ',
+    'This poses a risk since that token can be leaked to external libraries. ',
+    'Please make sure that any token gets deleted before running yarn.',
+  ].join('\n'));
+  process.exit(1);
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR changes the circleCI configuration for Metro to use `commands` and wrap every single call to `yarn` to avoid leaking the `NPM_TOKEN` env variable to external libraries.

Additionally, a `prebuild` script has been added to prevent calling `yarn install` without having deleted the `NPM_TOKEN` env var to avoid leaking it in the future.



**Test plan**

Check circleCI tests.
