### PR TITLE
Adds inline support for native variant in Platform.select

### DIFF
--- a/packages/metro/src/JSTransformer/worker/__tests__/inline-plugin-test.js
+++ b/packages/metro/src/JSTransformer/worker/__tests__/inline-plugin-test.js
@@ -250,6 +250,39 @@ describe('inline constants', () => {
     });
   });
 
+  it("inlines Platform.select in the code if Platform is a global and the argument doesn't have target platform in it keys but has native", () => {
+    const code = `
+      function a() {
+        var a = Platform.select({ios: 1, native: 2});
+        var b = a.Platform.select({ios: 1, native: 2});
+      }
+    `;
+
+    compare([inlinePlugin], code, code.replace(/Platform\.select[^;]+/, '2'), {
+      inlinePlatform: 'true',
+      platform: 'android',
+    });
+  });
+
+  it("doesn't inline Platform.select in the code if Platform is a global and the argument only has an unknown platform in its keys", () => {
+    const code = `
+      function a() {
+        var a = Platform.select({web: 2});
+        var b = a.Platform.select({native: 2});
+      }
+    `;
+
+    compare(
+      [inlinePlugin],
+      code,
+      code.replace(/Platform\.select[^;]+/, 'undefined'),
+      {
+        inlinePlatform: 'true',
+        platform: 'android',
+      },
+    );
+  });
+
   it('inlines Platform.select in the code when using string keys', () => {
     const code = `
       function a() {

--- a/packages/metro/src/JSTransformer/worker/__tests__/inline-plugin-test.js
+++ b/packages/metro/src/JSTransformer/worker/__tests__/inline-plugin-test.js
@@ -236,7 +236,7 @@ describe('inline constants', () => {
     });
   });
 
-  it("inlines Platform.select in the code if Platform is a global and the argument doesn't have target platform in it's keys", () => {
+  it("inlines Platform.select in the code if Platform is a global and the argument doesn't have a target platform in its keys", () => {
     const code = `
       function a() {
         var a = Platform.select({ios: 1, default: 2});
@@ -250,7 +250,7 @@ describe('inline constants', () => {
     });
   });
 
-  it("inlines Platform.select in the code if Platform is a global and the argument doesn't have target platform in it keys but has native", () => {
+  it("inlines Platform.select in the code if Platform is a global and the argument doesn't have a target platform in its keys but has native", () => {
     const code = `
       function a() {
         var a = Platform.select({ios: 1, native: 2});

--- a/packages/metro/src/JSTransformer/worker/inline-plugin.js
+++ b/packages/metro/src/JSTransformer/worker/inline-plugin.js
@@ -141,7 +141,9 @@ function inlinePlugin(
         ) {
           if (hasStaticProperties(arg)) {
             const fallback = () =>
-              findProperty(arg, 'default', () => t.identifier('undefined'));
+              findProperty(arg, 'native', () =>
+                findProperty(arg, 'default', () => t.identifier('undefined')),
+              );
 
             path.replaceWith(findProperty(arg, opts.platform, fallback));
           }


### PR DESCRIPTION
**Summary**

In https://github.com/facebook/react-native/pull/26966 I propose adding a `native` variant to `Platform.select`, similar to the existing platform-specific extensions. This PR adds supports for that in Metro's inline plugin.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added a couple unit tests. `yarn test inline` is passing, `yarn test` is failing some seemingly unrelated tests (some issues with package.json in metro-babel7-plugin-react-transform)

cc @cpojer 