### PR TITLE
[fix] Use absolute path, not relative path, when calculating delta

### DIFF
--- a/packages/metro/src/DeltaBundler/__tests__/traverseDependencies-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/traverseDependencies-test.js
@@ -425,6 +425,21 @@ describe('edge cases', () => {
     expect(graph.dependencies.get('/foo')).toBe(undefined);
   });
 
+  it('should handle file extension changes correctly', async () => {
+    await initialTraverseDependencies(graph, options);
+
+    Actions.removeDependency('/foo', '/baz');
+    Actions.addDependency('/foo', '/baz.js', null, 'baz');
+
+    expect(
+      getPaths(await traverseDependencies([...files], graph, options)),
+    ).toEqual({
+      added: new Set(['/baz.js']),
+      modified: new Set(['/foo']),
+      deleted: new Set(['/baz']),
+    });
+  });
+
   it('modify a file and delete it afterwards', async () => {
     await initialTraverseDependencies(graph, options);
 

--- a/packages/metro/src/DeltaBundler/traverseDependencies.js
+++ b/packages/metro/src/DeltaBundler/traverseDependencies.js
@@ -227,7 +227,11 @@ async function processModule<T>(
   }
 
   for (const [relativePath, dependency] of previousDependencies) {
-    if (!currentDependencies.has(relativePath)) {
+    if (
+      !currentDependencies.has(relativePath) ||
+      nullthrows(currentDependencies.get(relativePath)).absolutePath !==
+        dependency.absolutePath
+    ) {
       removeDependency(module, dependency.absolutePath, graph, delta);
     }
   }
@@ -244,7 +248,11 @@ async function processModule<T>(
         dependency.data.data.isAsync
       ) {
         graph.importBundleNames.add(dependency.absolutePath);
-      } else if (!previousDependencies.has(relativePath)) {
+      } else if (
+        !previousDependencies.has(relativePath) ||
+        nullthrows(previousDependencies.get(relativePath)).absolutePath !==
+          dependency.absolutePath
+      ) {
         promises.push(
           addDependency(module, dependency.absolutePath, graph, delta, options),
         );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
When an absolute dependency path changes but the relative path stays the same (e.g. an extension change), DeltaBundler does not pick up the change. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This ultimately leads to a "no such file or directory" error when trying to require a dependency with the incorrect extension.

To repro, create a file `foo.js` which imports `bar.js`:
```
// foo.js
import `bar`
```
 1. initialize the graph via `incrementalBundler.initializeGraph()`
 2. rename `bar.js` -> `bar.ts`
 3. update the graph via `incrementalBundler.updateGraph()`
 4. notice that the resulting graph still has `bar.js` listed as a dependency

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

After apply these changes, I confirmed the delta now includes 1 added file (`bar.ts`), 1 modified file (`foo.js`) and 1 deleted file (`bar.js`) (where as before it only included the 1 modified file). I also confirmed that the "no such file or directory" error we were seeing at Airbnb went away.