### PR TITLE
Fix blacklist regex syntax errors

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -39,7 +39,7 @@ Object {
       "ttf",
       "zip",
     ],
-    "blacklistRE": /\\(node_modules\\[\\\\/\\\\\\\\\\]react\\[\\\\/\\\\\\\\\\]dist\\[\\\\/\\\\\\\\\\]\\.\\*\\|website\\\\/node_modules\\\\/\\.\\*\\|heapCapture\\\\/bundle\\\\\\.js\\|\\.\\*\\\\/__tests__\\\\/\\.\\*\\)\\$/,
+    "blacklistRE": /\\(node_modules\\\\/react\\\\/dist\\\\/\\.\\*\\|website\\\\/node_modules\\\\/\\.\\*\\|heapCapture\\\\/bundle\\\\\\.js\\|\\.\\*\\\\/__tests__\\\\/\\.\\*\\)\\$/,
     "extraNodeModules": Object {},
     "hasteImplModulePath": undefined,
     "platforms": Array [
@@ -167,7 +167,7 @@ Object {
       "ttf",
       "zip",
     ],
-    "blacklistRE": /\\(node_modules\\[\\\\/\\\\\\\\\\]react\\[\\\\/\\\\\\\\\\]dist\\[\\\\/\\\\\\\\\\]\\.\\*\\|website\\\\/node_modules\\\\/\\.\\*\\|heapCapture\\\\/bundle\\\\\\.js\\|\\.\\*\\\\/__tests__\\\\/\\.\\*\\)\\$/,
+    "blacklistRE": /\\(node_modules\\\\/react\\\\/dist\\\\/\\.\\*\\|website\\\\/node_modules\\\\/\\.\\*\\|heapCapture\\\\/bundle\\\\\\.js\\|\\.\\*\\\\/__tests__\\\\/\\.\\*\\)\\$/,
     "extraNodeModules": Object {},
     "hasteImplModulePath": undefined,
     "platforms": Array [

--- a/packages/metro-config/src/defaults/__tests__/blacklist-test.js
+++ b/packages/metro-config/src/defaults/__tests__/blacklist-test.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+metro_bundler
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+const path = require('path');
+const blacklist = require('../blacklist');
+
+describe('blacklist', () => {
+  let originalSeparator;
+  beforeEach(() => {
+    originalSeparator = path.sep;
+  });
+
+  afterEach(() => {
+    // $FlowFixMe: property sep is not writable.
+    path.sep = originalSeparator;
+  });
+
+  it('converts forward slashes in the RegExp to the OS specific path separator', () => {
+    // $FlowFixMe: property sep is not writable.
+    path.sep = '/';
+    expect('a/b/c').toMatch(blacklist([new RegExp('a/b/c')]));
+
+    // $FlowFixMe: property sep is not writable.
+    path.sep = '\\';
+    expect(require('path').sep).toBe('\\');
+    expect('a\\b\\c').toMatch(blacklist([new RegExp('a/b/c')]));
+  });
+});

--- a/packages/metro-config/src/defaults/blacklist.js
+++ b/packages/metro-config/src/defaults/blacklist.js
@@ -22,7 +22,6 @@ var sharedBlacklist = [
 
 function escapeRegExp(pattern) {
   if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
-    // eslint-disable-next-line no-console
     return pattern.source.replace(/\//g, path.sep);
   } else if (typeof pattern === 'string') {
     var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');

--- a/packages/metro-config/src/defaults/blacklist.js
+++ b/packages/metro-config/src/defaults/blacklist.js
@@ -14,17 +14,15 @@ var path = require('path');
 // Don't forget to everything listed here to `package.json`
 // modulePathIgnorePatterns.
 var sharedBlacklist = [
-  /node_modules[/\\]react[/\\]dist[/\\].*/,
-
+  /node_modules\/react\/dist\/.*/,
   /website\/node_modules\/.*/,
-
   /heapCapture\/bundle\.js/,
-
   /.*\/__tests__\/.*/,
 ];
 
 function escapeRegExp(pattern) {
   if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
+    // eslint-disable-next-line no-console
     return pattern.source.replace(/\//g, path.sep);
   } else if (typeof pattern === 'string') {
     var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');


### PR DESCRIPTION
**Summary**

On Windows with Node.js v12.x.x, Metro crashes with
```
SyntaxError: Invalid regular expression: /(.*\\__fixtures__\\.*|node_modules[\\\]react[\\\]dist[\\\].*|website\\node_modules\\.*|heapCapture\\bundle\.js|.*\\__tests__\\.*)$/: Unterminated character class
```
This has been reported in https://github.com/facebook/metro/issues/453, https://github.com/facebook/react-native/issues/26829, https://github.com/facebook/react-native/issues/26969, https://github.com/facebook/react-native/issues/26878, https://github.com/facebook/react-native/issues/26598, https://github.com/expo/expo-cli/issues/1147 and https://github.com/expo/expo-cli/issues/1074.

There are a few open pull requests attempting to fix this same issue:
* https://github.com/facebook/metro/pull/464
* https://github.com/facebook/metro/pull/461
* https://github.com/facebook/metro/pull/458
* https://github.com/facebook/metro/pull/454

However, none of the existing PRs address the *root cause* of this error: the `escapeRegExp` function in `blacklist.js` tries to convert regular expressions to be agnostic to the path separator ("/" or "\\"), but turns some valid regular expressions to invalid syntax.

The error was is this line:
https://github.com/facebook/metro/blob/142348f5345e40ce2075fc7f9dfa30c5d31fee2a/packages/metro-config/src/defaults/blacklist.js#L28
When given a regular expression, such as `/node_modules[/\\]react[/\\]dist[/\\].*/`, on Windows where `path.sep` is `\` (which is also an escape character in regular expressions), this gets turned into `/node_modules[\\\]react[\\\]dist[\\\].*/`, resulting in the `Unterminated character class` error.

Automatically replacing `[/]` with `[\]` is an error, as is replacing `[\/]` with `[\\]`, because in both of these cases the backslash before the end of character class "]" escapes it, and the character class becomes unterminated. Therefore, this PR changes the code to look for both escaped forward slash `\/` and forward slash `/`, and always replace them with the escaped version (`\/` or `\\`, depending on the platform).

This fixes https://github.com/facebook/metro/issues/453.

**Test plan**

Added a test case that exercises the code with both `\` and `/` as path separators.