### PR TITLE
Prevent unhandled rejection with `buildCodeFrameMessage`

### DIFF
--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -316,7 +316,7 @@ class UnableToResolveError extends Error {
     try {
       file = fs.readFileSync(this.originModulePath, 'utf8');
     } catch (error) {
-      if (error.code === 'ENOENT') {
+      if (error.code === 'ENOENT' || error.code === 'EISDIR') {
         // We're probably dealing with a virtualised file system where
         // `this.originModulePath` doesn't actually exist on disk.
         // We can't show a code frame, but there's no need to let this I/O


### PR DESCRIPTION
We encounter regular resolution issue but was not captured by throwing
proper resolution error, this handles the specific case we're seeing.

```
(node:309) UnhandledPromiseRejectionWarning: Error: EISDIR: illegal operation on a directory, read
    at Object.readSync (fs.js:498:3)
    at tryReadSync (fs.js:332:20)
    at Object.readFileSync (fs.js:369:19)
    at UnableToResolveError.buildCodeFrameMessage 
```

Ever since upgraded, we've seen the above error messages representing in fact an actual resolution error that should have been represented by `Unable to resolve module %s from %s: %s` messages.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
- CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
