### PR TITLE
Add watch option to Server and disable file watchers for runBuild

### DIFF
--- a/packages/metro/src/Bundler.js
+++ b/packages/metro/src/Bundler.js
@@ -17,12 +17,16 @@ import type {TransformOptions} from './DeltaBundler/Worker';
 import type {TransformResultWithSource} from './DeltaBundler';
 import type {ConfigT} from 'metro-config/src/configTypes.flow';
 
+export type BundlerOptions = {|
+  +watch?: boolean,
+|};
+
 class Bundler {
   _depGraphPromise: Promise<DependencyGraph>;
   _transformer: Transformer;
 
-  constructor(config: ConfigT) {
-    this._depGraphPromise = DependencyGraph.load(config);
+  constructor(config: ConfigT, options: BundlerOptions = {}) {
+    this._depGraphPromise = DependencyGraph.load(config, options);
 
     this._depGraphPromise
       .then((dependencyGraph: DependencyGraph) => {

--- a/packages/metro/src/Bundler.js
+++ b/packages/metro/src/Bundler.js
@@ -25,7 +25,7 @@ class Bundler {
   _depGraphPromise: Promise<DependencyGraph>;
   _transformer: Transformer;
 
-  constructor(config: ConfigT, options: BundlerOptions = {}) {
+  constructor(config: ConfigT, options?: BundlerOptions) {
     this._depGraphPromise = DependencyGraph.load(config, options);
 
     this._depGraphPromise

--- a/packages/metro/src/Bundler.js
+++ b/packages/metro/src/Bundler.js
@@ -17,9 +17,9 @@ import type {TransformOptions} from './DeltaBundler/Worker';
 import type {TransformResultWithSource} from './DeltaBundler';
 import type {ConfigT} from 'metro-config/src/configTypes.flow';
 
-export type BundlerOptions = {|
-  +watch?: boolean,
-|};
+export type BundlerOptions = $ReadOnly<{|
+  watch?: boolean,
+|}>;
 
 class Bundler {
   _depGraphPromise: Promise<DependencyGraph>;

--- a/packages/metro/src/IncrementalBundler.js
+++ b/packages/metro/src/IncrementalBundler.js
@@ -45,6 +45,10 @@ export type GraphRevision = {|
   +prepend: $ReadOnlyArray<Module<>>,
 |};
 
+export type IncrementalBundlerOptions = {|
+  +watch?: boolean,
+|};
+
 function createRevisionId(): RevisionId {
   return crypto.randomBytes(8).toString('hex');
 }
@@ -64,9 +68,9 @@ class IncrementalBundler {
     str: string,
   ) => RevisionId = revisionIdFromString;
 
-  constructor(config: ConfigT) {
+  constructor(config: ConfigT, options: IncrementalBundlerOptions = {}) {
     this._config = config;
-    this._bundler = new Bundler(config);
+    this._bundler = new Bundler(config, options);
     this._deltaBundler = new DeltaBundler(this._bundler);
   }
 

--- a/packages/metro/src/IncrementalBundler.js
+++ b/packages/metro/src/IncrementalBundler.js
@@ -68,7 +68,7 @@ class IncrementalBundler {
     str: string,
   ) => RevisionId = revisionIdFromString;
 
-  constructor(config: ConfigT, options: IncrementalBundlerOptions = {}) {
+  constructor(config: ConfigT, options?: IncrementalBundlerOptions) {
     this._config = config;
     this._bundler = new Bundler(config, options);
     this._deltaBundler = new DeltaBundler(this._bundler);

--- a/packages/metro/src/IncrementalBundler.js
+++ b/packages/metro/src/IncrementalBundler.js
@@ -45,9 +45,9 @@ export type GraphRevision = {|
   +prepend: $ReadOnlyArray<Module<>>,
 |};
 
-export type IncrementalBundlerOptions = {|
-  +watch?: boolean,
-|};
+export type IncrementalBundlerOptions = $ReadOnly<{|
+  watch?: boolean,
+|}>;
 
 function createRevisionId(): RevisionId {
   return crypto.randomBytes(8).toString('hex');

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -91,9 +91,9 @@ type ProcessEndContext<T> = {|
   +result: T,
 |};
 
-export type ServerOptions = {|
-  +watch?: boolean,
-|};
+export type ServerOptions = $ReadOnly<{|
+  watch?: boolean,
+|}>;
 
 const DELTA_ID_HEADER = 'X-Metro-Delta-ID';
 const FILES_CHANGED_COUNT_HEADER = 'X-Metro-Files-Changed-Count';

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -91,6 +91,10 @@ type ProcessEndContext<T> = {|
   +result: T,
 |};
 
+export type ServerOptionsT = {|
+  +watch?: boolean,
+|};
+
 const DELTA_ID_HEADER = 'X-Metro-Delta-ID';
 const FILES_CHANGED_COUNT_HEADER = 'X-Metro-Files-Changed-Count';
 
@@ -104,7 +108,7 @@ class Server {
   _bundler: IncrementalBundler;
   _isEnded: boolean;
 
-  constructor(config: ConfigT) {
+  constructor(config: ConfigT, options?: ServerOptions = {}) {
     this._config = config;
 
     if (this._config.resetCache) {
@@ -124,7 +128,9 @@ class Server {
     // the HmrServer.
     // The whole bundling/serializing logic should follow as well.
     this._createModuleId = config.serializer.createModuleIdFactory();
-    this._bundler = new IncrementalBundler(config);
+    this._bundler = new IncrementalBundler(config, {
+      watch: options.watch,
+    });
     this._nextBundleBuildID = 1;
   }
 

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -91,7 +91,7 @@ type ProcessEndContext<T> = {|
   +result: T,
 |};
 
-export type ServerOptionsT = {|
+export type ServerOptions = {|
   +watch?: boolean,
 |};
 
@@ -108,7 +108,7 @@ class Server {
   _bundler: IncrementalBundler;
   _isEnded: boolean;
 
-  constructor(config: ConfigT, options?: ServerOptions = {}) {
+  constructor(config: ConfigT, options?: ServerOptions) {
     this._config = config;
 
     if (this._config.resetCache) {
@@ -129,7 +129,7 @@ class Server {
     // The whole bundling/serializing logic should follow as well.
     this._createModuleId = config.serializer.createModuleIdFactory();
     this._bundler = new IncrementalBundler(config, {
-      watch: options.watch,
+      watch: options ? options.watch : undefined,
     });
     this._nextBundleBuildID = 1;
   }

--- a/packages/metro/src/index.js
+++ b/packages/metro/src/index.js
@@ -26,6 +26,7 @@ const outputBundle = require('./shared/output/bundle');
 const {loadConfig, mergeConfig, getDefaultConfig} = require('metro-config');
 const {InspectorProxy} = require('metro-inspector-proxy');
 
+import type {ServerOptions} from './Server';
 import type {Graph} from './DeltaBundler';
 import type {CustomTransformOptions} from './JSTransformer/worker';
 import type {RequestOptions, OutputOptions} from './shared/types.flow.js';
@@ -107,7 +108,10 @@ async function getConfig(config: InputConfigT): Promise<ConfigT> {
   return mergeConfig(defaultConfig, config);
 }
 
-async function runMetro(config: InputConfigT): Promise<MetroServer> {
+async function runMetro(
+  config: InputConfigT,
+  options?: ServerOptions,
+): Promise<MetroServer> {
   const mergedConfig = await getConfig(config);
 
   mergedConfig.reporter.update({
@@ -118,7 +122,7 @@ async function runMetro(config: InputConfigT): Promise<MetroServer> {
     projectRoots: mergedConfig.watchFolders,
   });
 
-  return new MetroServer(mergedConfig);
+  return new MetroServer(mergedConfig, options);
 }
 
 exports.runMetro = runMetro;
@@ -272,7 +276,10 @@ exports.runBuild = async (
   map: string,
   ...
 }> => {
-  const metroServer = await runMetro(config);
+  const metroServer = await runMetro(config, {
+    // watchers not needed for one-off builds
+    watch: false,
+  });
 
   try {
     const requestOptions: RequestOptions = {

--- a/packages/metro/src/index.js
+++ b/packages/metro/src/index.js
@@ -277,7 +277,6 @@ exports.runBuild = async (
   ...
 }> => {
   const metroServer = await runMetro(config, {
-    // watchers not needed for one-off builds
     watch: false,
   });
 

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -73,7 +73,11 @@ class DependencyGraph extends EventEmitter {
     this._createModuleResolver();
   }
 
-  static _createHaste(config: ConfigT): JestHasteMap {
+  static _createHaste(config: ConfigT, watch?: boolean): JestHasteMap {
+    const shouldWatch = watch === undefined ?
+      !ci.isCI :
+      options.watch;
+
     return new JestHasteMap({
       cacheDirectory: config.hasteMapCacheDirectory,
       computeDependencies: false,
@@ -93,17 +97,17 @@ class DependencyGraph extends EventEmitter {
       roots: config.watchFolders,
       throwOnModuleCollision: true,
       useWatchman: config.resolver.useWatchman,
-      watch: !ci.isCI,
+      watch: shouldWatch,
     });
   }
 
-  static async load(config: ConfigT): Promise<DependencyGraph> {
+  static async load(config: ConfigT, options: { watch?: boolean } = {}): Promise<DependencyGraph> {
     const initializingMetroLogEntry = log(
       createActionStartEntry('Initializing Metro'),
     );
 
     config.reporter.update({type: 'dep_graph_loading'});
-    const haste = DependencyGraph._createHaste(config);
+    const haste = DependencyGraph._createHaste(config, options.watch);
     const {hasteFS, moduleMap} = await haste.build();
 
     log(createActionEndEntry(initializingMetroLogEntry));

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -74,8 +74,6 @@ class DependencyGraph extends EventEmitter {
   }
 
   static _createHaste(config: ConfigT, watch?: boolean): JestHasteMap {
-    const shouldWatch = watch === undefined ? !ci.isCI : watch;
-
     return new JestHasteMap({
       cacheDirectory: config.hasteMapCacheDirectory,
       computeDependencies: false,
@@ -95,7 +93,7 @@ class DependencyGraph extends EventEmitter {
       roots: config.watchFolders,
       throwOnModuleCollision: true,
       useWatchman: config.resolver.useWatchman,
-      watch: shouldWatch,
+      watch: watch == null ? !ci.isCI : watch,
     });
   }
 
@@ -108,7 +106,10 @@ class DependencyGraph extends EventEmitter {
     );
 
     config.reporter.update({type: 'dep_graph_loading'});
-    const haste = DependencyGraph._createHaste(config, (options || {}).watch);
+    const haste = DependencyGraph._createHaste(
+      config,
+      options && options.watch,
+    );
     const {hasteFS, moduleMap} = await haste.build();
 
     log(createActionEndEntry(initializingMetroLogEntry));

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -74,9 +74,7 @@ class DependencyGraph extends EventEmitter {
   }
 
   static _createHaste(config: ConfigT, watch?: boolean): JestHasteMap {
-    const shouldWatch = watch === undefined ?
-      !ci.isCI :
-      options.watch;
+    const shouldWatch = watch === undefined ? !ci.isCI : watch;
 
     return new JestHasteMap({
       cacheDirectory: config.hasteMapCacheDirectory,
@@ -101,13 +99,16 @@ class DependencyGraph extends EventEmitter {
     });
   }
 
-  static async load(config: ConfigT, options: { watch?: boolean } = {}): Promise<DependencyGraph> {
+  static async load(
+    config: ConfigT,
+    options?: {|+watch?: boolean|},
+  ): Promise<DependencyGraph> {
     const initializingMetroLogEntry = log(
       createActionStartEntry('Initializing Metro'),
     );
 
     config.reporter.update({type: 'dep_graph_loading'});
-    const haste = DependencyGraph._createHaste(config, options.watch);
+    const haste = DependencyGraph._createHaste(config, (options || {}).watch);
     const {hasteFS, moduleMap} = await haste.build();
 
     log(createActionEndEntry(initializingMetroLogEntry));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

In this PR I am disabling file watching for bundle generation done through `runBuild`. A `watch` option is also added to `Server` in order to enable that (and also because `Server` is used by the React Native CLI instead of `runBuild`).

The goal of this is to solve `ENOSPC` errors related to excessive file watcher use, particularly in CI environments. See: https://github.com/facebook/metro/issues/355 

Context:
I previously attempted to fix this by resolving a regression in the existing `watch` config option: https://github.com/facebook/metro/pull/491
Which was closed in favor of a similar PR:  https://github.com/facebook/metro/pull/497
Which was then re-created in: https://github.com/facebook/metro/pull/503 (and landed)

The above PR was modified to automatically set the `watch` value depending on whether it was built in a CI environment. There was a desire to remove the `watch` config option altogether.

At the end, we concluded that there is still a need for a caller to turn off file watching explicitly, and not only through CI detection.

Therefore, I'm threading it through the code as an option that is passed through programmatically and *not* through the config.

Once/if this lands, I will update the React Native CLI to use this option.

**Test plan**

I used the rn-cli as a test harness of sorts.

Invoked metro via `react-native start`
- Observed that the `watch` flag was true through `console.log`

Invoked metro via `react-native bundle`
- Observed that `watch` was set to false.

Relatively new to this project, so please let me know if I should be taking a look at anything else.