### PR TITLE
Add transformProfile `jsc-ios10.3`

### DIFF
--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -24,7 +24,11 @@ export type CustomTransformOptions = {
   ...
 };
 
-export type TransformProfile = 'default' | 'hermes-stable' | 'hermes-canary';
+export type TransformProfile =
+  | 'default'
+  | 'hermes-stable'
+  | 'hermes-canary'
+  | 'jsc-ios10.3';
 
 type BabelTransformerOptions = $ReadOnly<{
   customTransformOptions?: CustomTransformOptions,

--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -31,6 +31,7 @@
     "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
     "@babel/plugin-syntax-optional-chaining": "^7.0.0",
     "@babel/plugin-transform-arrow-functions": "^7.0.0",
+    "@babel/plugin-transform-async-to-generator": "^7.0.0",
     "@babel/plugin-transform-block-scoping": "^7.0.0",
     "@babel/plugin-transform-classes": "^7.0.0",
     "@babel/plugin-transform-computed-properties": "^7.0.0",
@@ -55,6 +56,7 @@
     "@babel/plugin-transform-template-literals": "^7.0.0",
     "@babel/plugin-transform-typescript": "^7.5.0",
     "@babel/plugin-transform-unicode-regex": "^7.0.0",
+    "@babel/preset-modules": "^0.1.2",
     "@babel/template": "^7.0.0",
     "react-refresh": "^0.4.0"
   },

--- a/packages/metro-react-native-babel-preset/src/__tests__/getPreset-test.js
+++ b/packages/metro-react-native-babel-preset/src/__tests__/getPreset-test.js
@@ -1,0 +1,41 @@
+const main = require('../configs/main');
+const getPreset = main.getPreset;
+
+const transformBlockScoping = require('@babel/plugin-transform-block-scoping');
+const transformTemplateLiterals = require('@babel/plugin-transform-template-literals');
+const transformRegenerator = require('@babel/plugin-transform-regenerator');
+
+describe('getPreset', () => {
+  const baseOptions = {
+    enableBabelRuntime: true,
+  };
+
+  it('returns default plugins', () => {
+    const preset = getPreset(null, baseOptions);
+
+    const defaultPlugins = preset.overrides[1].plugins;
+    const extraPlugins = preset.overrides[4].plugins;
+
+    expect(defaultPlugins.length).toBe(16);
+    expect(extraPlugins.length).toBe(16);
+
+    expect(defaultPlugins.some(plugin => plugin[0] === transformBlockScoping)).toBe(true);
+    expect(defaultPlugins.some(plugin => plugin[0] === transformRegenerator)).toBe(true);
+    expect(extraPlugins.some(plugin => plugin[0] === transformTemplateLiterals)).toBe(true);
+  });
+
+  it('returns optimized plugins for transformProfile "jsc-ios10.3"', () => {
+    const options = {unstable_transformProfile: 'jsc-ios10.3'};
+    const preset = getPreset(null, {...baseOptions, ...options});
+
+    const defaultPlugins = preset.overrides[1].plugins;
+    const extraPlugins = preset.overrides[4].plugins;
+
+    expect(defaultPlugins.length).toBe(10);
+    expect(extraPlugins.length).toBe(9);
+
+    expect(defaultPlugins.some(plugin => plugin[0] === transformBlockScoping)).toBe(false);
+    expect(defaultPlugins.some(plugin => plugin[0] === transformRegenerator)).toBe(false);
+    expect(extraPlugins.some(plugin => plugin[0] === transformTemplateLiterals)).toBe(false);
+  });
+});

--- a/packages/metro-react-native-babel-preset/src/__tests__/getPreset-test.js
+++ b/packages/metro-react-native-babel-preset/src/__tests__/getPreset-test.js
@@ -16,8 +16,8 @@ describe('getPreset', () => {
     const defaultPlugins = preset.overrides[1].plugins;
     const extraPlugins = preset.overrides[4].plugins;
 
-    expect(defaultPlugins.length).toBe(16);
-    expect(extraPlugins.length).toBe(16);
+    expect(defaultPlugins.length).toBe(15);
+    expect(extraPlugins.length).toBe(17);
 
     expect(defaultPlugins.some(plugin => plugin[0] === transformBlockScoping)).toBe(true);
     expect(defaultPlugins.some(plugin => plugin[0] === transformRegenerator)).toBe(true);

--- a/packages/metro-react-native-babel-preset/src/configs/filter-es2015.js
+++ b/packages/metro-react-native-babel-preset/src/configs/filter-es2015.js
@@ -1,0 +1,80 @@
+/**
+ * See "https://github.com/babel/babel/blob/master/packages/babel-compat-data/data/plugins.json"
+ */
+const es2015Plugins = [
+  require('@babel/plugin-transform-arrow-functions'), // iOS 10
+  require('@babel/plugin-transform-classes'), // iOS 10
+  require('@babel/plugin-transform-computed-properties'), // iOS 8
+  require('@babel/plugin-transform-destructuring'), // iOS 10
+  require('@babel/plugin-transform-function-name'), // iOS 10
+  require('@babel/plugin-transform-literals'), // iOS 9
+  require('@babel/plugin-transform-parameters'), // iOS 10
+  require('@babel/plugin-transform-sticky-regex'), // iOS 10
+  require('@babel/plugin-transform-for-of'), // iOS 10
+  require('@babel/plugin-transform-shorthand-properties'), // iOS 9
+  require('@babel/plugin-transform-spread'), // iOS 10
+  require('@babel/plugin-transform-object-assign'), // iOS 10
+  require('@babel/plugin-transform-exponentiation-operator'), // iOS 10.3
+];
+
+/**
+ * Safari ~11 has an issue where variable declarations in a For statement throw if they shadow parameters.
+ * This is fixed by renaming any declarations in the left/init part of a For* statement so they don't shadow.
+ * @see https://bugs.webkit.org/show_bug.cgi?id=171041
+ *
+ * @example
+ *   e => { for (let e of []) e }   // throws
+ *   e => { for (let _e of []) _e }   // works
+ */
+const transformBlockScoping = require('@babel/plugin-transform-block-scoping');
+const safariForShadowing = require('@babel/preset-modules/lib/plugins/transform-safari-for-shadowing');
+
+/**
+ * Converts destructured parameters with default values to non-shorthand syntax.
+ * This fixes the only Tagged Templates-related bug in ES Modules-supporting browsers (Safari 10 & 11).
+ * Use this plugin instead of `@babel/plugin-transform-template-literals` when targeting ES Modules.
+ *
+ * @example
+ *   // Bug 1: Safari 10/11 doesn't reliably return the same Strings value.
+ *   // The value changes depending on invocation and function optimization state.
+ *   function f() { return Object`` }
+ *   f() === new f()  // false, should be true.
+ *
+ * @example
+ *   // Bug 2: Safari 10/11 use the same cached strings value when the string parts are the same.
+ *   // This behavior comes from an earlier version of the spec, and can cause tricky bugs.
+ *   Object``===Object``  // true, should be false.
+ */
+const transformTemplateLiterals = require('@babel/plugin-transform-template-literals');
+const taggedTemplateCaching = require('@babel/preset-modules/lib/plugins/transform-tagged-template-caching');
+
+/**
+ * JavaScriptCore implements generator functions, so we replace the regenerator runtime
+ * with the `async-to-generator` transform.
+ */
+const transformRegenerator = require('@babel/plugin-transform-regenerator');
+const transformAsyncToGenerator = require('@babel/plugin-transform-async-to-generator');
+const transformRuntime = require('@babel/plugin-transform-runtime');
+
+function isNeeededForES2015([plugin]) {
+  return !es2015Plugins.includes(plugin);
+}
+
+function filterES2015Plugins(plugins) {
+  const updatedPlugins = plugins.filter(isNeeededForES2015).map(plugin => {
+    if (plugin[0] === transformBlockScoping) {
+      return [safariForShadowing];
+    } else if (plugin[0] === transformTemplateLiterals) {
+      return [taggedTemplateCaching];
+    } else if (plugin[0] === transformRegenerator) {
+      return [transformAsyncToGenerator];
+    } else if (plugin[0] === transformRuntime) {
+      return [transformRuntime, {helpers: true, regenerator: false}];
+    } else {
+      return plugin;
+    }
+  });
+  return updatedPlugins;
+}
+
+module.exports = filterES2015Plugins;

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+const filterES2015Plugins = require('./filter-es2015');
 const lazyImports = require('./lazy-imports');
 const passthroughSyntaxPlugins = require('../passthrough-syntax-plugins');
 
@@ -20,7 +21,7 @@ function isTSXSource(fileName) {
   return !!fileName && fileName.endsWith('.tsx');
 }
 
-const defaultPlugins = [
+const defaultPluginsList = [
   [require('@babel/plugin-syntax-flow')],
   [require('@babel/plugin-proposal-optional-catch-binding')],
   [require('@babel/plugin-transform-block-scoping')],
@@ -100,7 +101,8 @@ const getPreset = (src, options) => {
   const hasForOf =
     isNull || (src.indexOf('for') !== -1 && src.indexOf('of') !== -1);
 
-  const extraPlugins = [];
+  let defaultPlugins = defaultPluginsList;
+  let extraPlugins = [];
   if (!options.useTransformReactJSXExperimental) {
     extraPlugins.push([require('@babel/plugin-transform-react-jsx')]);
   }
@@ -174,6 +176,11 @@ const getPreset = (src, options) => {
 
   if (!options || options.enableBabelRuntime !== false) {
     extraPlugins.push(babelRuntime);
+  }
+
+  if (transformProfile === 'jsc-ios10.3') {
+    defaultPlugins = filterES2015Plugins(defaultPlugins);
+    extraPlugins = filterES2015Plugins(extraPlugins);
   }
 
   return {

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -451,6 +451,16 @@ module.exports = {
     let map = result.rawMappings ? result.rawMappings.map(toSegmentTuple) : [];
     let code = result.code;
 
+    // Make the minifier aware of the modern JS syntax
+    if (options.minify && options.unstable_transformProfile === 'jsc-ios10.3') {
+      const minifierConfig = {
+        ...config.minifierConfig,
+        ecma: 2015,
+        safari10: true,
+      };
+      config = {...config, minifierConfig};
+    }
+
     if (options.minify) {
       ({map, code} = await minifyCode(
         config,

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,6 +300,14 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
+"@babel/plugin-proposal-unicode-property-regex@^7.4.4":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz#2a183958d417765b9eae334f47758e5d6a82e072"
+  integrity sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.12.1"
+    "@babel/helper-plugin-utils" "^7.10.4"
+
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
@@ -468,6 +476,14 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz#b9a570fe0d0a8d460116413cb4f97e8e08b2f847"
   integrity sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==
   dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-dotall-regex@^7.4.4":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz#a1d16c14862817b6409c0a678d6f9373ca9cd975"
+  integrity sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-exponentiation-operator@^7.0.0":
@@ -649,6 +665,17 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/preset-modules@^0.1.2":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.4.tgz#362f2b68c662842970fdb5e254ffc8fc1c2e415e"
+  integrity sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
 "@babel/register@^7.0.0":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.12.1.tgz#cdb087bdfc4f7241c03231f22e15d211acf21438"
@@ -691,7 +718,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.12.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
   integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==


### PR DESCRIPTION
**Summary**

React Native now requires iOS 10, which includes a JavaScriptCore runtime that implements much of ES2015. It also bundles a modern JavaScriptCore on Android, which also implements ES2015 (I think it is roughly at the level of JSC in iOS 12).

This PR adds a new transform profile `jsc-ios10.3`, which removes all Babel transforms that are no longer needed on devices that are iOS 10.3+ or Android. This creates more optimal JS when running in these environments.

This PR is intended to replace the work done in PR #515 in a way that will not destabilize React Native users that use the default transform profile, or other options such as `unstable_disableES6Transforms`.

Fixes #359

**Test plan**

I added a unit test for the `getPreset()` function that tests that the appropriate plugins are removed when the transform profile is set to `jsc-ios10.3`.

I modified the `babel.config.js` in our project as follows:
```
module.exports = {
  presets: [
    [
      "module:metro-react-native-babel-preset",
      {unstable_transformProfile: "jsc-ios10.3"},
    ],
  ],
};
```
The bundle was generated with modern JS syntax such as `const` and `() => {}`.
