### PR TITLE
Added `extendsBabelConfigPath` option for using a non-standard babel config location

### DIFF
--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -23,6 +23,7 @@ type BabelTransformerOptions = $ReadOnly<{
   disableFlowStripTypesTransform?: boolean,
   enableBabelRCLookup?: boolean,
   enableBabelRuntime: boolean,
+  extendsBabelConfigPath?: string,
   experimentalImportSupport?: boolean,
   hot: boolean,
   inlineRequires: boolean,

--- a/packages/metro-react-native-babel-transformer/src/index.js
+++ b/packages/metro-react-native-babel-transformer/src/index.js
@@ -47,15 +47,22 @@ const getBabelRC = (function() {
     plugins: BabelPlugins,
   } = null;
 
-  return function _getBabelRC(projectRoot, options) {
+  return function _getBabelRC({
+    projectRoot,
+    extendsBabelConfigPath,
+    ...options
+  }) {
     if (babelRC != null) {
       return babelRC;
     }
 
-    babelRC = {plugins: []};
+    babelRC = {plugins: [], extends: extendsBabelConfigPath};
+
+    if (extendsBabelConfigPath) {
+      return babelRC;
+    }
 
     // Let's look for a babel config file in the project root.
-    // TODO look into adding a command line option to specify this location
     let projectBabelRCPath;
 
     // .babelrc
@@ -90,6 +97,7 @@ const getBabelRC = (function() {
         [
           require('metro-react-native-babel-preset'),
           {
+            projectRoot,
             ...presetOptions,
             disableImportExportTransform: experimentalImportSupport,
             enableBabelRuntime: options.enableBabelRuntime,
@@ -107,7 +115,7 @@ const getBabelRC = (function() {
  * config object with the appropriate plugins.
  */
 function buildBabelConfig(filename, options, plugins?: BabelPlugins = []) {
-  const babelRC = getBabelRC(options.projectRoot, options);
+  const babelRC = getBabelRC(options);
 
   const extraConfig = {
     babelrc:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Added an option `extendsBabelConfigPath` for extending a custom babel preset.

**Test plan**


`metro.config.js`
```js
module.exports = {
  transformer: {
     babelTransformerPath: require.resolve('./transformer.js'),
  },
}
```

`transformer.js`
```js
const transformer = require('metro-react-native-babel-transformer');

module.exports.getCacheKey = transformer.getCacheKey;

module.exports.transform = function({ filename, options, src, plugins }) {
  return transformer.transform({
    filename, 
    options: Object.assign(options, { extendsBabelConfigPath: require.resolve('babel-preset-cool-custom-thing') }), 
    src, 
    plugins
  });
};
```
