### PR TITLE
Set the file watch of jest haste map configurable.

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -121,6 +121,7 @@ Object {
     "workerPath": "metro/src/DeltaBundler/Worker",
   },
   "transformerPath": "",
+  "watch": true,
   "watchFolders": Array [
     "/",
   ],
@@ -248,6 +249,7 @@ Object {
     "workerPath": "metro/src/DeltaBundler/Worker",
   },
   "transformerPath": "",
+  "watch": true,
   "watchFolders": Array [
     "/",
   ],

--- a/packages/metro-config/src/__tests__/convertConfig-test.js
+++ b/packages/metro-config/src/__tests__/convertConfig-test.js
@@ -47,6 +47,7 @@ describe('convertConfig', () => {
       minifierPath: DEFAULT_METRO_MINIFIER_PATH,
       port: 8080,
       reporter: new TerminalReporter(new Terminal(process.stdout)),
+      watch: true,
     });
 
     expect(prettyFormat(convertedConfig)).toEqual(prettyFormat(defaultConfig));

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -164,6 +164,7 @@ type MetalConfigT = {|
   transformerPath: string,
   reporter: Reporter,
   resetCache: boolean,
+  watch: boolean,
   watchFolders: $ReadOnlyArray<string>,
 |};
 

--- a/packages/metro-config/src/convertConfig.js
+++ b/packages/metro-config/src/convertConfig.js
@@ -31,6 +31,7 @@ type PublicMetroOptions = {|
   minifierPath?: string,
   port?: ?number,
   reporter?: Reporter,
+  watch?: boolean,
 |};
 
 // We get the metro runServer signature here and create the new config out of it
@@ -41,6 +42,7 @@ async function convertOldToNew({
   minifierPath,
   port = null,
   reporter = new TerminalReporter(new Terminal(process.stdout)),
+  watch = true,
 }: PublicMetroOptions): Promise<ConfigT> {
   const {
     getBlacklistRE,
@@ -154,6 +156,7 @@ async function convertOldToNew({
     watchFolders,
     transformerPath: defaultConfig.transformerPath,
     resetCache,
+    watch,
     maxWorkers,
   };
 }

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -122,6 +122,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
   projectRoot: projectRoot || path.resolve(__dirname, '../../..'),
   stickyWorkers: true,
   watchFolders: [],
+  watch: true,
   transformerPath: require.resolve('metro/src/JSTransformer/worker.js'),
   maxWorkers: getMaxWorkers(),
   resetCache: false,

--- a/packages/metro/src/DeltaBundler/Transformer/__tests__/Transformer-test.js
+++ b/packages/metro/src/DeltaBundler/Transformer/__tests__/Transformer-test.js
@@ -46,6 +46,7 @@ describe('Transformer', function() {
       projectRoot: '/root',
       resetCache: false,
       transformerPath: '/path/to/transformer.js',
+      watch: true,
       watchFolders: ['/root'],
     };
 

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -92,7 +92,7 @@ class DependencyGraph extends EventEmitter {
       roots: config.watchFolders,
       throwOnModuleCollision: true,
       useWatchman: config.resolver.useWatchman,
-      watch: true,
+      watch: config.watch,
     });
   }
 


### PR DESCRIPTION
**Summary**
This PR will fix the regression caused by [this commit ](https://github.com/facebook/metro/commit/0d6c135045a33f2b9effa8ca31b648e6b29ec24c#diff-75dc57ca2d6ab410090adb917784434f)

In the [Metro documentation we have a `watch` field](https://facebook.github.io/metro/docs/en/configuration#watch), which is not working after the above commit. 

We cannot simply revert that commit because it will set the default value of the watch field to `false`, but the current default value is `true`. So I created this PR by reverting that commit and setting its default value to `true`. Which make this commit a no-op to current functionality, but fix the regression.

**Motivation** 

*Why this fix is required now ?*
Apart from fixing the bug, this enables react-native app developers to build there app in cloud servers, which has limit in no. of file watch at a time. This is a pain for people who have large dependencies, which causes the `node_modules` to have a large no. of files, which cause the build to fail with `ENOSPC` error.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Apart from the completing the [metro pull request workflow](https://github.com/facebook/metro/blob/master/CONTRIBUTING.md#workflow-and-pull-requests)
I tested it by applying this patch to a sample react-native feature and it is working as expected. Also, since it is almost a revert of one of the previous commit, it has less foreign changes.

The test feature which I created is available here - https://github.com/alanjoxa/AwesomeProject
Test simulation instructions
```
git clone https://github.com/alanjoxa/AwesomeProject.git
cd AwesomeProject
npm install
npm start
```
This will start a metro server, now you can change the watch property in that [project's metro config](https://github.com/alanjoxa/AwesomeProject/blob/master/metro.config.js#L9), and see the difference, by making a build request at  by a GET at `http://localhost:8081/index.bundle?platform=ios`. 
When 

- `watch : true` - Metro server will watch for  all files in the project folder, including `node_modules` and apply any file changes to the bundle on the subsequent build request.
- `watch: false` - Will not watch for files, that means we need to restart the server for seeing the file changes. 

This file watching functionality will help in accelerating the local development, but that is not expected when we are building the project to release or in our CI pipelines, where the build is happening in some docker containers or some ec2 servers, where sometimes we do not have access to set the `fs.inotify.max_user_watches`. So people try the workarounds like, npm script for deleting the folders in the node_modules which are not required in the bundling process. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
