### PR TITLE
[breaking] Turn off providesModuleNodeModules by default

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -49,10 +49,7 @@ Object {
       "windows",
       "web",
     ],
-    "providesModuleNodeModules": Array [
-      "react-native",
-      "react-native-windows",
-    ],
+    "providesModuleNodeModules": Array [],
     "resolveRequest": null,
     "resolverMainFields": Array [
       "browser",
@@ -181,10 +178,7 @@ Object {
       "windows",
       "web",
     ],
-    "providesModuleNodeModules": Array [
-      "react-native",
-      "react-native-windows",
-    ],
+    "providesModuleNodeModules": Array [],
     "resolveRequest": null,
     "resolverMainFields": Array [
       "browser",

--- a/packages/metro-config/src/defaults/defaults.js
+++ b/packages/metro-config/src/defaults/defaults.js
@@ -54,7 +54,7 @@ exports.moduleSystem = require.resolve('metro/src/lib/polyfills/require.js');
 
 exports.platforms = ['ios', 'android', 'windows', 'web'];
 
-exports.providesModuleNodeModules = ['react-native', 'react-native-windows'];
+exports.providesModuleNodeModules = [];
 
 exports.DEFAULT_METRO_MINIFIER_PATH = 'metro-minify-uglify';
 


### PR DESCRIPTION
(This is a draft PR until we completely replace Haste in RN.)

**Summary**

Sets the default value of `providesModuleNodeModules` to an empty array, since Haste is going away from RN. **This is a breaking change and metro and metro-config's major semver needs to be bumped.**

**Test plan**

Modify my copy of metro-config under RN so that `providesModuleNodeModules` defaults to an empty array, start the packager with `--reset-cache`, and load the RNTester bundle successfully.