### PR TITLE
Pass the original module name to custom resolver

### DIFF
--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -85,7 +85,12 @@ function resolve(
 
   if (resolveRequest) {
     try {
-      const resolution = resolveRequest(context, realModuleName, platform);
+      const resolution = resolveRequest(
+        context,
+        realModuleName,
+        platform,
+        moduleName,
+      );
       if (resolution) {
         return resolution;
       }

--- a/packages/metro-resolver/src/types.js
+++ b/packages/metro-resolver/src/types.js
@@ -122,4 +122,5 @@ export type CustomResolver = (
   ResolutionContext,
   string,
   string | null,
+  string | null,
 ) => Resolution;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
We are using a custom resolver for our custom module resolution logic,
and we got an issue where the module name passed to our custom resolver
is not the actual name of the module in the node-modules.
Our investigation find that the metro's resolver will change the [original
module name](https://github.com/facebook/metro/blob/master/packages/metro-resolver/src/resolve.js#L50) as per the redirect defined in "react-native" or "browser"
field of the package.json of that requiring package. Eg. [here](https://github.com/aws/aws-sdk-js/blob/master/package.json#L66)

I found that, by just adding the original module name to the list of
arguments passed to the custom resolver will solve the problem without
affecting any of its existing users/functionalities. Also this will give the custom
resolver a better context on the required module, which the custom
resolver can handle in a better way.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We came to this fix by the investigation on the bug we faced, but we found it beneficial for anyone who wanted to use a custom resolver with metro. 

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

We are using this the change as a [patch](https://www.npmjs.com/package/patch-package) in our package for the past few months, so it is throughly tested for its newly added argument.

Also I created a test feature which is available here -  https://github.com/alanjoxa/AwesomeProject/tree/resolver
Test simulation instructions
```
git clone https://github.com/alanjoxa/AwesomeProject.git
git checkout resolver
cd AwesomeProject
npm install
npm start
```
This will start a metro server at 8081. 
The metro config of this package has a [custom resolver](https://github.com/alanjoxa/AwesomeProject/blob/resolver/metro.config.js#L12), which is just intercepting all resolve request for the demo of this use case. Also this package [depend on the aws-sdk](https://github.com/alanjoxa/AwesomeProject/blob/resolver/package.json#L14) package which has a [react-native specific redirect defined](https://github.com/aws/aws-sdk-js/blob/master/package.json#L61). Now on any bundle request to this server - the metro will call the custom resolver for the modules required in the package and it will pass the requested module name alone with the context and platform . But without my patch, the original module name of the redirected modules will be unknown to the custom resolver. 
Eg: in place of [xml2js](https://github.com/aws/aws-sdk-js/blob/master/package.json#L66), the custom resolver will get it as "./dist/xml2js.js"

