### PR TITLE
Bring back terser minifier

### DIFF
--- a/packages/metro-minify-terser/.npmignore
+++ b/packages/metro-minify-terser/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+build
+src.real
+yarn.lock

--- a/packages/metro-minify-terser/__tests__/minify-test.js
+++ b/packages/metro-minify-terser/__tests__/minify-test.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @emails oncall+js_foundation
+ */
+'use strict';
+
+import type {BasicSourceMap} from 'metro-source-map';
+
+jest.mock('terser', () => ({
+  minify: jest.fn(code => {
+    return {
+      code: code.replace(/(^|\W)\s+/g, '$1'),
+      map: {},
+    };
+  }),
+}));
+
+const minify = require('..');
+const {objectContaining} = jasmine;
+
+function getFakeMap(): BasicSourceMap {
+  return {
+    version: 3,
+    sources: ['?'],
+    mappings: '',
+    names: [],
+  };
+}
+
+const baseOptions = {
+  code: '',
+  map: getFakeMap(),
+  filename: '',
+  reserved: [],
+  config: {},
+};
+
+describe('Minification:', () => {
+  const filename = '/arbitrary/file.js';
+  const code = 'arbitrary(code)';
+  let map: BasicSourceMap;
+  let terser;
+
+  beforeEach(() => {
+    terser = require('terser');
+    /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
+     * error found when Flow v0.99 was deployed. To see the error, delete this
+     * comment and run Flow. */
+    terser.minify.mockClear();
+    /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
+     * error found when Flow v0.99 was deployed. To see the error, delete this
+     * comment and run Flow. */
+    terser.minify.mockReturnValue({code: '', map: '{}'});
+    map = getFakeMap();
+  });
+
+  it('passes file name, code, and source map to `terser`', () => {
+    minify({
+      ...baseOptions,
+      code,
+      map,
+      filename,
+      config: {sourceMap: {includeSources: false}},
+    });
+    expect(terser.minify).toBeCalledWith(
+      code,
+      objectContaining({
+        sourceMap: {
+          content: map,
+          includeSources: false,
+        },
+      }),
+    );
+  });
+
+  it('returns the code provided by terser', () => {
+    /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
+     * error found when Flow v0.99 was deployed. To see the error, delete this
+     * comment and run Flow. */
+    terser.minify.mockReturnValue({code, map: '{}'});
+    const result = minify(baseOptions);
+    expect(result.code).toBe(code);
+  });
+
+  it('parses the source map object provided by terser and sets the sources property', () => {
+    /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
+     * error found when Flow v0.99 was deployed. To see the error, delete this
+     * comment and run Flow. */
+    terser.minify.mockReturnValue({map: JSON.stringify(map), code: ''});
+    const result = minify({...baseOptions, filename});
+    expect(result.map).toEqual({...map, sources: [filename]});
+  });
+});

--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "metro-minify-terser",
+  "version": "0.57.0",
+  "description": "🚇 Alternative minifier for Metro",
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/metro.git"
+  },
+  "scripts": {
+    "prepare-release": "test -d build && rm -rf src.real && mv src src.real && mv build src",
+    "cleanup-release": "test ! -e build && mv src build && mv src.real src"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "terser": "^4.6.3"
+  }
+}

--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metro-minify-terser",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "🚇 Alternative minifier for Metro",
   "main": "src/index.js",
   "repository": {

--- a/packages/metro-minify-terser/src/index.js
+++ b/packages/metro-minify-terser/src/index.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const minifier = require('./minifier');
+
+module.exports = minifier;

--- a/packages/metro-minify-terser/src/minifier.js
+++ b/packages/metro-minify-terser/src/minifier.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const terser = require('terser');
+
+import type {BasicSourceMap} from 'metro-source-map';
+import type {
+  MinifierResult,
+  MinifierOptions,
+} from 'metro/src/shared/types.flow.js';
+
+function minifier(options: MinifierOptions): MinifierResult {
+  const result = minify(options);
+
+  if (!options.map || result.map == null) {
+    return {code: result.code};
+  }
+
+  const map: BasicSourceMap = JSON.parse(result.map);
+
+  return {code: result.code, map: {...map, sources: [options.filename]}};
+}
+
+function minify({
+  code,
+  map,
+  reserved,
+  config,
+}: MinifierOptions): {code: string, map: ?string} {
+  const options = {
+    ...config,
+    mangle: {
+      ...config.mangle,
+      reserved,
+    },
+    sourceMap: map
+      ? {
+          ...config.sourceMap,
+          content: map,
+        }
+      : false,
+  };
+
+  /* $FlowFixMe(>=0.111.0 site=react_native_fb) This comment suppresses an
+   * error found when Flow v0.111 was deployed. To see the error, delete this
+   * comment and run Flow. */
+  const result = terser.minify(code, options);
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return {
+    code: result.code,
+    // eslint-disable-next-line lint/flow-no-fixme
+    // $FlowFixMe flow cannot coerce the uglify options after using spread.
+    map: result.map,
+  };
+}
+
+module.exports = minifier;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,6 +2102,11 @@ commander@^2.11.0, commander@^2.9.0, commander@~2.13.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
   integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
 
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
@@ -6705,6 +6710,14 @@ source-map-support@^0.5.6, source-map-support@^0.5.9:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map-support@~0.5.12:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -7036,6 +7049,15 @@ tempfile@^1.1.1:
   dependencies:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
+
+terser@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.3.tgz#e33aa42461ced5238d352d2df2a67f21921f8d87"
+  integrity sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
 
 test-exclude@^5.0.0:
   version "5.1.0"


### PR DESCRIPTION
**Summary**

This brings back `metro-minify-terser` which was removed because it wasn't used. Now to make sure it is used we'll make it the default.

`terser` is a fork of `uglify-es` which is not maintained. Updating this is required to remove es6 transforms since `uglify-es` currently crashes on in my app when not transforming es6. It would probably be possible to track down the bug but at this point it's probably easier and better long term to migrate to `terser`. It is now the default minifier for webpack and seem pretty stable.

**Test plan**

Tested in my app to make sure minifying works when disabling es6 transforms.