### PR TITLE
Add watch flag to metro config

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -121,6 +121,7 @@ Object {
     "workerPath": "metro/src/DeltaBundler/Worker",
   },
   "transformerPath": "",
+  "watch": true,
   "watchFolders": Array [
     "/",
   ],
@@ -248,6 +249,7 @@ Object {
     "workerPath": "metro/src/DeltaBundler/Worker",
   },
   "transformerPath": "",
+  "watch": true,
   "watchFolders": Array [
     "/",
   ],

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -99,6 +99,7 @@ export type OldConfigT = {
   resolveRequest: ?CustomResolver,
   transformVariants: () => TransformVariants,
   virtualMapper: (file: string) => Array<string>,
+  watch: ?boolean,
 };
 
 type ResolverConfigT = {|
@@ -152,6 +153,7 @@ type MetalConfigT = {|
   reporter: Reporter,
   resetCache: boolean,
   watchFolders: $ReadOnlyArray<string>,
+  watch: boolean,
 |};
 
 type ServerConfigT = {|

--- a/packages/metro-config/src/convertConfig.js
+++ b/packages/metro-config/src/convertConfig.js
@@ -74,6 +74,7 @@ async function convertOldToNew({
     transformVariants,
     processModuleFilter,
     virtualMapper,
+    watch,
   } = config;
 
   const defaultConfig = await getDefaultConfig(getProjectRoot());
@@ -154,6 +155,7 @@ async function convertOldToNew({
     watchFolders,
     transformerPath: defaultConfig.transformerPath,
     resetCache,
+    watch,
     maxWorkers,
   };
 }

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -122,6 +122,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
   projectRoot: projectRoot || path.resolve(__dirname, '../../..'),
   stickyWorkers: true,
   watchFolders: [],
+  watch: true,
   transformerPath: require.resolve('metro/src/JSTransformer/worker.js'),
   maxWorkers: getMaxWorkers(),
   resetCache: false,

--- a/packages/metro-config/src/oldConfig.js
+++ b/packages/metro-config/src/oldConfig.js
@@ -69,6 +69,7 @@ const DEFAULT = ({
   processModuleFilter: module => true,
   transformVariants: () => ({default: {}}),
   virtualMapper: file => [file],
+  watch: true,
 }: ConfigT);
 
 module.exports = {

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -92,7 +92,7 @@ class DependencyGraph extends EventEmitter {
       roots: config.watchFolders,
       throwOnModuleCollision: true,
       useWatchman: config.resolver.useWatchman,
-      watch: true,
+      watch: config.watch,
     });
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This is an attempt enable users of Metro to configure the `watch` flag that is passed to `JestHasteMap`. This addresses #355 

Without this change, we see failures on some of our internal build machines where we cannot easily configure `fs.inotify.max_user_watches`. 

**Test plan**

I have a corresponding PR to the react-native-cli: https://github.com/react-native-community/cli/pull/879. I used that change (via `yarn link`) to test this change in metro.

Invoked metro via `react-native start`
- Observed that the `watch` flag was true through `console.log`

Invoked metro via `react-native bundle`
- Observed that `watch` was set to false.

If there are any other test cases you would like me to run, please let me know!