### PR TITLE
Removed unused code to compute worker execArgv in WorkerFarm

### DIFF
--- a/packages/metro/src/DeltaBundler/WorkerFarm.js
+++ b/packages/metro/src/DeltaBundler/WorkerFarm.js
@@ -108,14 +108,6 @@ class WorkerFarm {
     exposedMethods: $ReadOnlyArray<string>,
     numWorkers: number,
   ) {
-    const execArgv = process.execArgv.slice();
-
-    // We swallow the first parameter if it's not an option (some things such as
-    // flow-node like to add themselves into the execArgv array)
-    if (execArgv.length > 0 && execArgv[0].charAt(0) !== '-') {
-      execArgv.shift();
-    }
-
     const env = {
       ...process.env,
       // Force color to print syntax highlighted code frames.


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The execArgv is not passed in to JestWorker anymore but was not removed
(and I assume linting doesn't catch it because we call `.shift()` on it
which could have a side effect)

I discovered this as I was trying to fix a bug with `--inspect` being passed in to child workers because the code used to overwrite the JestWorker behavior when computing child `execArgv`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Tests still pass!
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
