### PR TITLE
fix(android): Incorrect mapping of svg files

### DIFF
--- a/packages/metro/src/Bundler/util.js
+++ b/packages/metro/src/Bundler/util.js
@@ -148,7 +148,7 @@ function generateRemoteAssetCodeFileAst(
 // If it's not one of these, we won't treat it as an image.
 function isAssetTypeAnImage(type: string): boolean {
   return (
-    ['png', 'jpg', 'jpeg', 'bmp', 'gif', 'webp', 'psd', 'svg', 'tiff'].indexOf(
+    ['png', 'jpg', 'jpeg', 'bmp', 'gif', 'webp', 'psd', 'tiff'].indexOf(
       type,
     ) !== -1
   );


### PR DESCRIPTION
https://github.com/react-native-community/react-native-svg/issues/1306
https://github.com/react-native-community/cli/pull/1042
https://github.com/facebook/react-native/pull/28266

Summary:
---------

Fix mapping of svg files. They're currently bundled to the drawable folder incorrectly.


Test Plan:
----------

LocalSvg.js
```jsx
import React, {useState, useEffect} from 'react';
import {SvgCss} from 'react-native-svg';
import loadLocalResource from 'react-native-local-resource';

export function LocalSvg({asset, ...rest}) {
  const [xml, setXml] = useState(null);
  useEffect(() => {
    loadLocalResource(asset).then(setXml);
  }, [asset]);
  return <SvgCss xml={xml} {...rest} />;
}

```

App.js
```jsx
import React from 'react';
import {LocalSvg} from './LocalSvg';
export default () => <LocalSvg asset={require('./test.svg')} />;
```

test.svg: any svg content

The develop branch of react-native-svg contains an optimized version of LocalSvg, waiting to be released once this set of pull requests are merged.