### PR TITLE
Fix HMR crash when using namespace re-export

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -93,6 +93,9 @@ const getPreset = (src, options) => {
       [
         require('@babel/plugin-transform-modules-commonjs'),
         {
+          // Use `module.foo = bar` instead of `Object.defineProperty(module, 'foo', ...)`.
+          // This prevents an issue with HMR and namespace re-export (`export * from 'foo'`).
+          loose: true,
           strict: false,
           strictMode: false, // prevent "use strict" injections
           lazy:


### PR DESCRIPTION
**Summary**

When hot reloading a module that uses namespace re-export it crashes with:

```
Requiring module "foo", which threw an exception: Error: Requiring module "foo.js", which threw an exception: TypeError: Attempting to change the getter of an unconfigurable property.
```

See https://github.com/facebook/react-native/issues/22592 for a bunch or repros.

Seems like the technique we use for hot reloading is not compatible with the way babel transforms namespace re-exports (https://github.com/babel/babel/blob/master/packages/babel-helper-module-transforms/src/index.js#L181). By using loose mode we can make the transform output a simple assignment instead which fixes the error.

Theoretically this could break some code since the `__esModule` is now enumerable but it practice it shouldn't unless you are doing really weird stuff with es modules.

Fixes https://github.com/facebook/react-native/issues/22592

**Test plan**

Tested in an app that it fixes the HMR crash and that the new loose mode doesn't introduce other issues.