### PR TITLE
Fatal Error in REGEX Scape fixed in blacklist.js

### DIFF
--- a/packages/metro-config/src/defaults/blacklist.js
+++ b/packages/metro-config/src/defaults/blacklist.js
@@ -13,7 +13,7 @@ var path = require('path');
 // Don't forget to everything listed here to `package.json`
 // modulePathIgnorePatterns.
 var sharedBlacklist = [
-  /node_modules[/\\]react[/\\]dist[/\\].*/,
+  /node_modules[\/\\]react[\/\\]dist[\/\\].*/,
 
   /website\/node_modules\/.*/,
 


### PR DESCRIPTION
**Summary**
*Error:* In Windows 10
`Invalid regular expression: /(node_modules[\\\]react[\\\]dist[\\\].*|website\\node_modules\\.*|heapCapture\\bundle\.js)$/: Unterminated character class`

*Modification:*
In the first index of `sharedBlacklist` variable, the regex write was without scape, it is a path with a purpose to exclude react/dist of metro process.
The problem is resolved by escaping.
*Reference Issue*: facebook#453

**Test plan**
The fix resolved this issue and Metro started working after the modifications.
Tested using command `react-native start`

Thanks :)