### PR TITLE
Update Configuration.md

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -59,8 +59,8 @@ The root folder of your project.
 
 Type: `Array<string>`
 
-Specify any additional (to projectRoot) watch folders, this is used to know which files to watch.
-(By default the file watching is disabled in CI environments. Also it can be manually disabled by setting the env variable `CI=true`)
+Specify any additional (to projectRoot) watch folders, this is used to know which files to watch. The code within those folders would be considered a part of your source files - it will be transformed and bundled. 
+(By default the file watching is disabled in CI environments (But the folders are still bundled). Also it can be manually disabled by setting the env variable `CI=true`)
 
 #### `transformerPath`
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -59,8 +59,7 @@ The root folder of your project.
 
 Type: `Array<string>`
 
-Specify any additional (to projectRoot) watch folders, this is used to know which files to watch. The code within those folders would be considered a part of your source files - it will be transformed and bundled. 
-(By default the file watching is disabled in CI environments (But the folders are still bundled). Also it can be manually disabled by setting the env variable `CI=true`)
+Specify watch folders additional to `projectRoot`. This is used to know which files to watch as the files within those folders are considered source files that will be transformed and bundled. (By default the file watching is disabled in CI environments. It can be manually disabled by setting the env variable `CI=true`)
 
 #### `transformerPath`
 


### PR DESCRIPTION
Having `watchFolders` along with `extraNodeModules` options, led us to believe `watchFolders` are there only to signal when to rebuild and you need to also include them in `extraNodeModules` if you want them in your bundle. which is, as far as i understand, not correct. so i suggest this clarification. if you can confirm the clarifications are correct, please add them to the docs.