### PR TITLE
Allow custom BABEL_ENV

### DIFF
--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -44,7 +44,9 @@ export type BabelTransformer = {|
 
 function transform({filename, options, plugins, src}: BabelTransformerArgs) {
   const OLD_BABEL_ENV = process.env.BABEL_ENV;
-  process.env.BABEL_ENV = options.dev ? 'development' : 'production';
+  process.env.BABEL_ENV = options.dev
+    ? 'development'
+    : process.env.BABEL_ENV || 'production';
 
   try {
     const {ast} = transformSync(src, {

--- a/packages/metro-react-native-babel-transformer/src/index.js
+++ b/packages/metro-react-native-babel-transformer/src/index.js
@@ -141,7 +141,9 @@ function buildBabelConfig(filename, options, plugins?: BabelPlugins = []) {
 
 function transform({filename, options, src, plugins}: BabelTransformerArgs) {
   const OLD_BABEL_ENV = process.env.BABEL_ENV;
-  process.env.BABEL_ENV = options.dev ? 'development' : 'production';
+  process.env.BABEL_ENV = options.dev
+    ? 'development'
+    : process.env.BABEL_ENV || 'production';
 
   try {
     const babelConfig = buildBabelConfig(filename, options, plugins);


### PR DESCRIPTION
**Summary**

Allows custom non-dev `BABEL_ENV`s besides `'production'`. With respect to https://github.com/facebook/react-native/pull/6351#issuecomment-308820107.

**Test plan**

This change will break non-dev builds for people who for any reason has custom `BABEL_ENV` set but expects it to behave like `'production`' (current behavior). Though it can be easily fixed either by renaming their `env` from `production` to the value of custom `BABEL_ENV`, or by changing `BABEL_ENV` from custom to `'production'`.

Other than this unusual case, nothing should change.