### PR TITLE
fs.mkdir definition missing

### DIFF
--- a/packages/metro-memory-fs/src/index.js
+++ b/packages/metro-memory-fs/src/index.js
@@ -107,6 +107,7 @@ const ASYNC_FUNC_NAMES = [
   'fsync',
   'fdatasync',
   'lstat',
+  'mkdir',
   'open',
   'read',
   'readdir',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
When using `fs.mkdir` with memory-fs it doesn't work because its not mapped.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Can test by attempting a call to `fs.mkdir(file_path)`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
