### PR TITLE
feat: Move dependencies command from react-native-cli to metro

### DIFF
--- a/packages/metro/src/commands/dependencies.js
+++ b/packages/metro/src/commands/dependencies.js
@@ -55,7 +55,8 @@ async function dependencies(args: any, config: any) {
     // (a) JS code to not depend on anything outside this directory, or
     // (b) Come up with a way to declare this dependency in Buck.
     const isInsideProjectRoots =
-      config.watchFolders.filter(root => modulePath.startsWith(root)).length > 0;
+      config.watchFolders.filter(root => modulePath.startsWith(root)).length >
+      0;
     if (isInsideProjectRoots) {
       outStream.write(modulePath + '\n');
     }
@@ -69,11 +70,11 @@ module.exports = {
   command: 'dependencies',
   description: 'List dependencies',
   builder: (yargs: Yargs) => {
-    yargs.option('entry-file', { type: 'string', demandOption: true });
-    yargs.option('output', { type: 'string' });
-    yargs.option('platform', { type: 'string' });
-    yargs.option('transformer', { type: 'string' });
-    yargs.option('max-workers', { type: 'number' });
+    yargs.option('entry-file', {type: 'string', demandOption: true});
+    yargs.option('output', {type: 'string'});
+    yargs.option('platform', {type: 'string'});
+    yargs.option('transformer', {type: 'string'});
+    yargs.option('max-workers', {type: 'number'});
   },
   handler: makeAsyncCommand(async (argv: any) => {
     const config = await loadConfig(argv);

--- a/packages/metro/src/commands/dependencies.js
+++ b/packages/metro/src/commands/dependencies.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const denodeify = require('denodeify');
+const fs = require('fs');
+const path = require('path');
+const {loadConfig} = require('metro-config');
+
+const {getOrderedDependencyPaths} = require('../legacy');
+const {makeAsyncCommand} = require('../cli-utils');
+
+import typeof Yargs from 'yargs';
+
+async function dependencies(args: any, config: any) {
+  const rootModuleAbsolutePath = args.entryFile;
+  if (!fs.existsSync(rootModuleAbsolutePath)) {
+    return Promise.reject(
+      new Error(`File ${rootModuleAbsolutePath} does not exist`),
+    );
+  }
+
+  config.cacheStores = [];
+
+  const relativePath = path.relative(
+    config.projectRoot,
+    rootModuleAbsolutePath,
+  );
+
+  const options = {
+    platform: args.platform,
+    entryFile: relativePath,
+    dev: args.dev,
+    minify: false,
+    generateSourceMaps: !args.dev,
+  };
+
+  const writeToFile = args.output;
+  const outStream = writeToFile
+    ? fs.createWriteStream(args.output)
+    : process.stdout;
+
+  const deps = await getOrderedDependencyPaths(config, options);
+
+  deps.forEach(modulePath => {
+    // Temporary hack to disable listing dependencies not under this directory.
+    // Long term, we need either
+    // (a) JS code to not depend on anything outside this directory, or
+    // (b) Come up with a way to declare this dependency in Buck.
+    const isInsideProjectRoots =
+      config.watchFolders.filter(root => modulePath.startsWith(root)).length > 0;
+    if (isInsideProjectRoots) {
+      outStream.write(modulePath + '\n');
+    }
+  });
+  return writeToFile
+    ? denodeify(outStream.end).bind(outStream)()
+    : Promise.resolve();
+}
+
+module.exports = {
+  command: 'dependencies',
+  description: 'List dependencies',
+  builder: (yargs: Yargs) => {
+    yargs.option('entry-file', { type: 'string', demandOption: true });
+    yargs.option('output', { type: 'string' });
+    yargs.option('platform', { type: 'string' });
+    yargs.option('transformer', { type: 'string' });
+    yargs.option('max-workers', { type: 'number' });
+  },
+  handler: makeAsyncCommand(async (argv: any) => {
+    const config = await loadConfig(argv);
+    await dependencies(argv, config);
+  }),
+};

--- a/packages/metro/src/commands/dependencies.js
+++ b/packages/metro/src/commands/dependencies.js
@@ -66,7 +66,7 @@ async function dependencies(args: any, config: any) {
     : Promise.resolve();
 }
 
-module.exports = {
+module.exports = () => ({
   command: 'dependencies',
   description: 'List dependencies',
   builder: (yargs: Yargs) => {
@@ -80,4 +80,4 @@ module.exports = {
     const config = await loadConfig(argv);
     await dependencies(argv, config);
   }),
-};
+});

--- a/packages/metro/src/commands/dependencies.js
+++ b/packages/metro/src/commands/dependencies.js
@@ -75,6 +75,8 @@ module.exports = () => ({
     yargs.option('platform', {type: 'string'});
     yargs.option('transformer', {type: 'string'});
     yargs.option('max-workers', {type: 'number'});
+    yargs.option('dev', {type: 'boolean'});
+    yargs.option('verbose', {type: 'boolean'});
   },
   handler: makeAsyncCommand(async (argv: any) => {
     const config = await loadConfig(argv);

--- a/packages/metro/src/commands/dependencies.js
+++ b/packages/metro/src/commands/dependencies.js
@@ -70,13 +70,40 @@ module.exports = () => ({
   command: 'dependencies',
   description: 'List dependencies',
   builder: (yargs: Yargs) => {
-    yargs.option('entry-file', {type: 'string', demandOption: true});
-    yargs.option('output', {type: 'string'});
-    yargs.option('platform', {type: 'string'});
-    yargs.option('transformer', {type: 'string'});
-    yargs.option('max-workers', {type: 'number'});
-    yargs.option('dev', {type: 'boolean'});
-    yargs.option('verbose', {type: 'boolean'});
+    yargs.option('entry-file', {
+      type: 'string',
+      demandOption: true,
+      describe: 'Absolute path to the root JS file',
+    });
+    yargs.option('output', {
+      type: 'string',
+      describe:
+        'File name where to store the output, ex. /tmp/dependencies.txt',
+    });
+    yargs.option('platform', {
+      type: 'string',
+      describe: 'The platform extension used for selecting modules',
+    });
+    yargs.option('transformer', {
+      type: 'string',
+      describe: 'The platform extension used for selecting modules',
+    });
+    yargs.option('max-workers', {
+      type: 'number',
+      describe:
+        'Specifies the maximum number of workers the worker-pool ' +
+        'will spawn for transforming files. This defaults to the number of the ' +
+        'cores available on your machine.',
+    });
+    yargs.option('dev', {
+      type: 'boolean',
+      default: true,
+      describe: 'If false, skip all dev-only code path',
+    });
+    yargs.option('verbose', {
+      type: 'boolean',
+      default: false,
+    });
   },
   handler: makeAsyncCommand(async (argv: any) => {
     const config = await loadConfig(argv);

--- a/packages/metro/src/index.js
+++ b/packages/metro/src/index.js
@@ -19,6 +19,7 @@ const http = require('http');
 const https = require('https');
 const makeBuildCommand = require('./commands/build');
 const makeServeCommand = require('./commands/serve');
+const makeDependenciesCommand = require('./commands/dependencies');
 const outputBundle = require('./shared/output/bundle');
 
 const {readFile} = require('fs-extra');
@@ -319,9 +320,11 @@ exports.attachMetroCli = function(
     build = {},
     // $FlowFixMe TODO T26072405
     serve = {},
+    dependencies = {},
   }: {
     build: BuildCommandOptions,
     serve: ServeCommandOptions,
+    dependencies: any,
   } = {},
 ) {
   if (build) {
@@ -330,6 +333,10 @@ exports.attachMetroCli = function(
   }
   if (serve) {
     const {command, description, builder, handler} = makeServeCommand();
+    yargs.command(command, description, builder, handler);
+  }
+  if (dependencies) {
+    const {command, description, builder, handler} = makeDependenciesCommand();
     yargs.command(command, description, builder, handler);
   }
   return yargs;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This command exists as a part of [react-native-cli](https://github.com/react-native-community/react-native-cli/blob/master/packages/local-cli/dependencies/dependencies.js). We agreed with @cpojer and @grabbou, that this command is out of the scope of `cli` and should be moved to `metro` repository.
Also not sure if I should `legacy API` - it was used in `react-native-cli`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
This is moved from `react-native-cli` so I tested it by running commands in terminal.
<img width="612" alt="screenshot 2018-12-18 at 18 36 37" src="https://user-images.githubusercontent.com/9092510/50171924-1a6ae680-02f4-11e9-9444-23e183069aa7.png">

