### PR TITLE
[rn-babel-transformer]: use async transform

### DIFF
--- a/packages/metro-react-native-babel-transformer/src/index.js
+++ b/packages/metro-react-native-babel-transformer/src/index.js
@@ -72,6 +72,11 @@ const getBabelRC = (function() {
     }
 
     if (projectBabelRCPath) {
+      // babel.config.mjs
+      if (!fs.existsSync(projectBabelRCPath)) {
+        projectBabelRCPath = path.resolve(projectRoot, 'babel.config.mjs');
+      }
+      
       // .babelrc.js
       if (!fs.existsSync(projectBabelRCPath)) {
         projectBabelRCPath = path.resolve(projectRoot, '.babelrc.js');

--- a/packages/metro-react-native-babel-transformer/src/index.js
+++ b/packages/metro-react-native-babel-transformer/src/index.js
@@ -18,7 +18,7 @@ const inlineRequiresPlugin = require('babel-preset-fbjs/plugins/inline-requires'
 const makeHMRConfig = require('metro-react-native-babel-preset/src/configs/hmr');
 const path = require('path');
 
-const {parseSync, transformFromAstSync} = require('@babel/core');
+const {parseAsync, transformFromAstAsync} = require('@babel/core');
 const {generateFunctionMap} = require('metro-source-map');
 
 import type {Plugins as BabelPlugins} from '@babel/core';
@@ -161,7 +161,7 @@ function buildBabelConfig(filename, options, plugins?: BabelPlugins = []) {
   return Object.assign({}, babelRC, config);
 }
 
-function transform({filename, options, src, plugins}: BabelTransformerArgs) {
+async function transform({filename, options, src, plugins}: BabelTransformerArgs) {
   const OLD_BABEL_ENV = process.env.BABEL_ENV;
   process.env.BABEL_ENV = options.dev
     ? 'development'
@@ -175,11 +175,11 @@ function transform({filename, options, src, plugins}: BabelTransformerArgs) {
       caller: {name: 'metro', platform: options.platform},
       ast: true,
     };
-    const sourceAst = parseSync(src, babelConfig);
+    const sourceAst = await parseAsync(src, babelConfig);
     /* $FlowFixMe(>=0.111.0 site=react_native_fb) This comment suppresses an
      * error found when Flow v0.111 was deployed. To see the error, delete this
      * comment and run Flow. */
-    const result = transformFromAstSync(sourceAst, src, babelConfig);
+    const result = await transformFromAstAsync(sourceAst, src, babelConfig);
     const functionMap = generateFunctionMap(sourceAst, {filename});
 
     // The result from `transformFromAstSync` can be null (if the file is ignored)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This change allows Babel to be configured using "babel.config.mjs", with native ES5 imports in Node.js >= 13. There is no impact if a project is still configured using "babel.config.js" or any other sync configuration.

**Test plan**

1. I reset Metro cache and succesfully recompiled the project a few times using a "babel.config.mjs" with a few native ESM custom plugins imported using standard import declarations.

2. I removed my "babel.config.mjs" file, and reverted back to the default babel.config.js supplied by React Native. I then cleared the metro cache (confirmed via the notice message) and recompiled the project several times successfully.