### PR TITLE
Add forceIsTSX option to support JSX in .ts files

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -172,7 +172,10 @@ const getPreset = (src, options) => {
       {
         test: isTypeScriptSource,
         plugins: [
-          [require('@babel/plugin-transform-typescript'), {isTSX: false}],
+          [
+            require('@babel/plugin-transform-typescript'),
+            {isTSX: options && options.forceIsTSX === true},
+          ],
         ],
       },
       {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Add forceIsTSX option to support JSX in .ts files

Addresses #395
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Test that JSX code in `.ts` files no longer throws errors and the `isTSX` config option is enabled for `@babel/plugin-transform-typescript` when babel is configured like:
```js
module.exports = {
  presets: [['module:metro-react-native-babel-preset', { forceIsTSX: true }]],
};
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
