### PR TITLE
Catch exceptions in Transformer construction

### DIFF
--- a/packages/metro/src/Bundler.js
+++ b/packages/metro/src/Bundler.js
@@ -24,15 +24,16 @@ class Bundler {
   constructor(config: ConfigT) {
     this._depGraphPromise = DependencyGraph.load(config);
 
-    this._depGraphPromise.then(dependencyGraph => {
-      this._transformer = new Transformer(
-        config,
-        dependencyGraph.getSha1.bind(dependencyGraph),
-      );
-    }).catch(e => {
-      console.error("Failed to construct transformer");
-      console.error(e);
-    });
+    this._depGraphPromise
+      .then(dependencyGraph => {
+        this._transformer = new Transformer(
+          config,
+          dependencyGraph.getSha1.bind(dependencyGraph),
+        );
+      })
+      .catch(error => {
+        console.error('Failed to construct transformer: ', error);
+      });
   }
 
   async end() {

--- a/packages/metro/src/Bundler.js
+++ b/packages/metro/src/Bundler.js
@@ -29,6 +29,9 @@ class Bundler {
         config,
         dependencyGraph.getSha1.bind(dependencyGraph),
       );
+    }).catch(e => {
+      console.error("Failed to construct transformer");
+      console.error(e);
     });
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When transformerPath is set in metro.config.js, if there is a failure in loading the custom transformer, the exception is silently swallowed and all the user sees is this misleading error message (see below). In this patch, we add a catch to the promise to report the original exception to the user.

**Test plan**

Set an invalid transformerPath in metro.config.js to reproduce:
```
module.exports = {
  transformerPath: require.resolve('./fail.js'),
}
```

```text
Cannot read property 'transformFile' of undefined

TypeError: Cannot read property 'transformFile' of undefined
    at /Users/go/Library/Application Support/Go Agent/pipelines/ngf-app-ios/node_modules/react-native/node_modules/metro/src/Bundler.js:83:34
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/Users/go/Library/Application Support/Go Agent/pipelines/ngf-app-ios/node_modules/react-native/node_modules/metro/src/Bundler.js:14:24)
    at _next (/Users/go/Library/Application Support/Go Agent/pipelines/ngf-app-ios/node_modules/react-native/node_modules/metro/src/Bundler.js:34:9)
```
