### PR TITLE
metro-source-map: propagate sourcesContent when composing source maps

### DIFF
--- a/packages/metro-source-map/src/Consumer/AbstractConsumer.js
+++ b/packages/metro-source-map/src/Consumer/AbstractConsumer.js
@@ -54,9 +54,13 @@ class AbstractConsumer implements IConsumer {
     }
   }
 
-  // flowlint unsafe-getters-setters:off
+  // flowlint-next-line unsafe-getters-setters:off
   get file(): ?string {
     return this._sourceMap.file;
+  }
+
+  sourceContentFor(source: string, nullOnMissing: true): ?string {
+    invariant(false, 'Not implemented');
   }
 }
 

--- a/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
+++ b/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
@@ -64,9 +64,13 @@ class DelegatingConsumer implements IConsumer {
     return this._rootConsumer.eachMapping(callback, context, order);
   }
 
-  // flowlint unsafe-getters-setters:off
+  // flowlint-next-line unsafe-getters-setters:off
   get file(): ?string {
     return this._rootConsumer.file;
+  }
+
+  sourceContentFor(source: string, nullOnMissing: true): ?string {
+    return this._rootConsumer.sourceContentFor(source, nullOnMissing);
   }
 }
 

--- a/packages/metro-source-map/src/Consumer/MappingsConsumer.js
+++ b/packages/metro-source-map/src/Consumer/MappingsConsumer.js
@@ -33,6 +33,7 @@ import type {
   Mapping,
   IConsumer,
 } from './types.flow';
+import type {Number0} from 'ob1';
 
 /**
  * A source map consumer that supports "basic" source maps (that have a
@@ -191,6 +192,28 @@ class MappingsConsumer extends AbstractConsumer implements IConsumer {
 
   generatedMappings(): Iterable<Mapping> {
     return this._decodeAndCacheMappings();
+  }
+
+  _indexOfSource(source: string): ?Number0 {
+    const idx = this._normalizeAndCacheSources().indexOf(
+      normalizeSourcePath(source, this._sourceMap),
+    );
+    if (idx === -1) {
+      return null;
+    }
+    return add0(idx);
+  }
+
+  sourceContentFor(source: string, nullOnMissing: true): ?string {
+    const {sourcesContent} = this._sourceMap;
+    if (!sourcesContent) {
+      return null;
+    }
+    const idx = this._indexOfSource(source);
+    if (idx == null) {
+      return null;
+    }
+    return sourcesContent[get0(idx)] ?? null;
   }
 }
 

--- a/packages/metro-source-map/src/Consumer/SectionsConsumer.js
+++ b/packages/metro-source-map/src/Consumer/SectionsConsumer.js
@@ -111,6 +111,16 @@ class SectionsConsumer extends AbstractConsumer implements IConsumer {
     );
     return index != null ? this._consumers[index] : null;
   }
+
+  sourceContentFor(source: string, nullOnMissing: true): ?string {
+    for (const [_, consumer] of this._consumers) {
+      const content = consumer.sourceContentFor(source, nullOnMissing);
+      if (content != null) {
+        return content;
+      }
+    }
+    return null;
+  }
 }
 
 module.exports = SectionsConsumer;

--- a/packages/metro-source-map/src/Consumer/types.flow.js
+++ b/packages/metro-source-map/src/Consumer/types.flow.js
@@ -59,6 +59,12 @@ export interface IConsumer {
     order?: IterationOrder,
   ): void;
 
-  // flowlint unsafe-getters-setters:off
+  // flowlint-next-line unsafe-getters-setters:off
   get file(): ?string;
+
+  sourceContentFor(
+    source: string,
+    /* nullOnMissing = false behaves inconsistently upstream, so we don't support it */
+    nullOnMissing: true,
+  ): ?string;
 }

--- a/packages/metro-source-map/src/__tests__/Consumer-test.js
+++ b/packages/metro-source-map/src/__tests__/Consumer-test.js
@@ -194,6 +194,51 @@ describe('basic maps', () => {
       `);
     });
   });
+
+  describe('sourceContentFor', () => {
+    test('missing sourcesContent', () => {
+      const consumer = new Consumer({
+        version: 3,
+        mappings: '',
+        names: [],
+        sources: [],
+      });
+      expect(consumer.sourceContentFor('a.js', true)).toBeNull();
+    });
+
+    test('null in sourcesContent', () => {
+      const consumer = new Consumer({
+        version: 3,
+        mappings: '',
+        names: [],
+        sources: ['a.js'],
+        sourcesContent: [null],
+      });
+      expect(consumer.sourceContentFor('a.js', true)).toBeNull();
+    });
+
+    test('sourcesContent too short', () => {
+      const consumer = new Consumer({
+        version: 3,
+        mappings: '',
+        names: [],
+        sources: ['a.js'],
+        sourcesContent: [],
+      });
+      expect(consumer.sourceContentFor('a.js', true)).toBeNull();
+    });
+
+    test('string in sourcesContent', () => {
+      const consumer = new Consumer({
+        version: 3,
+        mappings: '',
+        names: [],
+        sources: ['a.js'],
+        sourcesContent: ['content of a.js'],
+      });
+      expect(consumer.sourceContentFor('a.js', true)).toBe('content of a.js');
+    });
+  });
 });
 
 describe('indexed (sectioned) maps', () => {
@@ -372,6 +417,64 @@ describe('indexed (sectioned) maps', () => {
           "source": "section2_source0",
         }
       `);
+    });
+  });
+
+  describe('sourceContentFor', () => {
+    test('empty map', () => {
+      const consumer = new Consumer({
+        version: 3,
+        sections: [],
+      });
+      expect(consumer.sourceContentFor('a.js', true)).toBeNull();
+    });
+
+    test('found in section', () => {
+      const consumer = new Consumer({
+        version: 3,
+        sections: [
+          {
+            offset: {line: 0, column: 0},
+            map: {
+              version: 3,
+              mappings: '',
+              names: [],
+              sources: ['a.js'],
+              sourcesContent: ['content of a.js'],
+            },
+          },
+        ],
+      });
+      expect(consumer.sourceContentFor('a.js', true)).toBe('content of a.js');
+    });
+
+    test('found in multiple sections', () => {
+      const consumer = new Consumer({
+        version: 3,
+        sections: [
+          {
+            offset: {line: 0, column: 0},
+            map: {
+              version: 3,
+              mappings: '',
+              names: [],
+              sources: ['a.js'],
+              sourcesContent: [null],
+            },
+          },
+          {
+            offset: {line: 1, column: 0},
+            map: {
+              version: 3,
+              mappings: '',
+              names: [],
+              sources: ['a.js'],
+              sourcesContent: ['content of a.js'],
+            },
+          },
+        ],
+      });
+      expect(consumer.sourceContentFor('a.js', true)).toBe('content of a.js');
     });
   });
 });

--- a/packages/metro-source-map/src/__tests__/composeSourceMaps-test.js
+++ b/packages/metro-source-map/src/__tests__/composeSourceMaps-test.js
@@ -156,6 +156,40 @@ describe('composeSourceMaps', () => {
     ]);
   });
 
+  it('preserves sourcesContent', () => {
+    const map1 = {
+      version: 3,
+      sections: [
+        {
+          offset: {line: 0, column: 0},
+          map: {
+            version: 3,
+            sources: ['1.js', '2.js'],
+            sourcesContent: ['content of 1.js', 'content of 2.js'],
+            names: [],
+            // One column from 2.js, one column from 1.js
+            mappings: 'ACAA,CDAA',
+          },
+        },
+      ],
+    };
+
+    const map2 = {
+      version: 3,
+      sources: ['transformed.js'],
+      names: [],
+      // Two consecutive columns from transformed.js
+      mappings: 'AAAA,CAAC',
+    };
+
+    const mergedMap = composeSourceMaps([map1, map2]);
+
+    expect(mergedMap.sourcesContent).toEqual([
+      'content of 2.js',
+      'content of 1.js',
+    ]);
+  });
+
   it('merges two maps', () => {
     const mergedMap = composeSourceMaps([
       fixtures['1.json'],

--- a/packages/metro-source-map/src/composeSourceMaps.js
+++ b/packages/metro-source-map/src/composeSourceMaps.js
@@ -66,6 +66,12 @@ function composeSourceMaps(
 
   const composedMap = generator.toJSON();
 
+  composedMap.sourcesContent = composedMap.sources.map(source =>
+    consumers[consumers.length - 1].sourceContentFor(source, true),
+  );
+  if (composedMap.sourcesContent.every(content => content == null)) {
+    delete composedMap.sourcesContent;
+  }
   const metadataConsumer = new SourceMetadataMapConsumer(firstMap);
   composedMap.x_facebook_sources = metadataConsumer.toArray(
     composedMap.sources,

--- a/packages/metro-source-map/src/source-map.js
+++ b/packages/metro-source-map/src/source-map.js
@@ -74,11 +74,12 @@ export type IndexMapSection = {
 export type IndexMap = {|
   +file?: string,
   +mappings?: void, // avoids SourceMap being a disjoint union
+  +sourcesContent?: void,
   +sections: Array<IndexMapSection>,
   +version: number,
   +x_facebook_offsets?: Array<number>,
   +x_metro_module_paths?: Array<string>,
-  +x_facebook_sources?: FBSourcesArray,
+  +x_facebook_sources?: void,
   +x_facebook_segments?: FBSegmentMap,
   +x_hermes_function_offsets?: HermesFunctionOffsets,
 |};


### PR DESCRIPTION
Summary:
* Implements the `sourceContentFor` API from `source-map` in Metro's `Consumer`.
* Copies source contents in `composeSourceMaps` if they exist.

Related issues: https://github.com/facebook/react-native/issues/26086, https://github.com/facebook/hermes/issues/85. We'll be able to close the RN issue once this lands in the version of `metro-source-map` used in RN master.

Differential Revision: D22284159

