### PR TITLE
fix browser warning while opening bundle visualizer

### DIFF
--- a/packages/metro-visualizer/src/app/index.html
+++ b/packages/metro-visualizer/src/app/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8"/>
 	<title>Metro Bundle Visualizer</title>
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/antd/3.7.1/antd.css" />
-	<link rel="stylesheet" href="https://unpkg.com/react-vis@1.10.4/dist/style.css">
+	<link rel="stylesheet" href="https://unpkg.com/react-vis@1.10.4/dist/style.css" />
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
**Summary**

Fix browser warning while opening Metro Bundle Visualizer:
`Refused to apply style from 'https://unpkg.com/react-vis@1.10.4/dist/style.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.`