### PR TITLE
[babel-plugin] Don't add es6 transforms when `unstable_disableES6Transforms` is set

### DIFF
--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -28,6 +28,7 @@
     "@babel/plugin-syntax-export-default-from": "^7.0.0",
     "@babel/plugin-syntax-flow": "^7.2.0",
     "@babel/plugin-transform-arrow-functions": "^7.0.0",
+    "@babel/plugin-transform-async-to-generator": "^7.0.0",
     "@babel/plugin-transform-block-scoping": "^7.0.0",
     "@babel/plugin-transform-classes": "^7.0.0",
     "@babel/plugin-transform-computed-properties": "^7.0.0",

--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@babel/preset-modules": "^0.1.2",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-export-default-from": "^7.0.0",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -22,7 +22,6 @@ function isTSXSource(fileName) {
 const defaultPlugins = [
   [require('@babel/plugin-syntax-flow')],
   [require('@babel/plugin-proposal-optional-catch-binding')],
-  [require('@babel/plugin-transform-block-scoping')],
   [
     require('@babel/plugin-proposal-class-properties'),
     // use `this.foo = bar` instead of `this.defineProperty('foo', ...)`
@@ -43,6 +42,9 @@ const es2015Spread = [require('@babel/plugin-transform-spread')];
 const es2015TemplateLiterals = [
   require('@babel/plugin-transform-template-literals'),
   {loose: true}, // dont 'a'.concat('b'), just use 'a'+'b'
+];
+const taggedTemplateCaching = [
+  require('@babel/preset-modules/lib/plugins/transform-tagged-template-caching'),
 ];
 const exponentiationOperator = [
   require('@babel/plugin-transform-exponentiation-operator'),
@@ -71,6 +73,10 @@ const es2015StickyRegex = [require('@babel/plugin-transform-sticky-regex')];
 const es2015Literals = [require('@babel/plugin-transform-literals')];
 const es2015ShorthandProperties = [
   require('@babel/plugin-transform-shorthand-properties'),
+];
+const es2015BlockScoping = [require('@babel/plugin-transform-block-scoping')];
+const safariForShadowing = [
+  require('@babel/preset-modules/lib/plugins/transform-safari-for-shadowing'),
 ];
 const functionName = [require('@babel/plugin-transform-function-name')];
 const regenerator = [require('@babel/plugin-transform-regenerator')];
@@ -147,10 +153,16 @@ const getPreset = (src, options) => {
     extraPlugins.push(es2015ArrowFunctions);
   }
 
+  extraPlugins.push(
+    enableES6Transforms ? es2015BlockScoping : safariForShadowing,
+  );
+
   extraPlugins.push(enableES6Transforms ? regenerator : asyncToGenerator);
 
   if (isNull || src.indexOf('`') !== -1) {
-    extraPlugins.push(es2015TemplateLiterals);
+    extraPlugins.push(
+      enableES6Transforms ? es2015TemplateLiterals : taggedTemplateCaching,
+    );
   }
 
   if (isNull || hasClass || src.indexOf('...') !== -1) {

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -30,15 +30,7 @@ const defaultPlugins = [
   ],
   [require('@babel/plugin-syntax-dynamic-import')],
   [require('@babel/plugin-syntax-export-default-from')],
-  [require('@babel/plugin-transform-computed-properties')],
-  [require('@babel/plugin-transform-destructuring')],
-  [require('@babel/plugin-transform-function-name')],
-  [require('@babel/plugin-transform-literals')],
-  [require('@babel/plugin-transform-parameters')],
-  [require('@babel/plugin-transform-shorthand-properties')],
   [require('@babel/plugin-transform-react-jsx')],
-  [require('@babel/plugin-transform-regenerator')],
-  [require('@babel/plugin-transform-sticky-regex')],
   [require('@babel/plugin-transform-unicode-regex')],
 ];
 
@@ -70,13 +62,20 @@ const reactDisplayName = [
 ];
 const reactJsxSource = [require('@babel/plugin-transform-react-jsx-source')];
 const symbolMember = [require('../transforms/transform-symbol-member')];
-
-const babelRuntime = [
-  require('@babel/plugin-transform-runtime'),
-  {
-    helpers: true,
-    regenerator: true,
-  },
+const es2015Parameters = [require('@babel/plugin-transform-parameters')];
+const es2015Destructuring = [require('@babel/plugin-transform-destructuring')];
+const es2015ComputedProperties = [
+  require('@babel/plugin-transform-computed-properties'),
+];
+const es2015StickyRegex = [require('@babel/plugin-transform-sticky-regex')];
+const es2015Literals = [require('@babel/plugin-transform-literals')];
+const es2015ShorthandProperties = [
+  require('@babel/plugin-transform-shorthand-properties'),
+];
+const functionName = [require('@babel/plugin-transform-function-name')];
+const regenerator = [require('@babel/plugin-transform-regenerator')];
+const asyncToGenerator = [
+  require('@babel/plugin-transform-async-to-generator'),
 ];
 
 function unstable_disableES6Transforms(options) {
@@ -90,6 +89,7 @@ const getPreset = (src, options) => {
     isNull || (src.indexOf('for') !== -1 && src.indexOf('of') !== -1);
 
   const extraPlugins = [];
+  const enableES6Transforms = !unstable_disableES6Transforms(options);
 
   if (!options || !options.disableImportExportTransform) {
     extraPlugins.push(
@@ -109,36 +109,58 @@ const getPreset = (src, options) => {
     );
   }
 
-  if (hasClass) {
-    extraPlugins.push(es2015Classes);
+  // Babel plugins required for each iOS (JSC) version can be found here
+  // https://github.com/babel/babel/blob/master/packages/babel-compat-data/data/plugins.json
+  if (enableES6Transforms) {
+    if (hasClass) {
+      extraPlugins.push(es2015Classes);
+    }
+
+    if (isNull || src.indexOf('Object.assign') !== -1) {
+      extraPlugins.push(objectAssign);
+    }
+
+    if (hasForOf) {
+      extraPlugins.push(es2015ForOf);
+    }
+
+    if (hasForOf || src.indexOf('Symbol') !== -1) {
+      extraPlugins.push(symbolMember);
+    }
+
+    if (isNull || hasClass || src.indexOf('...') !== -1) {
+      extraPlugins.push(es2015Spread);
+    }
+
+    extraPlugins.push(es2015Destructuring);
+    extraPlugins.push(es2015Parameters);
+    extraPlugins.push(es2015ComputedProperties);
+    extraPlugins.push(es2015StickyRegex);
+    extraPlugins.push(es2015Literals);
+    extraPlugins.push(es2015ShorthandProperties);
+    extraPlugins.push(functionName);
   }
 
   // TODO(gaearon): put this back into '=>' indexOf bailout
   // and patch react-refresh to not depend on this transform.
-  extraPlugins.push(es2015ArrowFunctions);
-
-  if (isNull || hasClass || src.indexOf('...') !== -1) {
-    extraPlugins.push(es2015Spread);
-    extraPlugins.push(objectRestSpread);
+  if (enableES6Transforms || (options && options.dev)) {
+    extraPlugins.push(es2015ArrowFunctions);
   }
+
+  extraPlugins.push(enableES6Transforms ? regenerator : asyncToGenerator);
+
   if (isNull || src.indexOf('`') !== -1) {
     extraPlugins.push(es2015TemplateLiterals);
   }
+
+  if (isNull || hasClass || src.indexOf('...') !== -1) {
+    extraPlugins.push(objectRestSpread);
+  }
+
   if (isNull || src.indexOf('**') !== -1) {
     extraPlugins.push(exponentiationOperator);
   }
-  if (isNull || src.indexOf('Object.assign') !== -1) {
-    extraPlugins.push(objectAssign);
-  }
-  if (hasForOf) {
-    extraPlugins.push(es2015ForOf);
-  }
-  if (
-    !unstable_disableES6Transforms(options) &&
-    (hasForOf || src.indexOf('Symbol') !== -1)
-  ) {
-    extraPlugins.push(symbolMember);
-  }
+
   if (
     isNull ||
     src.indexOf('React.createClass') !== -1 ||
@@ -158,7 +180,13 @@ const getPreset = (src, options) => {
   }
 
   if (!options || options.enableBabelRuntime !== false) {
-    extraPlugins.push(babelRuntime);
+    extraPlugins.push([
+      require('@babel/plugin-transform-runtime'),
+      {
+        helpers: true,
+        regenerator: enableES6Transforms,
+      },
+    ]);
   }
 
   let flowPlugins = {};

--- a/packages/metro/src/JSTransformer/worker.js
+++ b/packages/metro/src/JSTransformer/worker.js
@@ -143,13 +143,20 @@ class JsTransformer {
     if (options.type === 'script') {
       type = 'js/script';
     }
+    const disableES6Transforms = options.unstable_disableES6Transforms ?? false;
 
     if (filename.endsWith('.json')) {
       let code = JsFileWrapping.wrapJson(sourceCode);
       let map = [];
 
       if (options.minify) {
-        ({map, code} = await this._minifyCode(filename, code, sourceCode, map));
+        ({map, code} = await this._minifyCode(
+          filename,
+          code,
+          sourceCode,
+          map,
+          disableES6Transforms,
+        ));
       }
 
       return {
@@ -319,6 +326,7 @@ class JsTransformer {
         result.code,
         sourceCode,
         map,
+        disableES6Transforms,
         reserved,
       ));
     }
@@ -338,6 +346,7 @@ class JsTransformer {
     code: string,
     source: string,
     map: Array<MetroSourceMapSegmentTuple>,
+    disableES6Transforms: boolean,
     reserved?: $ReadOnlyArray<string> = [],
   ): Promise<{
     code: string,
@@ -356,7 +365,11 @@ class JsTransformer {
         map: sourceMap,
         filename,
         reserved,
-        config: this._config.minifierConfig,
+        config: {
+          ...this._config.minifierConfig,
+          ecma: disableES6Transforms ? 2015 : 5,
+          safari10: disableES6Transforms,
+        },
       });
 
       return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,14 @@
     "@babel/helper-replace-supers" "^7.7.4"
     "@babel/helper-split-export-declaration" "^7.7.4"
 
+"@babel/helper-create-regexp-features-plugin@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz#c774268c95ec07ee92476a3862b75cc2839beb79"
+  integrity sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==
+  dependencies:
+    "@babel/helper-regex" "^7.8.3"
+    regexpu-core "^4.6.0"
+
 "@babel/helper-define-map@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0.tgz#a5684dd2adf30f0137cf9b0bde436f8c2db17225"
@@ -207,11 +215,23 @@
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
 
+"@babel/helper-plugin-utils@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
+  integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+
 "@babel/helper-regex@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0.tgz#2c1718923b57f9bbe64705ffe5640ac64d9bdb27"
   dependencies:
     lodash "^4.17.10"
+
+"@babel/helper-regex@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.8.3.tgz#139772607d51b93f23effe72105b319d2a4c6965"
+  integrity sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==
+  dependencies:
+    lodash "^4.17.13"
 
 "@babel/helper-remap-async-to-generator@^7.0.0":
   version "7.0.0"
@@ -385,6 +405,14 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.2.0"
 
+"@babel/plugin-proposal-unicode-property-regex@^7.4.4":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz#b646c3adea5f98800c9ab45105ac34d06cd4a47f"
+  integrity sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+
 "@babel/plugin-syntax-async-generators@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz#bf0891dcdbf59558359d0c626fdc9490e20bc13c"
@@ -518,6 +546,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
+
+"@babel/plugin-transform-dotall-regex@^7.4.4":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz#c3c6ec5ee6125c6993c5cbca20dc8621a9ea7a6e"
+  integrity sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-transform-duplicate-keys@^7.0.0":
   version "7.0.0"
@@ -759,6 +795,17 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
+"@babel/preset-modules@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.2.tgz#9365f51343ee69d99351b2892ff7479ef4505e78"
+  integrity sha512-FMhghLBAnMG7Dh0C/xgpX+HbzkrDDK9BdgS+NUuEzcro+ySmKKk2F9ROnqRawHS5aR/AH56rVtL/LM2vsy+81g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
 "@babel/register@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
@@ -853,6 +900,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.4.4":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
+  integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.7.2":
@@ -6242,6 +6298,13 @@ regenerate-unicode-properties@^7.0.0:
   dependencies:
     regenerate "^1.4.0"
 
+regenerate-unicode-properties@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
+  integrity sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==
+  dependencies:
+    regenerate "^1.4.0"
+
 regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
@@ -6296,15 +6359,39 @@ regexpu-core@^4.1.3, regexpu-core@^4.2.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.0.2"
 
+regexpu-core@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
+  integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^8.1.0"
+    regjsgen "^0.5.0"
+    regjsparser "^0.6.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.1.0"
+
 regjsgen@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.4.0.tgz#c1eb4c89a209263f8717c782591523913ede2561"
   integrity sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==
 
+regjsgen@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.1.tgz#48f0bf1a5ea205196929c0d9798b42d1ed98443c"
+  integrity sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==
+
 regjsparser@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.3.0.tgz#3c326da7fcfd69fa0d332575a41c8c0cdf588c96"
   integrity sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==
+  dependencies:
+    jsesc "~0.5.0"
+
+regjsparser@^0.6.0:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.2.tgz#fd62c753991467d9d1ffe0a9f67f27a529024b96"
+  integrity sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==
   dependencies:
     jsesc "~0.5.0"
 
@@ -7245,6 +7332,11 @@ unicode-match-property-ecmascript@^1.0.4:
 unicode-match-property-value-ecmascript@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz#9f1dc76926d6ccf452310564fd834ace059663d4"
+
+unicode-match-property-value-ecmascript@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz#5b4b426e08d13a80365e0d657ac7a6c1ec46a277"
+  integrity sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==
 
 unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
**Summary**

@cpojer https://twitter.com/cpojer/status/1218189812533993473

Now that the minimum runtime we support is iOS 10 we can drop support for all es6 transforms. There was already a flag present in the config `unstable_disableES6Transforms` but it did not actually do much. I used https://github.com/babel/babel/blob/master/packages/babel-compat-data/data/plugins.json to verify which babel plugins no longer needed on iOS 10+.

I think this is the simplest implementation we can get for now, another alternative would be to use babel-preset-env but since we are already specifying all transforms manually and not based on an external preset this seemed to make sense. Further work could involve adding per platform plugins instead of using the lower common denominator (iOS 10).

**Test plan**

Tested in my app, using the following config in metro:

```js
    transformer: {
      getTransformOptions: () => {
        return {
          transform: {
            experimentalImportSupport: false,
            inlineRequires: true,
            unstable_disableES6Transforms: true,
          },
        };
      },
    },
```

This surfaced one error in third party deps because class declarations are not hoisted so they cannot be used before their declaration. See https://github.com/tipsi/tipsi-stripe/blob/master/src/components/PaymentCardTextField.js#L19.

Did some quick benchmarks on iOS 13.3 Simulator with flipper-plugin-react-native-performance. Nothing very scientific but it does indicate a decent bundle size decrease and no noticeable perf impact (maybe ~20ms regression but my sample size is very small and not on real device). This seems consistent with experiments ran by airbnb according to Leland https://twitter.com/intelligibabble/status/1218240414047600640.

### No ES6 transforms

#### prod, no minify:
size: 10,5mb
execution: 322ms

#### prod, minify:
size: 4.9mb
execution: 240ms

### ES6 transforms

#### prod, no minify:
size: 9,5mb
execution: 308ms

#### prod, minify:
size: 4.6mb
execution: 226ms

Also inspected the generated bundle to make sure it does in fact keep modern js syntax like let/const and class.

TODO:

- Run more tests on iOS 10 / Android (JSC + Hermes)