### PR TITLE
Update siteConfig.js

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -28,7 +28,7 @@ const siteConfig = {
   ],
   headerIcon: 'img/metro.svg',
   footerIcon: 'img/metro.svg',
-  favicon: 'img/favicon/favicon.ico',
+  favicon: 'img/favicon.png',
   ogImage: 'img/opengraph.png',
   recruitingLink: 'https://crowdin.com/project/metro',
   algolia: {


### PR DESCRIPTION
Summary
Favicon Link not working currently because of invalid href link in index.html also the img extension was written as ico instead of png, however its fixed now and is working fine! was updated under siteConfig.js.


Test plan

you can view a preview here hosted on gh-pages "https://developerayo.github.io/metro/"
@mjesun 