### PR TITLE
Add option to disable constantFoldingPlugin

### DIFF
--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -312,7 +312,7 @@ module.exports = {
       ]);
     }
 
-    if (!options.dev) {
+    if (!options.dev && !options.disableConstantFolding) {
       plugins.push([constantFoldingPlugin, opts]);
     }
 

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -89,6 +89,7 @@ export type {CustomTransformOptions} from 'metro-babel-transformer';
 export type JsTransformOptions = $ReadOnly<{|
   customTransformOptions?: CustomTransformOptions,
   dev: boolean,
+  disableConstantFolding: boolean,
   experimentalImportSupport?: boolean,
   hot: boolean,
   inlinePlatform: boolean,

--- a/packages/metro/src/IncrementalBundler.js
+++ b/packages/metro/src/IncrementalBundler.js
@@ -188,6 +188,7 @@ class IncrementalBundler {
     const transformOptionsWithoutType = {
       customTransformOptions: transformOptions.customTransformOptions,
       dev: transformOptions.dev,
+      disableConstantFolding: transformOptions.disableConstantFolding,
       experimentalImportSupport: transformOptions.experimentalImportSupport,
       hot: transformOptions.hot,
       minify: transformOptions.minify,


### PR DESCRIPTION
**Summary**

Constant folding breaks some already minified code.   

The current workaround is to patch the `worker.js` file to comment out 

```js
plugins.push([constantFoldingPlugin, opts]);
```

Adding an option to disable constantFoldingPlugin provides a configuration based solution.

Related issues:
#291 describes the problem this feature would resolve.
#550 is a request for an option to disable constantFoldingPlugin

**Test plan**

TBC
