### PR TITLE
Pass console logs through the reporter interface

### DIFF
--- a/packages/metro/src/HmrServer.js
+++ b/packages/metro/src/HmrServer.js
@@ -18,7 +18,6 @@ const debounceAsyncQueue = require('./lib/debounceAsyncQueue');
 const formatBundlingError = require('./lib/formatBundlingError');
 const getGraphId = require('./lib/getGraphId');
 const hmrJSBundle = require('./DeltaBundler/Serializers/hmrJSBundle');
-const logToConsole = require('./lib/logToConsole');
 const nullthrows = require('nullthrows');
 const parseOptionsFromUrl = require('./lib/parseOptionsFromUrl');
 const splitBundleOptions = require('./lib/splitBundleOptions');
@@ -204,7 +203,11 @@ class HmrServer<TClient: Client> {
             ),
           );
         case 'log':
-          logToConsole(data.level, data.data);
+          this._config.reporter.update({
+            type: 'client_log',
+            level: data.level,
+            data: data.data,
+          });
           break;
         case 'log-opt-in':
           client.optedIntoHMR = true;

--- a/packages/metro/src/lib/TerminalReporter.js
+++ b/packages/metro/src/lib/TerminalReporter.js
@@ -16,6 +16,7 @@ const reporting = require('./reporting');
 const throttle = require('lodash.throttle');
 
 const {AmbiguousModuleResolutionError} = require('metro-core');
+const logToConsole = require('./logToConsole');
 
 import type {
   BundleDetails,
@@ -265,6 +266,9 @@ class TerminalReporter {
         break;
       case 'hmr_client_error':
         this._logHmrClientError(event.error);
+        break;
+      case 'client_log':
+        logToConsole(event.level, event.data);
         break;
       case 'dep_graph_loading':
         // IMPORTANT: Keep this in sync with `nuclide-metro-rpc/lib/parseMessages.tsx`

--- a/packages/metro/src/lib/reporting.js
+++ b/packages/metro/src/lib/reporting.js
@@ -94,6 +94,19 @@ export type ReportableEvent =
   | {
       type: 'hmr_client_error',
       error: Error,
+    }
+  | {
+      type: 'client_log',
+      level:
+        | 'trace'
+        | 'info'
+        | 'warn'
+        | 'log'
+        | 'group'
+        | 'groupCollapsed'
+        | 'groupEnd'
+        | 'debug',
+      data: Array<mixed>,
     };
 
 /**


### PR DESCRIPTION
**Summary**

Sending `console` logs from the device where the code is running using HMRClient was implemented in https://github.com/facebook/metro/commit/2d590a6157ce2587a8737c59a4b17344385151ba. This is nice, but currently these logs are printed directly to console, without a chance to customize the output format when Metro is running inside another tool, such as [Expo CLI](https://github.com/expo/expo-cli).

There's already a nice custom [reporting interface](https://github.com/facebook/metro/blob/v0.56.1/packages/metro/src/lib/reporting.js) in Metro that allows customizing the output format. For example, in Expo CLI we use a custom reporter similar to [JsonReporter](https://github.com/facebook/metro/blob/v0.56.1/packages/metro/src/lib/JsonReporter.js) to get all the Metro logging as JSON and then implement things like a web UI for viewing logs on top of that. This would be really difficult, if we had to parse everything from the regular text based logs meant to be read by humans, not computers.

This PR changes the `console` logging introduced in Metro v0.56.0 to pass these logs through the reporting interface, so that custom reporters can format them as necessary. The default implementation in `TerminalReporter` remains the same, without changes to the log output.

**Test plan**

Verify that all the tests pass.
