### PR TITLE
Rename inlineRequires.blacklist -> blockList

### DIFF
--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -53,7 +53,7 @@ type ExtraTransformOptions = {
   +ramGroups: Array<string>,
   +transform: {|
     +experimentalImportSupport: boolean,
-    +inlineRequires: {+blacklist: {[string]: true, ...}, ...} | boolean,
+    +inlineRequires: {+blockList: {[string]: true, ...}, ...} | boolean,
     +nonInlinedRequires?: $ReadOnlyArray<string>,
     +unstable_disableES6Transforms?: boolean,
   |},

--- a/packages/metro/src/Bundler/util.js
+++ b/packages/metro/src/Bundler/util.js
@@ -47,7 +47,7 @@ type SubTree<T: ModuleTransportLike> = (
   moduleTransportsByPath: Map<string, T>,
 ) => Iterable<number>;
 
-const assetPropertyBlacklist = new Set(['files', 'fileSystemLocation', 'path']);
+const assetPropertyBlockList = new Set(['files', 'fileSystemLocation', 'path']);
 
 function generateAssetCodeFileAst(
   assetRegistryPath: string,
@@ -55,7 +55,7 @@ function generateAssetCodeFileAst(
 ): Ast {
   const properDescriptor = filterObject(
     assetDescriptor,
-    assetPropertyBlacklist,
+    assetPropertyBlockList,
   );
 
   // {...}
@@ -153,10 +153,10 @@ function isAssetTypeAnImage(type: string): boolean {
 
 function filterObject(
   object: AssetDataWithoutFiles,
-  blacklist: Set<string>,
+  blockList: Set<string>,
 ): AssetDataFiltered {
   const copied = Object.assign({}, object);
-  for (const key of blacklist) {
+  for (const key of blockList) {
     delete copied[key];
   }
   return copied;

--- a/packages/metro/src/lib/transformHelpers.js
+++ b/packages/metro/src/lib/transformHelpers.js
@@ -18,7 +18,7 @@ import type DeltaBundler, {TransformFn} from '../DeltaBundler';
 import type {ConfigT} from 'metro-config/src/configTypes.flow';
 import type {Type} from 'metro-transform-worker';
 
-type InlineRequiresRaw = {+blacklist: {[string]: true, ...}, ...} | boolean;
+type InlineRequiresRaw = {+blockList: {[string]: true, ...}, ...} | boolean;
 
 export type TransformInputOptions = $Diff<
   TransformOptions,
@@ -99,12 +99,12 @@ async function calcTransformerOptions(
   };
 }
 
-function removeInlineRequiresBlacklistFromOptions(
+function removeInlineRequiresBlockListFromOptions(
   path: string,
   inlineRequires: InlineRequiresRaw,
 ): boolean {
   if (typeof inlineRequires === 'object') {
-    return !(path in inlineRequires.blacklist);
+    return !(path in inlineRequires.blockList);
   }
 
   return inlineRequires;
@@ -129,7 +129,7 @@ async function getTransformFn(
     return await bundler.transformFile(path, {
       ...transformOptions,
       type: getType(transformOptions.type, path, config.resolver.assetExts),
-      inlineRequires: removeInlineRequiresBlacklistFromOptions(
+      inlineRequires: removeInlineRequiresBlockListFromOptions(
         path,
         inlineRequires,
       ),

--- a/packages/metro/src/shared/output/__tests__/__snapshots__/meta-test.js.snap
+++ b/packages/metro/src/shared/output/__tests__/__snapshots__/meta-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`exports the blacklist creator 1`] = `
+exports[`exports the block list creator 1`] = `
 Object {
   "data": Array [
     56,

--- a/packages/metro/src/shared/output/__tests__/meta-test.js
+++ b/packages/metro/src/shared/output/__tests__/meta-test.js
@@ -13,6 +13,6 @@
 
 const meta = require('../meta');
 
-it('exports the blacklist creator', () => {
+it('exports the block list creator', () => {
   expect(meta('some formatted code', 'utf8')).toMatchSnapshot();
 });


### PR DESCRIPTION
Summary: Renames the Metro `transform.inlineRequires.blacklist` option to `blockList`.

Differential Revision: D23709132

