### PR TITLE
Fix regex scape #453

### DIFF
--- a/packages/metro-config/src/defaults/blacklist.js
+++ b/packages/metro-config/src/defaults/blacklist.js
@@ -13,7 +13,7 @@ var path = require('path');
 // Don't forget to everything listed here to `package.json`
 // modulePathIgnorePatterns.
 var sharedBlacklist = [
-  /node_modules[/\\]react[/\\]dist[/\\].*/,
+  /node_modules[\/\\]react[\/\\]dist[\/\\].*/,
 
   /website\/node_modules\/.*/,
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
In the first index of sharedBlacklist variable the regex writed was without scape, it is a path with purpose to exclude react/dist of metro process.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Adding the slash scape "\\" before slash used in the path
executing ```react-native start``` i got it normally

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
