### PR TITLE
Fix invalid regular expression on Windows

### DIFF
--- a/packages/metro-config/src/defaults/blacklist.js
+++ b/packages/metro-config/src/defaults/blacklist.js
@@ -22,7 +22,8 @@ var sharedBlacklist = [
 
 function escapeRegExp(pattern) {
   if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
-    return pattern.source.replace(/\//g, path.sep);
+    // convert the '/' into an escaped local file separator
+    return pattern.source.replace(/\\\//g, '\\' + path.sep);
   } else if (typeof pattern === 'string') {
     var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
     // convert the '/' into an escaped local file separator


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When invoking `react-native run-windows`, an `Invalid regular expression` error is thrown by Metro due to path separator being `\` on Windows. Metro tries to replace every `/` with the path separator, but this makes expressions like `[/\\]` in `[\\\]`, an invalid regular expression.

A solution would be replace only escaped `/` with the actual escaped path separator. instead of replacing any `/`:

https://github.com/facebook/metro/blob/d88295cc17453c74ffcb72627dd5e0f97886a55a/packages/metro-config/src/defaults/blacklist.js#L26

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```powershell
react-native init PoC --version 0.60.6
cd PoC
yarn add rnpm-plugin-windows
react-native windows --template vnext
yarn start
```

*Currently*

![image](https://user-images.githubusercontent.com/7753096/70966478-407eb000-2048-11ea-8757-84a3d27b6ec0.png)

*Expected*

![image](https://user-images.githubusercontent.com/7753096/70966570-905d7700-2048-11ea-80a9-74c7203a37c5.png)