### PR TITLE
[Metro] update default blacklist

### DIFF
--- a/packages/metro-config/src/defaults/blacklist.js
+++ b/packages/metro-config/src/defaults/blacklist.js
@@ -18,6 +18,7 @@ var sharedBlacklist = [
   /website\/node_modules\/.*/,
   /heapCapture\/bundle\.js/,
   /.*\/__tests__\/.*/,
+  /.*\/(ios|android)\/.*\/build\/.*/
 ];
 
 function escapeRegExp(pattern) {


### PR DESCRIPTION
## Add ios/android build directories to blacklist
On windows rebuilding an app while metro is running causes both the build and metro to crash. 
This means that every time you rebuild your native code you need to restart metro and wait for it to complete bundling, which can be a nightmare when debugging native code.
This fixes this issues.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
