### PR TITLE
Set BABEL_ENV in output/bundle.js

### DIFF
--- a/packages/metro/src/shared/output/bundle.js
+++ b/packages/metro/src/shared/output/bundle.js
@@ -28,8 +28,8 @@ function buildBundle(
 }> {
   const OLD_BABEL_ENV = process.env.BABEL_ENV;
   process.env.BABEL_ENV = requestOptions.dev
-                        ? "development"
-                        : (process.env.BABEL_ENV || "production");
+                        ? 'development'
+                        : (process.env.BABEL_ENV || 'production');
   try {
     return packagerClient.build({
       ...Server.DEFAULT_BUNDLE_OPTIONS,

--- a/packages/metro/src/shared/output/bundle.js
+++ b/packages/metro/src/shared/output/bundle.js
@@ -35,7 +35,10 @@ function buildBundle(
     ...requestOptions,
     bundleType: 'bundle',
   })
-  .finally(res => {
+  .then(res => {
+    process.env.BABEL_ENV = OLD_BABEL_ENV;
+    return res;
+  }, res => {
     process.env.BABEL_ENV = OLD_BABEL_ENV;
     return res;
   });

--- a/packages/metro/src/shared/output/bundle.js
+++ b/packages/metro/src/shared/output/bundle.js
@@ -30,15 +30,15 @@ function buildBundle(
   process.env.BABEL_ENV = requestOptions.dev
     ? 'development'
     : process.env.BABEL_ENV || 'production';
-  try {
-    return packagerClient.build({
-      ...Server.DEFAULT_BUNDLE_OPTIONS,
-      ...requestOptions,
-      bundleType: 'bundle',
-    });
-  } finally {
+  return packagerClient.build({
+    ...Server.DEFAULT_BUNDLE_OPTIONS,
+    ...requestOptions,
+    bundleType: 'bundle',
+  })
+  .finally(res => {
     process.env.BABEL_ENV = OLD_BABEL_ENV;
-  }
+    return res;
+  });
 }
 
 function relativateSerializedMap(

--- a/packages/metro/src/shared/output/bundle.js
+++ b/packages/metro/src/shared/output/bundle.js
@@ -28,8 +28,8 @@ function buildBundle(
 }> {
   const OLD_BABEL_ENV = process.env.BABEL_ENV;
   process.env.BABEL_ENV = requestOptions.dev
-                        ? 'development'
-                        : (process.env.BABEL_ENV || 'production');
+    ? 'development'
+    : (process.env.BABEL_ENV || 'production');
   try {
     return packagerClient.build({
       ...Server.DEFAULT_BUNDLE_OPTIONS,

--- a/packages/metro/src/shared/output/bundle.js
+++ b/packages/metro/src/shared/output/bundle.js
@@ -30,18 +30,22 @@ function buildBundle(
   process.env.BABEL_ENV = requestOptions.dev
     ? 'development'
     : process.env.BABEL_ENV || 'production';
-  return packagerClient.build({
-    ...Server.DEFAULT_BUNDLE_OPTIONS,
-    ...requestOptions,
-    bundleType: 'bundle',
-  })
-  .then(res => {
-    process.env.BABEL_ENV = OLD_BABEL_ENV;
-    return res;
-  }, res => {
-    process.env.BABEL_ENV = OLD_BABEL_ENV;
-    return res;
-  });
+  return packagerClient
+    .build({
+      ...Server.DEFAULT_BUNDLE_OPTIONS,
+      ...requestOptions,
+      bundleType: 'bundle',
+    })
+    .then(
+      res => {
+        process.env.BABEL_ENV = OLD_BABEL_ENV;
+        return res;
+      },
+      res => {
+        process.env.BABEL_ENV = OLD_BABEL_ENV;
+        return res;
+      },
+    );
 }
 
 function relativateSerializedMap(

--- a/packages/metro/src/shared/output/bundle.js
+++ b/packages/metro/src/shared/output/bundle.js
@@ -26,11 +26,19 @@ function buildBundle(
   map: string,
   ...
 }> {
-  return packagerClient.build({
-    ...Server.DEFAULT_BUNDLE_OPTIONS,
-    ...requestOptions,
-    bundleType: 'bundle',
-  });
+  const OLD_BABEL_ENV = process.env.BABEL_ENV;
+  process.env.BABEL_ENV = requestOptions.dev
+                        ? "development"
+                        : (process.env.BABEL_ENV || "production");
+  try {
+    return packagerClient.build({
+      ...Server.DEFAULT_BUNDLE_OPTIONS,
+      ...requestOptions,
+      bundleType: 'bundle',
+    });
+  } finally {
+    process.env.BABEL_ENV = OLD_BABEL_ENV;
+  }
 }
 
 function relativateSerializedMap(

--- a/packages/metro/src/shared/output/bundle.js
+++ b/packages/metro/src/shared/output/bundle.js
@@ -29,7 +29,7 @@ function buildBundle(
   const OLD_BABEL_ENV = process.env.BABEL_ENV;
   process.env.BABEL_ENV = requestOptions.dev
     ? 'development'
-    : (process.env.BABEL_ENV || 'production');
+    : process.env.BABEL_ENV || 'production';
   try {
     return packagerClient.build({
       ...Server.DEFAULT_BUNDLE_OPTIONS,


### PR DESCRIPTION
First, let me apologize for the paucity of this pull request. I made this change as a patch on version 0.56.3, which is what got automatically installed for me in my react-native project. I thought I would submit it as this pull request just so someone who might know what they are doing on this project could see it, since my googling showed others who were hitting the same problem. I do not have the capacity right now to really become familiar enough with the code to be sure this is the right fix for the problem, nor to really test it thoroughly. If someone on the project wants it, great; if not and you ignore it, that's great, too. Again, my apologies.

When using metro from 'yarn android --variant=release' or 'yarn ios --variant=release', BABEL_ENV needs to be set to 'production' so that babel can find the right configuration in babel.config.js. I just copied the code from the other places in metro where this is done.

The only test I made was successfully running 'yarn android --variant=release' on my project, and then only on version 0.56.3.
