### PR TITLE
Rename babylon parser to babel

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -101,7 +101,7 @@ function buildFile(file, silent) {
       );
   } else {
     const transformed = prettier.format(babel.transformFileSync(file, {}).code, {
-      parser: 'babylon',
+      parser: 'babel',
     });
     fs.writeFileSync(destPath, transformed);
     const source = fs.readFileSync(file).toString('utf-8');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix the following warning:
> `{ parser: "babylon" }` is deprecated; we now treat it as `{ parser: "babel" }`

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

No more warnings and tests are still green.
