### PR TITLE
Move pretty-format to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "micromatch": "^2.3.11",
     "mkdirp": "^0.5.1",
     "prettier": "1.17.0",
-    "pretty-format": "^24.9.0",
     "progress": "^2.0.0",
     "promise": "^7.1.1",
     "temp": "^0.8.3"

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -17,10 +17,10 @@
     "jest-validate": "^24.9.0",
     "metro": "0.58.0",
     "metro-cache": "0.58.0",
-    "metro-core": "0.58.0",
-    "pretty-format": "^24.9.0"
+    "metro-core": "0.58.0"
   },
   "devDependencies": {
+    "pretty-format": "^24.9.0",
     "strip-ansi": "^4.0.0"
   }
 }


### PR DESCRIPTION
**Summary**

`pretty-format` is only used in tests, so there's no need for it to be included in dependencies.

**Test plan**

Green CI
