### PR TITLE
Pass config overrides to metro.config.js function

### DIFF
--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -47,7 +47,7 @@ describe('loadConfig', () => {
       reporter: null,
       maxWorkers: 2,
       resolver: {
-        ...defaultConfig.resolver,
+        sourceExts: [...defaultConfig.resolver.sourceExts, 'tsx'],
         hasteImplModulePath: 'test',
       },
       transformerPath: '',
@@ -55,9 +55,19 @@ describe('loadConfig', () => {
 
     cosmiconfig.setResolvedConfig(config);
 
-    const result = await loadConfig({});
+    const defaultConfigOverrides = {
+      resolver: {
+        sourceExts: ['json', 're'],
+      },
+    };
 
-    expect(result.resolver.hasteImplModulePath).toEqual('test');
+    const result = await loadConfig({}, defaultConfigOverrides);
+    const defaults = await getDefaultConfig();
+    expect(result.resolver).toMatchObject({
+      assetExts: defaults.resolver.assetExts,
+      sourceExts: ['json', 're', 'tsx'],
+      hasteImplModulePath: 'test',
+    });
   });
 
   it('can load the config with a path', async () => {

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -164,17 +164,18 @@ async function loadMetroConfigFromDisk(
   const {config: configModule, filepath} = resolvedConfigResults;
   const rootPath = dirname(filepath);
 
-  const defaultConfig: ConfigT = await getDefaultConfig(rootPath);
+  const defaults = await getDefaultConfig(rootPath);
+  const defaultConfig: ConfigT = mergeConfig(defaults, defaultConfigOverrides);
 
   if (typeof configModule === 'function') {
     // Get a default configuration based on what we know, which we in turn can pass
     // to the function.
 
     const resultedConfig = await configModule(defaultConfig);
-    return resultedConfig;
+    return mergeConfig(defaultConfig, resultedConfig);
   }
 
-  return mergeConfig(defaultConfig, defaultConfigOverrides, configModule);
+  return mergeConfig(defaultConfig, configModule);
 }
 
 function overrideConfigWithArguments(


### PR DESCRIPTION
**Summary**

Merge `defaultConfigOverrides` to the default config passed to the config function defined in `metro.config.js`.

This PR, when merged will allow overriding fields using a config function, like this:
```js
// metro.config.js
module.exports = defaultConfig => ({
  resolver: {
    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
  },
});
```
The result will be merged to the defaults and the function is also passed `defaultConfig`, which includes defaults from Metro and any `defaultConfigOverrides` specified by tools like RN CLI.

**Background**

It's already been possible to define the Metro configuration as a function in `metro.config.js`, making it simpler to have a config that somehow depends on the default config. However this has previously had a couple of gotchas:

1. The function is passed the default configuration with the `defaultConfig` argument. However, this argument ignores the `defaultConfigOverrides` that are used, for example, by `@react-native-community/cli` and `expo-cli` to override some configuration values.
2. Unlike with the plain object config, the result from the config function is also not merged with the Metro defaults or `defaultConfigOverrides`, meaning that you must remember to manually spread the Metro defaults into the config (including all nested arrays/objects) and that the overrides set by `@react-native-community/cli` are discarded when using a config function.
```js
// metro.config.js
module.exports = (
  defaultConfig // Metro defaults only, RN CLI and Expo CLI defaults are ignored.
) => ({
  ...defaultConfig, // Spread required here.
  resolver: {
    ...defaultConfig.resolver, // Spread required here.
    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
  },
});
```
When you try to modify a single config value and as a result unrelated defaults get dropped, it doesn't follow the principle of least surprise.

The current workaround is to avoid the config function and use a plain object instead, and import the RN CLI / Expo CLI defaults from another package, [for example `@expo/metro-config`](https://docs.expo.io/guides/customizing-metro/#adding-more-file-extensions-to-assetexts):
```js
const { getDefaultConfig } = require('@expo/metro-config');

const defaultConfig = getDefaultConfig(__dirname);

module.exports = {
  resolver: {
    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
  },
};
```
However, compared to the config function approach, this is less convenient as it you must install an additional package, use the correct version and keep it up to date, and it will vary for each tool / config preset. Also, unless the custom config package also includes all defaults from Metro, you must import the defaults from two packages the custom config and `metro-config` and for each config field know which one it's defined in.

**Test plan**

Modified the test case in `loadConfig-test.js` to test that:
- the config function can extend a value coming from `defaultConfigOverrides`
- the result of the config function is merged with the Metro defaults, even if it's not done manually

Verified that tests pass.
