### PR TITLE
Exclude `$projectRoot/package.json` from assets

### DIFF
--- a/packages/metro/src/DeltaBundler/Serializers/getAssets.js
+++ b/packages/metro/src/DeltaBundler/Serializers/getAssets.js
@@ -38,7 +38,7 @@ async function getAssets(
       isJsModule(module) &&
       processModuleFilter(module) &&
       getJsOutput(module).type === 'js/module/asset' &&
-      path.relative(options.projectRoot, module.path) !== "package.json"
+      path.relative(options.projectRoot, module.path) !== 'package.json'
     ) {
       promises.push(
         getAssetData(

--- a/packages/metro/src/DeltaBundler/Serializers/getAssets.js
+++ b/packages/metro/src/DeltaBundler/Serializers/getAssets.js
@@ -37,7 +37,8 @@ async function getAssets(
     if (
       isJsModule(module) &&
       processModuleFilter(module) &&
-      getJsOutput(module).type === 'js/module/asset'
+      getJsOutput(module).type === 'js/module/asset' &&
+      path.relative(options.projectRoot, module.path) !== "package.json"
     ) {
       promises.push(
         getAssetData(


### PR DESCRIPTION
**Summary**

From https://github.com/facebook/metro/commit/dcb41e39f0df6ae1e0b3dfeff9ef5a69128830d5#diff-235a3e5d21175615e1cc254dd8b17eb2, files with `json` extension will be considered as assets and returned as `outputAssets` for `@react-native-community/cli`.

This means `cli` will copy files with `json` extension to resource dir, in Android's case, `android/app/build/res`.

Here comes a problem. If `package.json` at the project root gets copied, it won't be renamed as other `package.json` in `node_modules` (e.g. `raw/node_modules_reactnativecodepush_package.json`). Instead, it will reside in `res` as `package.json`, which causes the error:

https://github.com/facebook/react-native/issues/25325

```
android/app/src/main/res/raw/package.json: Error: package is not a valid resource name (reserved Java keyword)
```

This regression (I believe ;)) was introduced to React Native 0.60.0-rc with metro bumping from 0.51 to 0.54.

**Possible impact**

1. Typical usage concerning `package.json` at the root will be something like `import packageJson from "./package.json"` in JS files to get some project configurations and those content will be bundled into `index.android.bundle` no matter what. So removing `$projectRoot/package.json` won't have too much impact.

2. This new (or bad?) behavior has only been in React Native 0.60-rc so it won't affect current projects running 0.59. It should be fixed before the final release of 0.60, I assume.

**Test plan**

1. `react-native init resoucesRepro --version react-native@next` (so it uses 0.60.0-rc)
1. Add `import packageJson from './package.json'` to `App.js`.
1. `cd android && ./gradlew assembleRelease`
1. Get the error.
1. Modify `node_modules/metro/src/DeltaBundler/Serializers/getAssets.js` to match this commit.
1. `cd android && ./gradlew assembleRelease`
1. It now works!