### PR TITLE
Added support for named exports using object and array destructuring

### DIFF
--- a/packages/metro/src/JSTransformer/worker/__tests__/import-export-plugin-test.js
+++ b/packages/metro/src/JSTransformer/worker/__tests__/import-export-plugin-test.js
@@ -99,6 +99,50 @@ it('exports members of another module directly from an import (as default)', () 
   compare([importExportPlugin], code, expected, opts);
 });
 
+it('exports named members', () => {
+  const code = `
+    export const foo = 'bar';
+  `;
+
+  const expected = `
+    Object.defineProperty(exports, '__esModule', {value: true});
+    const foo = 'bar';
+    exports.foo = foo;
+  `;
+
+  compare([importExportPlugin], code, expected, opts);
+});
+
+it('exports destructured named object members', () => {
+  const code = `
+    export const {foo,bar} = {foo: 'bar',bar: 'baz'};
+  `;
+
+  const expected = `
+    Object.defineProperty(exports, '__esModule', {value: true});
+    const {foo,bar} = {foo: 'bar',bar: 'baz'};
+    exports.foo = foo;
+    exports.bar = bar;
+  `;
+
+  compare([importExportPlugin], code, expected, opts);
+});
+
+it('exports destructured named array members', () => {
+  const code = `
+    export const [foo,bar] = ['bar','baz'];
+  `;
+
+  const expected = `
+    Object.defineProperty(exports, '__esModule', {value: true});
+    const [foo,bar] = ['bar','baz'];
+    exports.foo = foo;
+    exports.bar = bar;
+  `;
+
+  compare([importExportPlugin], code, expected, opts);
+});
+
 it('exports members of another module directly from an import (as all)', () => {
   const code = `
     export * from 'bar';

--- a/packages/metro/src/JSTransformer/worker/import-export-plugin.js
+++ b/packages/metro/src/JSTransformer/worker/import-export-plugin.js
@@ -135,9 +135,32 @@ function importExportPlugin({types: t}: $FlowFixMe) {
         if (declaration.node) {
           if (t.isVariableDeclaration(declaration)) {
             declaration.get('declarations').forEach(d => {
-              const name = d.get('id').node.name;
-
-              state.exportNamed.push({local: name, remote: name});
+              switch (d.get('id').node.type) {
+                case 'ObjectPattern':
+                  {
+                    const properties = d.get('id').get('properties');
+                    properties.forEach(p => {
+                      const name = p.get('key').node.name;
+                      state.exportNamed.push({local: name, remote: name});
+                    });
+                  }
+                  break;
+                case 'ArrayPattern':
+                  {
+                    const elements = d.get('id').get('elements');
+                    elements.forEach(e => {
+                      const name = e.node.name;
+                      state.exportNamed.push({local: name, remote: name});
+                    });
+                  }
+                  break;
+                default:
+                  {
+                    const name = d.get('id').node.name;
+                    state.exportNamed.push({local: name, remote: name});
+                  }
+                  break;
+              }
             });
           } else {
             const id =


### PR DESCRIPTION
**Summary**

Exports using array/object destructuring currently cause metro to crash due to the import-export-plugin not handling these syntaxes correctly. This PR adds support so that things like

```export const {foo} = {foo:"bar"}```

work as expected

**Test plan**

Run the new unit tests & built the Instagram web codebase without transpiling away destructured exports and seeing that the generated code runs correctly
