### PR TITLE
Pass caller option to babel when transforming. Fixes #190

### DIFF
--- a/flow-typed/babel.js.flow
+++ b/flow-typed/babel.js.flow
@@ -192,6 +192,7 @@ type BabelCoreOptions = {|
   babelrc?: boolean,
   babelrcRoots?: Array<string>,
   envName?: string,
+  caller?: {name: string},
   code?: boolean,
   comments?: boolean,
   compact?: 'auto' | boolean,

--- a/packages/metro/src/defaultTransformer.js
+++ b/packages/metro/src/defaultTransformer.js
@@ -22,6 +22,7 @@ function transform({filename, options, plugins, src}: BabelTransformerArgs) {
 
   try {
     const {ast} = transformSync(src, {
+      caller: {name: 'metro', platform: options.platform},
       ast: true,
       babelrc: options.enableBabelRCLookup,
       code: false,

--- a/packages/metro/src/reactNativeTransformer.js
+++ b/packages/metro/src/reactNativeTransformer.js
@@ -149,6 +149,7 @@ function transform({filename, options, src, plugins}: BabelTransformerArgs) {
       // ES modules require sourceType='module' but OSS may not always want that
       sourceType: 'unambiguous',
       ...babelConfig,
+      caller: {name: 'metro', platform: options.platform},
       ast: true,
     });
 


### PR DESCRIPTION
**Summary**

Passing this option allows us to conditionally return a different babel config according to the platform. For example:

```js
// babel.config.js
module.exports = api => {
  const platform = api.caller(caller => caller.platform);

  if (platform === 'android') {
    // return some config
  }

  // return some config
};
```

This is especially useful when using the new JSC on Android where we don't need to run all of the transforms.

Fixes #190

**Test plan**

Tested in a freshly inited React native app. The `caller` is correctly set to `{ caller: 'metro', platform: 'ios' }`