### PR TITLE
Added bundler property to babel caller

### DIFF
--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -65,7 +65,7 @@ function transform({filename, options, plugins, src}: BabelTransformerArgs) {
 
   try {
     const babelConfig = {
-      caller: {name: 'metro', platform: options.platform},
+      caller: {name: 'metro', bundler: 'metro', platform: options.platform},
       ast: true,
       babelrc: options.enableBabelRCLookup,
       code: false,

--- a/packages/metro-react-native-babel-transformer/src/index.js
+++ b/packages/metro-react-native-babel-transformer/src/index.js
@@ -172,7 +172,7 @@ function transform({filename, options, src, plugins}: BabelTransformerArgs) {
       // ES modules require sourceType='module' but OSS may not always want that
       sourceType: 'unambiguous',
       ...buildBabelConfig(filename, options, plugins),
-      caller: {name: 'metro', platform: options.platform},
+      caller: {name: 'metro', bundler: 'metro', platform: options.platform},
       ast: true,
     };
     const sourceAst = parseSync(src, babelConfig);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`name` is set to `babel-loader` in Webpack but certain tools use custom babel loaders which makes the `name` field an unpredictable property for detecting what bundler is being used. 

Adding a bundler property to every loader will help make this more distinguishable.

Expo currently does this in the `@expo/webpack-config` ([here](https://github.com/expo/expo-cli/blob/098b38a37a4271c8401a20e4a65340b01485adf2/packages/webpack-config/src/loaders/createBabelLoader.ts#L206-L207)) as a way of configuring the babel preset to tree-shake unused `react-native-web` code. 

We'd like to move away from using `babel-loader` in favor of using this new `bundler` property so more free form configurations like "Metro + react-native-web" can be easily configurable https://github.com/expo/expo/pull/8170
