### PR TITLE
Fix BABEL_ENV resolution in babel transformer

### DIFF
--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -71,7 +71,9 @@ function transform({filename, options, plugins, src}: BabelTransformerArgs) {
 
     return {ast, functionMap};
   } finally {
-    process.env.BABEL_ENV = OLD_BABEL_ENV;
+    if (OLD_BABEL_ENV) {
+      process.env.BABEL_ENV = OLD_BABEL_ENV;
+    }
   }
 }
 

--- a/packages/metro-react-native-babel-transformer/src/index.js
+++ b/packages/metro-react-native-babel-transformer/src/index.js
@@ -172,7 +172,9 @@ function transform({filename, options, src, plugins}: BabelTransformerArgs) {
 
     return {ast: result.ast, functionMap};
   } finally {
-    process.env.BABEL_ENV = OLD_BABEL_ENV;
+    if (OLD_BABEL_ENV) {
+      process.env.BABEL_ENV = OLD_BABEL_ENV;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix a regression introduced in `v0.53.0` via https://github.com/facebook/metro/commit/c0f6693f4f34a29af4a81a90080d92b45c36ae6c

We're using some babel plugins in our React Native applications and noticed some weird issues after upgrading to RN 0.60. Upon further investigation, it appeared the issue is coming from metro babel transformer setting `BABEL_ENV` to an incorrect value.

The problem is due to the very unintuitive behavior of assigning values on `process.env` as described in [nodejs doc](https://nodejs.org/dist/latest-v10.x/docs/api/process.html) :
> Assigning a property on process.env will implicitly convert the value to a string. This behavior is deprecated. Future versions of Node.js may throw an error when the value is not a string, number, or boolean. 

For example, from a node REPL :
```
> process.env.BABEL_ENV = undefined
undefined
> process.env.BABEL_ENV === undefined
false
> process.env.BABEL_ENV === 'undefined'
true
```

With `BABEL_ENV` not set (undefined), and `options.dev=false` the first run of the `transform` function is properly setting `BABEL_ENV` to `production`. Then, prior to exiting the function, it is [restoring `BABEL_ENV` to its initial value](https://github.com/facebook/metro/blob/v0.56.0/packages/metro-babel-transformer/src/index.js#L74) that was captured upon entering the function. In this case `undefined`, so `BABEL_ENV` is now set to `'undefined'` (string). On subsequent runs of the function it will therefore set `BABEL_ENV` to `'undefined'`.

Given this, the fix is actually straightforward. Only assign `OLD_BABEL_ENV` to `BABEL_ENV` if `OLD_BABEL_ENV` is defined, to avoid running into the problem of having `BABEL_ENV` set to `'undefined'`.