### PR TITLE
Allow to configure Haste Map cache directory

### DIFF
--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -154,7 +154,7 @@ export type VisualizerConfigT = {|
 type MetalConfigT = {|
   cacheStores: $ReadOnlyArray<CacheStore<TransformResult<>>>,
   cacheVersion: string,
-  hasteMapCacheDirectory: string,
+  hasteMapCacheDirectory?: string,
   maxWorkers: number,
   projectRoot: string,
   stickyWorkers: boolean,

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -154,6 +154,7 @@ export type VisualizerConfigT = {|
 type MetalConfigT = {|
   cacheStores: $ReadOnlyArray<CacheStore<TransformResult<>>>,
   cacheVersion: string,
+  hasteMapCacheDirectory: string,
   maxWorkers: number,
   projectRoot: string,
   stickyWorkers: boolean,

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -74,6 +74,7 @@ class DependencyGraph extends EventEmitter {
 
   static _createHaste(config: ConfigT): JestHasteMap {
     return new JestHasteMap({
+      cacheDirectory: config.hasteMapCacheDirectory,
       computeDependencies: false,
       computeSha1: true,
       extensions: config.resolver.sourceExts.concat(config.resolver.assetExts),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
We perform integrations tests for [Microsoft/vscode-react-native](https://github.com/Microsoft/vscode-react-native) which includes debugging scenarios for React Native apps in VS Code. Since we started to perform testing we've faced a lot of problems due to Haste map cache inconsistency, i.e. we had to manually clean it on our test machines. The problem is that by default Metro stores Haste Map cache inside `os.tmpdir()` which is shared between test runs. That's why, also, using of `resetCache` parameter is not acceptable. This PR passes `cacheDirectory` parameter directly to `HasteMap` constructor allowing us to reconfigure it to another place.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

After applying the fix, you can easily configure where to store haste map cache as shown below:
![Peek 2019-06-25 15-37](https://user-images.githubusercontent.com/30265843/60098904-3944ac80-975f-11e9-912d-5c8d8c503c8a.gif)

