### PR TITLE
Fix JSON.parse error when read cache files which havn't been closed

### DIFF
--- a/packages/metro-cache/src/stores/FileStore.js
+++ b/packages/metro-cache/src/stores/FileStore.js
@@ -40,7 +40,7 @@ class FileStore<T> {
         return JSON.parse(data.toString('utf8'));
       }
     } catch (err) {
-      if (err.code === 'ENOENT') {
+      if (err.code === 'ENOENT' || err instanceof SyntaxError) {
         return null;
       }
 

--- a/packages/metro-cache/src/stores/__tests__/FileStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/FileStore-test.js
@@ -41,6 +41,15 @@ describe('FileStore', () => {
     expect(fileStore.get(cache)).toEqual(null);
   });
 
+  it('returns null when reading a empty file', () => {
+    const fileStore = new FileStore({root: '/root'});
+    const cache = Buffer.from([0xfa, 0xce, 0xb0, 0x0c]);
+    const filePath = fileStore._getFilePath(cache);
+
+    fs.writeFileSync(filePath, '');
+    expect(fileStore.get(cache)).toEqual(null);
+  });
+
   it('writes into cache if folder is missing', () => {
     const fileStore = new FileStore({root: '/root'});
     const cache = Buffer.from([0xfa, 0xce, 0xb0, 0x0c]);


### PR DESCRIPTION
**Summary**

Since we build a batch of  `jsbundle` concurrently, occasionally when one process is writing a new file on the file system, at this moment another process try to read the file, it will got an empty file and cause the `JSON.parse` throw `SyntaxError`.

**Test plan**

Added a test.
