### PR TITLE
Changed sharedBlacklist RegExp due to a bug with Node 12.11.0

### DIFF
--- a/packages/metro-config/src/defaults/blacklist.js
+++ b/packages/metro-config/src/defaults/blacklist.js
@@ -14,7 +14,7 @@ var path = require('path');
 // Don't forget to everything listed here to `package.json`
 // modulePathIgnorePatterns.
 var sharedBlacklist = [
-  /node_modules[/\\]react[/\\]dist[/\\].*/,
+  /node_modules[\/\\]react[\/\\]dist[\/\\].*/,
 
   /website\/node_modules\/.*/,
 


### PR DESCRIPTION
NodeJs updated in version 12.11.0 to the V8 engine 7.7.7.299.11 (i think the update to the newer V8 is the reason why this is broken) since then the sharedBlacklist regexp was broken due to the function sharedBlacklist() witch in a earlier version from NodeJs returned for the first element in sharedBlacklist this `/node_modules[\\\\]react[\\\\]dist[\\\\].*/` output. 
In the newer version of NodeJs the output is different `/node_modules[\\\]react[\\\]dist[\\\].*/` witch is not valid anymore and it trows a error.

With my little change `/node_modules[\/\\]react[\/\\]dist[\/\\].*/` it works again on both versions
Output NodeJs version 12.11.0: `/node_modules[\\\\]react[\\\\]dist[\\\\].*/`
Output NodeJs version 10.15.2: `/node_modules[\\\\]react[\\\\]dist[\\\\].*/`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

In the React-Native repo there are many Issues regarding this bug 
a few examples 
https://github.com/facebook/react-native/issues/26829
https://github.com/facebook/react-native/issues/26598
https://github.com/facebook/react-native/issues/26808

With this small change all the Issues should be fixed
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Without my Change:
  Output NodeJs version 12.11.0: `/node_modules[\\\]react[\\\\]dist[\\\].*/`
  Output NodeJs version 10.15.2: `/node_modules[\\\\]react[\\\\]dist[\\\\].*/`
With my Change:
  Output NodeJs version 12.11.0: `/node_modules[\\\\]react[\\\\]dist[\\\\].*/`
  Output NodeJs version 10.15.2: `/node_modules[\\\\]react[\\\\]dist[\\\\].*/`

i did not wrote any tests 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**Other**
this is my first pull request for a Facebook product and I've accepted the Facebook CLA
