### PR TITLE
Handle circular dependency upon dependency removal

### DIFF
--- a/packages/metro/src/DeltaBundler/__tests__/traverseDependencies-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/traverseDependencies-test.js
@@ -476,7 +476,7 @@ describe('edge cases', () => {
     expect(graph.dependencies.get('/baz')).toBe(undefined);
   });
 
-  it('removes a cyclic dependecy but should not remove any dependency', async () => {
+  it('removes a cyclic dependency but should not remove any dependency', async () => {
     Actions.createFile('/bar1');
     Actions.addDependency('/bar', '/bar1');
     Actions.addDependency('/bar1', '/foo');

--- a/packages/metro/src/DeltaBundler/traverseDependencies.js
+++ b/packages/metro/src/DeltaBundler/traverseDependencies.js
@@ -375,9 +375,9 @@ function canSafelyRemoveFromParentModule<T>(
 
   if (!topInverseDependencies.size) {
     /**
-     * This happens when parentModule and inverseDependencies has circular dependency,
-     * this will eventaully became an empty set due to `visited` Set being the base case
-     * for the recursive call.
+     * This happens when parentModule and inverseDependencies have a circular dependency.
+     * This will eventually become an empty set due to the `visited` Set being the
+     * base case for the recursive call.
      */
     return true;
   }
@@ -387,9 +387,9 @@ function canSafelyRemoveFromParentModule<T>(
   ).filter(x => !delta.deleted.has(x));
 
   /**
-   * We can only mark `visited` set of modules to be safely removable if
-   * 1. We do not have top level module to compare with parentModule,
-   *   this can happen when trying to see if we can safely remove from
+   * We can only mark the `visited` Set of modules to be safely removable if
+   * 1. We do not have top a level module to compare with parentModule.
+   *   This can happen when trying to see if we can safely remove from
    *   a module that was deleted. This is why we filtered them out with `delta.deleted`
    * 2. We have one top module and it is parentModule
    */

--- a/packages/metro/src/DeltaBundler/traverseDependencies.js
+++ b/packages/metro/src/DeltaBundler/traverseDependencies.js
@@ -356,11 +356,11 @@ function getAllTopLevelInverseDependencies<T>(
  * Given `inverseDependencies`, tracing back inverse dependencies to
  * see if it only leads back to `parentModule`.
  */
-async function canSafelyRemoveFromParentModule<T>(
+function canSafelyRemoveFromParentModule<T>(
   inverseDependencies: Set<string>,
   parentModule: string,
   graph: Graph<T>,
-): Promise<boolean> {
+): boolean {
   const result = getAllTopLevelInverseDependencies(
     inverseDependencies,
     parentModule,
@@ -390,11 +390,11 @@ async function removeDependency<T>(
   // by tracing back the inverseDependencies.
   if (
     module.inverseDependencies.size &&
-    !(await canSafelyRemoveFromParentModule(
+    !canSafelyRemoveFromParentModule(
       module.inverseDependencies,
       module.path,
       graph,
-    ))
+    )
   ) {
     return;
   }

--- a/packages/metro/src/DeltaBundler/traverseDependencies.js
+++ b/packages/metro/src/DeltaBundler/traverseDependencies.js
@@ -425,7 +425,7 @@ function removeDependency<T>(
   module.inverseDependencies.delete(parentModule.path);
 
   // Even if there are modules still using parentModule, we want to ensure
-  // there isn't circular dependency. Thus, we check if it can be safely remove
+  // there is no circular dependency. Thus, we check if it can be safely removed
   // by tracing back the inverseDependencies.
   if (!canBeRemovedSafely.has(module.path)) {
     if (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
**Summary**
This is a proposed fix for the issue I submitted https://github.com/facebook/metro/issues/500. For problem statement, please refer to the issue linked to understand the scope of the bug.

Currently Metro does not handle dependency removal correctly in the presence of certain circular dependency. Since we rely on Metro server to produce correct dependency graph in hopes to bundle only the needed modules. This is especially an issue when a dependency is removed from the entry point, however, due to it having circular dependency, the updated dependency graph will leave out all its dependencies in the graph.

I added the following two more test cases to ensure the correctness of the algorithm:

1. Remove `B` from `E`: `removes a dependency with transient cyclic dependency`
![image](https://user-images.githubusercontent.com/1754430/71753699-39bdae80-2e38-11ea-82f7-ab4285acc869.png)

2. Remove `B` from `E`: `removes a cyclic dependency which is both inverse dependency and direct dependency`
![image](https://user-images.githubusercontent.com/1754430/71753852-bea8c800-2e38-11ea-9166-4f97854b1faa.png)

3. Remove `B` from `E`: `removes a sub graph that has internal cyclic dependency`
![image](https://user-images.githubusercontent.com/1754430/71753928-ffa0dc80-2e38-11ea-8c9e-cdd292290472.png)

Feel free to propose more tests to ensure the correctness of the algorithm. I'm aware that this may introduce more expensive graph updates for certain scenarios, but I believe that ensuring the correctness is far more important for dependency graph updates.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Implementation
Previously, our implementation will stop removing circular dependency due to it having remaining `inverseDependencies`:

https://github.com/facebook/metro/blob/984aab84358aeef8de13ba86c33834a1c1bf6926/packages/metro/src/DeltaBundler/traverseDependencies.js#L328-L330

This can be illustrated by this example: 
![image](https://user-images.githubusercontent.com/1754430/71753699-39bdae80-2e38-11ea-82f7-ab4285acc869.png)

When removing `B` from `E`, `B` will still have an inverse dependency `A` left. Henceforth, the rest of the graph remain untouched. My proposed solution is to have this async function `canSafelyRemoveFromParentModule` recursively checking all the inverse dependencies. In this example, we will look up inverse dependencies of `A` all the way to the end until there is no inverse dependency. We can only safely remove this dependency if and only if its end inverse dependency (in this case `A` will have `B` as its end inverse dependency) only has one path and the path is the same as the parent path. 

**Test plan**
- Updated 1 existing test, with 2 additional unit tests to ensure the correctness of the dependency removal logic handling with circular dependency.

```
yarn run jest packages/metro/src/DeltaBundler/__tests__/traverseDependencies-test.js
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


