### PR TITLE
Add customizeFrame symbolicator config option

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -83,6 +83,7 @@ Object {
   },
   "stickyWorkers": true,
   "symbolicator": Object {
+    "customizeFrame": [Function],
     "workerPath": "metro/src/Server/symbolicate/worker",
   },
   "transformer": Object {
@@ -214,6 +215,7 @@ Object {
   },
   "stickyWorkers": true,
   "symbolicator": Object {
+    "customizeFrame": [Function],
     "workerPath": "metro/src/Server/symbolicate/worker",
   },
   "transformer": Object {

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -173,6 +173,12 @@ type ServerConfigT = {|
 |};
 
 type SymbolicatorConfigT = {|
+  customizeFrame: ({
+    +file: string,
+    +lineNumber: number,
+    +column: number,
+    +methodName: ?string,
+  }) => ?{|+collapse?: boolean|} | Promise<?{|+collapse?: boolean|}>,
   workerPath: string,
 |};
 

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -66,6 +66,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
   },
 
   symbolicator: {
+    customizeFrame: () => {},
     workerPath: 'metro/src/Server/symbolicate/worker',
   },
 

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -57,7 +57,7 @@ import type {CacheStore} from 'metro-cache';
 import type {BundleVariant} from './lib/bundle-modules/types.flow';
 import type DependencyGraph from './node-haste/DependencyGraph';
 import type {MixedOutput, TransformResult} from './DeltaBundler/types.flow';
-import type {Stack} from './Server/symbolicate/symbolicate';
+import type {StackFrameOutput} from './Server/symbolicate/symbolicate';
 
 const {
   Logger,
@@ -989,7 +989,7 @@ class Server {
         });
       })
       .then(
-        (stack: Stack) => {
+        (stack: $ReadOnlyArray<StackFrameOutput>) => {
           debug('Symbolication done');
           res.end(JSON.stringify({stack}));
           process.nextTick(() => {

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -762,6 +762,7 @@ describe('processRequest', () => {
           source: 'foo.js',
           line: 21,
           column: 4,
+          collapse: false,
         },
       ];
       const sourceMaps = [
@@ -806,6 +807,7 @@ describe('processRequest', () => {
           source: 'foo.js',
           line: 21,
           column: 4,
+          collapse: false,
         },
       ];
       const sourceMaps = [


### PR DESCRIPTION
Adds the `symbolicator.customizeFrame` config option to Metro. This is a function that receives a symbolicated stack frame and can modify the response before it's sent back to the client. The `collapse` field is the first supported customization, intended for auto-collapsing "internal" or infra-related stack frames.

This is a redesign of work done originally in https://github.com/facebook/react-native/pull/24662; I intend to eventually remove the client-side regex from RN.

Reviewed By: cpojer

Differential Revision: D16499755

