### PR TITLE
[Fix] `DependencyGraph.resolveDependency` resolves to the same module when imported from `.`

### DIFF
--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -179,6 +179,39 @@ let resolver;
         );
       });
 
+      it('resolves shorthand syntax for relative index module', async () => {
+        setMockFileSystem({
+          'index.js': '',
+          'foo.js': '',
+        });
+
+        resolver = await createResolver();
+
+        expect(resolver.resolve(p('/root/foo.js'), '.')).toBe(
+          p('/root/index.js'),
+        );
+      });
+
+      it('resolves shorthand syntax for nested relative index module with resolution cache', async () => {
+        setMockFileSystem({
+          'index.js': '',
+          'foo.js': '',
+          folderA: {
+            'foo.js': '',
+            'index.js': '',
+          },
+        });
+
+        resolver = await createResolver();
+
+        expect(resolver.resolve(p('/root/foo.js'), '.')).toBe(
+          p('/root/index.js'),
+        );
+        expect(resolver.resolve(p('/root/folderA/foo.js'), '.')).toBe(
+          p('/root/folderA/index.js'),
+        );
+      });
+
       it('resolves custom extensions in the correct order', async () => {
         setMockFileSystem({
           'index.js': '',

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -244,7 +244,9 @@ class DependencyGraph extends EventEmitter {
     },
   ): string {
     const isPath =
-      to.includes('/') || from.includes(path.sep + 'node_modules' + path.sep);
+      to.includes('/') ||
+      to === '.' ||
+      from.includes(path.sep + 'node_modules' + path.sep);
     const mapByDirectory = getOrCreate(
       this._resolutionCache,
       isPath ? path.dirname(from) : '',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
**Summary**

When attempting to upgrade from v0.58.0 to v0.59.0, I discovered there was an issue with one bundle. I bisected the commits and found this PR first introduced the resolution cache: https://github.com/facebook/metro/commit/663d05ee5bd0eb15459fa694c5346ac84b0fc09c

As I investigate the dependency graph output between v0.58.0 and v0.59.0, I discovered that `DependencyGraph.resolveDependency` was having issue when an import statement such as `import Foo from '.';`. Here is a simple illustration of the issue, and this is also added as a test in the PR:

```
root
├── folderA
│   ├── index.js
│   └── foo.js
├── index.js   
└── foo.js   
```

If we were to resolve `.` from `foo.js` and `folderA/foo.js`, the resolutions would have been `index.js` and `folderA/index.js` respectively. Due to the new resolution cache logic, the second attempt at resolving `folderA/index.js` would have mapped to `index.js` instead. This was an issue due to the following logic:

https://github.com/facebook/metro/blob/f9a61e33c214d66a0a4c96fea1bb26e9e24e6db3/packages/metro/src/node-haste/DependencyGraph.js#L246-L247

`to` is not accounted for if it is `.` in this scenario.

While I'm writing the unit test and investigating how the resolution cache works, it turns out that even if we're resolving to the same thing it will still be considered as separate cache entry. Is this intended?

i.e.
```js
setMockFileSystem({
  'index.js': '',
  'foo.js': '',
  folderA: {
    'foo.js': '',
    'index.js': '',
  },
});

resolver = await createResolver();

expect(resolver.resolve(p('/root/foo.js'), '.')).toBe(
  p('/root/index.js'),
);
expect(resolver.resolve(p('/root/foo.js'), './index')).toBe(
  p('/root/index.js'),
);
expect(resolver.resolve(p('/root/foo.js'), './index.js')).toBe(
  p('/root/index.js'),
);
expect(resolver.resolve(p('/root/folderA/foo.js'), '.')).toBe(
  p('/root/folderA/index.js'),
);
expect(resolver.resolve(p('/root/folderA/foo.js'), './index')).toBe(
  p('/root/folderA/index.js'),
);
```


```
// `this._resolutionCache`
Map {
  '/root' => Map {
    '.' => Map { '' => '/root/index.js' },
    './index' => Map { '' => '/root/index.js' },
    './index.js' => Map { '' => '/root/index.js' } },
  '/root/folderA' => Map {
    '.' => Map { '' => '/root/folderA/index.js' },
    './index' => Map { '' => '/root/folderA/index.js' } } }
```


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
- Unit tests
- I have applied the fix to our code base and everything is happy again. The problematic dependency graph had ~10500 dependencies.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
