### PR TITLE
imp: Rename dependencies command and add docs

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,3 +20,19 @@ Generates a JavaScript bundle containing the specified entrypoint and its descen
 ## `serve`
 
 Starts a Metro server on the given port, building bundles on the fly.
+
+## `get-dependencies`
+
+Lists dependencies.
+
+### Options
+
+| Option | Description |
+|---|---|
+| `entry-file` | Absolute path to the root JS file |
+| `output` | File name where to store the output, ex. /tmp/dependencies.txt |
+| `platform` | The platform extension used for selecting modules |
+| `transformer` | Specify a custom transformer to be used |
+| `max-workers` | Specifies the maximum number of workers the worker-pool will spawn for transforming files. This defaults to the number of the cores available on your machine. |
+| `dev` | If false, skip all dev-only code path |
+| `verbose` | Enables logging |

--- a/packages/metro/src/commands/dependencies.js
+++ b/packages/metro/src/commands/dependencies.js
@@ -67,7 +67,7 @@ async function dependencies(args: any, config: any) {
 }
 
 module.exports = () => ({
-  command: 'dependencies',
+  command: 'get-dependencies',
   description: 'List dependencies',
   builder: (yargs: Yargs) => {
     yargs.option('entry-file', {
@@ -86,7 +86,7 @@ module.exports = () => ({
     });
     yargs.option('transformer', {
       type: 'string',
-      describe: 'The platform extension used for selecting modules',
+      describe: 'Specify a custom transformer to be used',
     });
     yargs.option('max-workers', {
       type: 'number',
@@ -103,6 +103,7 @@ module.exports = () => ({
     yargs.option('verbose', {
       type: 'boolean',
       default: false,
+      description: 'Enables logging',
     });
   },
   handler: makeAsyncCommand(async (argv: any) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Renamed the `dependencies` command to `get-dependencies` and added documentation. cc @cpojer 

**Test plan**

Running metro in command line and compiled documentation markdown.
