### PR TITLE
allow defaultConfigOverrides to work with configModule function

### DIFF
--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -169,8 +169,10 @@ async function loadMetroConfigFromDisk(
   if (typeof configModule === 'function') {
     // Get a default configuration based on what we know, which we in turn can pass
     // to the function.
+    
+    const inputConfig = mergeConfig(defaultConfig, defaultConfigOverrides);
 
-    const resultedConfig = await configModule(defaultConfig);
+    const resultedConfig = await configModule(inputConfig);
     return resultedConfig;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I was attempting to write a custom config for a `react-native` project (mostly for cache control), so I set up my `metro.config.js` to look something like this:

```js
module.exports = async (defaultConfig) => ({
  ...defaultConfig,
  cacheStores: [
    new FileStore(/* config */),
	...defaultConfig.cacheStores,
  ],
});
```

However, when I did that, I got compilation errors because of `flow` syntax not being compiled away. `@react-native-community/cli` [passes in it's own default config](https://github.com/react-native-community/cli/blob/e7d694672a1d4021267c9eda378282f4c97c193a/packages/cli/src/tools/loadMetroConfig.ts) as overrides when calling `loadConfig`.

Unfortunately, these are silently thrown away when you set `metro.config.js` to export a function.

This is one option for a "fix" (this will make my code work, but may not be generally liked). Another would be:

```diff
- const resultedConfig = await configModule(defaultConfig);
+ const resultedConfig = await configModule(defaultConfig, defaultConfigOverrides);
```

That one would be backwards compatible, because wouldn't touch the default config for older `configModule`s, and newer ones could accept the second argument.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Unsure at this stage - if there is appetite for this change, I can look at adding tests.
