### PR TITLE
[Fix] `DependencyGraph.resolveDependency` resolves to the same module when imported from `..`

### DIFF
--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -179,6 +179,33 @@ let resolver;
         );
       });
 
+      it('resolves shorthand syntax for parent directory', async () => {
+        setMockFileSystem({
+          'index.js': '',
+          'foo.js': '',
+          folderA: {
+            'foo.js': '',
+            'index.js': '',
+            folderB: {
+              'foo.js': '',
+              'index.js': '',
+            },
+          },
+        });
+
+        resolver = await createResolver();
+
+        expect(resolver.resolve(p('/root/folderA/folderB/foo.js'), '..')).toBe(
+          p('/root/folderA/index.js'),
+        );
+        expect(
+          resolver.resolve(p('/root/folderA/folderB/index.js'), '..'),
+        ).toBe(p('/root/folderA/index.js'));
+        expect(resolver.resolve(p('/root/folderA/foo.js'), '..')).toBe(
+          p('/root/index.js'),
+        );
+      });
+
       it('resolves shorthand syntax for relative index module', async () => {
         setMockFileSystem({
           'index.js': '',

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -252,6 +252,7 @@ class DependencyGraph extends EventEmitter {
     const isPath =
       to.includes('/') ||
       to === '.' ||
+      to === '..' ||
       from.includes(path.sep + 'node_modules' + path.sep);
     const mapByDirectory = getOrCreate(
       this._resolutionCache,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This is a part 2 to what I didn't anticipate from the previous PR: https://github.com/facebook/metro/pull/540

Essentially the previous PR didn't also account for the usage of `..`, this fixes the issue.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
- CI
- Test against our code base.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
