### PR TITLE
Add react-native to resolverMainFields

### DIFF
--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -37,7 +37,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     platforms,
     sourceExts,
     dependencyExtractor: undefined,
-    resolverMainFields: ['browser', 'main'],
+    resolverMainFields: ['react-native', 'browser', 'main'],
     extraNodeModules: {},
     resolveRequest: null,
     hasteImplModulePath: undefined,


### PR DESCRIPTION
**Summary**

Sorry, if I do something stupid. As a creator of [`nanoid`](https://github.com/ai/nanoid/) and [`dual-publish`](https://github.com/ai/dual-publish/) I found `package.react-native` very useful to provide specific hacks to a unique React Native environment.

Unfortunately, I didn’t find the reason to remove it. Maybe it happened just because of migration to the config?

**Test plan**

I can add tests if you approved changes.
