### PR TITLE
Prevent custom plugins being replaced by HMR preset

### DIFF
--- a/packages/metro-react-native-babel-transformer/src/index.js
+++ b/packages/metro-react-native-babel-transformer/src/index.js
@@ -141,6 +141,7 @@ function buildBabelConfig(filename, options, plugins?: BabelPlugins = []) {
 
     if (mayContainEditableReactComponents) {
       const hmrConfig = makeHMRConfig();
+      hmrConfig.plugins = config.plugins.concat(hmrConfig.plugins);
       config = Object.assign({}, config, hmrConfig);
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This change will allow devs to pass new plugins to `metro-react-native-babel-transformer` in a custom transformer.

**Test plan**

`metro.config.js`
```js
module.exports = {
  transformer: {
     babelTransformerPath: require.resolve('./transformer.js'),
  },
}
```

`transformer.js`
```js
const transformer = require('metro-react-native-babel-transformer');

module.exports.getCacheKey = transformer.getCacheKey;

module.exports.transform = function(props) {
  return transformer.transform(Object.assign(props, {
    plugins: [ /* Custom plugins that won't be replaced after this PR... */],
  }));
};
```


