### PR TITLE
Fix regular expression compatibility issue with node v12

### DIFF
--- a/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
+++ b/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
@@ -25,14 +25,84 @@ describe('exclusionList', () => {
     path.sep = originalSeparator;
   });
 
-  it('converts forward slashes in the RegExp to the OS specific path separator', () => {
+  it('proves we can write to path.sep for setting up the tests', () => {
     // $FlowFixMe: property sep is not writable.
     path.sep = '/';
-    expect('a/b/c').toMatch(exclusionList([new RegExp('a/b/c')]));
-
+    expect(require('path').sep).toBe('/');
     // $FlowFixMe: property sep is not writable.
     path.sep = '\\';
     expect(require('path').sep).toBe('\\');
+  });
+
+  it('converts forward slashes in the RegExp to the OS specific path separator in macOS/linux', () => {
+    // $FlowFixMe: property sep is not writable.
+    path.sep = '/';
+    // Simple case
+    expect('a/b/c').toMatch(exclusionList([new RegExp('a/b/c')]));
+    expect('a/b/c').toMatch(exclusionList([/a\/b\/c/]));
+    // Regular expression that already considered OS specific path separator.
+    // When explictly construct RegExp instance, the string needs to be escaped first.
+    // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
+    expect('/foo/bar').toMatch(exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]));
+    expect('/foo/bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
+  });
+
+  it('converts forward slashes in the RegExp to the OS specific path separator in windows', () => {
+    // $FlowFixMe: property sep is not writable.
+    path.sep = '\\';
+    // Simple case
     expect('a\\b\\c').toMatch(exclusionList([new RegExp('a/b/c')]));
+    expect('a\\b\\c').toMatch(exclusionList([/a\/b\/c/]));
+    // Regular expression that already considered OS specific path separator.
+    // When explictly construct RegExp instance, the string needs to be escaped first.
+    // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
+    expect('\\foo\\bar').toMatch(exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]));
+    expect('\\foo\\bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
+  });
+
+  it('converts forward slashes in the string to the OS specific path separator in macOS/linux', () => {
+    // $FlowFixMe: property sep is not writable.
+    path.sep = '/';
+    // Simple case
+    expect('a/b/c').toMatch(exclusionList(['a/b/c']));
+    // Strings that already considered OS specific path separator.
+    expect('/foo/bar').toMatch(exclusionList(['.*[/\\]foo[/\\]bar']));
+  });
+
+  it('converts forward slashes in the string to the OS specific path separator in windows', () => {
+    // $FlowFixMe: property sep is not writable.
+    path.sep = '\\';
+    // Simple case
+    expect('a\\b\\c').toMatch(exclusionList(['a/b/c']));
+    // Strings that already considered OS specific path separator.
+    expect('\\foo\\bar').toMatch(exclusionList(['.*[/\\]foo[/\\]bar']));
+  });
+
+  it('converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below', () => {
+    // In node version 10 or below, the forward slash in brackets are escaped automatically.
+    // eg. /[/\\]/ => /[\/\\]/
+    // Ideally this test case should be removed and instead the whole test should run in
+    // multiple node versions.
+    // $FlowFixMe: property sep is not writable.
+    path.sep = '/';
+    // Regular expression that already considered OS specific path separator.
+    // When explictly construct RegExp instance, the string needs to be escaped first.
+    // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
+    expect('/foo/bar').toMatch(exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]));
+    expect('/foo/bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
+  });
+
+  it('converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below', () => {
+    // In node version 10 or below, the forward slash in brackets are escaped automatically.
+    // eg. /[/\\]/ => /[\/\\]/
+    // Ideally this test case should be removed and instead the whole test should run in
+    // multiple node versions.
+    // $FlowFixMe: property sep is not writable.
+    path.sep = '\\';
+    // Regular expression that already considered OS specific path separator.
+    // When explictly construct RegExp instance, the string needs to be escaped first.
+    // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
+    expect('\\foo\\bar').toMatch(exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]));
+    expect('\\foo\\bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
   });
 });

--- a/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
+++ b/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
@@ -39,22 +39,20 @@ describe('exclusionList', () => {
   });
 
   describe('simulate macOS/linux enviornment', () => {
-    it('converts forward slashes in the RegExp to the OS specific path separator in macOS/linux', () => {
-      setPathSeperator('/');
+    beforeEach(() => setPathSeperator('/'));
+
+    it('converts forward slashes in the RegExp to the OS specific path separator', () => {
       // Simple case
       expect('a/b/c').toMatch(exclusionList([new RegExp('a/b/c')]));
       expect('a/b/c').toMatch(exclusionList([/a\/b\/c/]));
       // Regular expression that already considered OS specific path separator.
-      // When explictly construct RegExp instance, the string needs to be escaped first.
-      // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
       expect('/foo/bar').toMatch(
         exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]),
       );
       expect('/foo/bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
     });
 
-    it('converts forward slashes in the string to the OS specific path separator in macOS/linux', () => {
-      setPathSeperator('/');
+    it('converts forward slashes in the string to the OS specific path separator', () => {
       // Simple case
       expect('a/b/c').toMatch(exclusionList(['a/b/c']));
       // Make sure the special characters are escaped properly
@@ -63,15 +61,12 @@ describe('exclusionList', () => {
       );
     });
 
-    it('converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below', () => {
+    it('converts forward slashes in the RegExp to the OS specific path separator in nodejs 10 or below', () => {
       // In node version 10 or below, the forward slash in brackets are escaped automatically.
       // eg. /[/\\]/ => /[\/\\]/
       // Ideally this test case should be removed and instead the whole test should run in
       // multiple node versions.
-      setPathSeperator('/');
       // Regular expression that already considered OS specific path separator.
-      // When explictly construct RegExp instance, the string needs to be escaped first.
-      // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
       expect('/foo/bar').toMatch(
         exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]),
       );
@@ -80,22 +75,20 @@ describe('exclusionList', () => {
   });
 
   describe('simulate windows enviornment', () => {
-    it('converts forward slashes in the RegExp to the OS specific path separator in windows', () => {
-      setPathSeperator('\\');
+    beforeEach(() => setPathSeperator('\\'));
+    
+    it('converts forward slashes in the RegExp to the OS specific path separator', () => {
       // Simple case
       expect('a\\b\\c').toMatch(exclusionList([new RegExp('a/b/c')]));
       expect('a\\b\\c').toMatch(exclusionList([/a\/b\/c/]));
       // Regular expression that already considered OS specific path separator.
-      // When explictly construct RegExp instance, the string needs to be escaped first.
-      // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
       expect('\\foo\\bar').toMatch(
         exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]),
       );
       expect('\\foo\\bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
     });
 
-    it('converts forward slashes in the string to the OS specific path separator in windows', () => {
-      setPathSeperator('\\');
+    it('converts forward slashes in the string to the OS specific path separator', () => {
       // Simple case
       expect('a\\b\\c').toMatch(exclusionList(['a/b/c']));
       // Make sure the special characters are escaped properly
@@ -104,15 +97,12 @@ describe('exclusionList', () => {
       );
     });
 
-    it('converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below', () => {
+    it('converts forward slashes in the RegExp to the OS specific path separator in nodejs 10 or below', () => {
       // In node version 10 or below, the forward slash in brackets are escaped automatically.
       // eg. /[/\\]/ => /[\/\\]/
       // Ideally this test case should be removed and instead the whole test should run in
       // multiple node versions.
-      setPathSeperator('\\');
       // Regular expression that already considered OS specific path separator.
-      // When explictly construct RegExp instance, the string needs to be escaped first.
-      // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
       expect('\\foo\\bar').toMatch(
         exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]),
       );

--- a/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
+++ b/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
@@ -76,7 +76,7 @@ describe('exclusionList', () => {
 
   describe('simulate windows enviornment', () => {
     beforeEach(() => setPathSeperator('\\'));
-    
+
     it('converts forward slashes in the RegExp to the OS specific path separator', () => {
       // Simple case
       expect('a\\b\\c').toMatch(exclusionList([new RegExp('a/b/c')]));

--- a/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
+++ b/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
@@ -16,6 +16,12 @@ const path = require('path');
 
 describe('exclusionList', () => {
   let originalSeparator;
+
+  function setPathSeperator(sep: string) {
+    // $FlowFixMe: property sep is not writable.
+    path.sep = sep;
+  };
+
   beforeEach(() => {
     originalSeparator = path.sep;
   });
@@ -26,83 +32,81 @@ describe('exclusionList', () => {
   });
 
   it('proves we can write to path.sep for setting up the tests', () => {
-    // $FlowFixMe: property sep is not writable.
-    path.sep = '/';
+    setPathSeperator('/');
     expect(require('path').sep).toBe('/');
-    // $FlowFixMe: property sep is not writable.
-    path.sep = '\\';
+    setPathSeperator('\\');
     expect(require('path').sep).toBe('\\');
   });
 
-  it('converts forward slashes in the RegExp to the OS specific path separator in macOS/linux', () => {
-    // $FlowFixMe: property sep is not writable.
-    path.sep = '/';
-    // Simple case
-    expect('a/b/c').toMatch(exclusionList([new RegExp('a/b/c')]));
-    expect('a/b/c').toMatch(exclusionList([/a\/b\/c/]));
-    // Regular expression that already considered OS specific path separator.
-    // When explictly construct RegExp instance, the string needs to be escaped first.
-    // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
-    expect('/foo/bar').toMatch(exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]));
-    expect('/foo/bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
+  describe('simulate macOS/linux enviornment', () => {
+    it('converts forward slashes in the RegExp to the OS specific path separator in macOS/linux', () => {
+      setPathSeperator('/');
+      // Simple case
+      expect('a/b/c').toMatch(exclusionList([new RegExp('a/b/c')]));
+      expect('a/b/c').toMatch(exclusionList([/a\/b\/c/]));
+      // Regular expression that already considered OS specific path separator.
+      // When explictly construct RegExp instance, the string needs to be escaped first.
+      // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
+      expect('/foo/bar').toMatch(exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]));
+      expect('/foo/bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
+    });
+
+    it('converts forward slashes in the string to the OS specific path separator in macOS/linux', () => {
+      setPathSeperator('/');
+      // Simple case
+      expect('a/b/c').toMatch(exclusionList(['a/b/c']));
+      expect('a/b/c').toMatch(exclusionList(['a[/]b[/]c']));
+      // Strings that already considered OS specific path separator.
+      expect('/foo/bar').toMatch(exclusionList(['.*[/\\]foo[/\\]bar']));
+    });
+
+    it('converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below', () => {
+      // In node version 10 or below, the forward slash in brackets are escaped automatically.
+      // eg. /[/\\]/ => /[\/\\]/
+      // Ideally this test case should be removed and instead the whole test should run in
+      // multiple node versions.
+      setPathSeperator('/');
+      // Regular expression that already considered OS specific path separator.
+      // When explictly construct RegExp instance, the string needs to be escaped first.
+      // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
+      expect('/foo/bar').toMatch(exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]));
+      expect('/foo/bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
+    });
   });
 
-  it('converts forward slashes in the RegExp to the OS specific path separator in windows', () => {
-    // $FlowFixMe: property sep is not writable.
-    path.sep = '\\';
-    // Simple case
-    expect('a\\b\\c').toMatch(exclusionList([new RegExp('a/b/c')]));
-    expect('a\\b\\c').toMatch(exclusionList([/a\/b\/c/]));
-    // Regular expression that already considered OS specific path separator.
-    // When explictly construct RegExp instance, the string needs to be escaped first.
-    // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
-    expect('\\foo\\bar').toMatch(exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]));
-    expect('\\foo\\bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
-  });
+  describe('simulate windows enviornment', () => {
+    it('converts forward slashes in the RegExp to the OS specific path separator in windows', () => {
+      setPathSeperator('\\');
+      // Simple case
+      expect('a\\b\\c').toMatch(exclusionList([new RegExp('a/b/c')]));
+      expect('a\\b\\c').toMatch(exclusionList([/a\/b\/c/]));
+      // Regular expression that already considered OS specific path separator.
+      // When explictly construct RegExp instance, the string needs to be escaped first.
+      // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
+      expect('\\foo\\bar').toMatch(exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]));
+      expect('\\foo\\bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
+    });
 
-  it('converts forward slashes in the string to the OS specific path separator in macOS/linux', () => {
-    // $FlowFixMe: property sep is not writable.
-    path.sep = '/';
-    // Simple case
-    expect('a/b/c').toMatch(exclusionList(['a/b/c']));
-    // Strings that already considered OS specific path separator.
-    expect('/foo/bar').toMatch(exclusionList(['.*[/\\]foo[/\\]bar']));
-  });
+    it('converts forward slashes in the string to the OS specific path separator in windows', () => {
+      setPathSeperator('\\');
+      // Simple case
+      expect('a\\b\\c').toMatch(exclusionList(['a/b/c']));
+      expect('a\\b\\c').toMatch(exclusionList(['a[/]b[/]c']));
+      // Strings that already considered OS specific path separator.
+      expect('\\foo\\bar').toMatch(exclusionList(['.*[/\\]foo[/\\]bar']));
+    });
 
-  it('converts forward slashes in the string to the OS specific path separator in windows', () => {
-    // $FlowFixMe: property sep is not writable.
-    path.sep = '\\';
-    // Simple case
-    expect('a\\b\\c').toMatch(exclusionList(['a/b/c']));
-    // Strings that already considered OS specific path separator.
-    expect('\\foo\\bar').toMatch(exclusionList(['.*[/\\]foo[/\\]bar']));
-  });
-
-  it('converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below', () => {
-    // In node version 10 or below, the forward slash in brackets are escaped automatically.
-    // eg. /[/\\]/ => /[\/\\]/
-    // Ideally this test case should be removed and instead the whole test should run in
-    // multiple node versions.
-    // $FlowFixMe: property sep is not writable.
-    path.sep = '/';
-    // Regular expression that already considered OS specific path separator.
-    // When explictly construct RegExp instance, the string needs to be escaped first.
-    // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
-    expect('/foo/bar').toMatch(exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]));
-    expect('/foo/bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
-  });
-
-  it('converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below', () => {
-    // In node version 10 or below, the forward slash in brackets are escaped automatically.
-    // eg. /[/\\]/ => /[\/\\]/
-    // Ideally this test case should be removed and instead the whole test should run in
-    // multiple node versions.
-    // $FlowFixMe: property sep is not writable.
-    path.sep = '\\';
-    // Regular expression that already considered OS specific path separator.
-    // When explictly construct RegExp instance, the string needs to be escaped first.
-    // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
-    expect('\\foo\\bar').toMatch(exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]));
-    expect('\\foo\\bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
-  });
+    it('converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below', () => {
+      // In node version 10 or below, the forward slash in brackets are escaped automatically.
+      // eg. /[/\\]/ => /[\/\\]/
+      // Ideally this test case should be removed and instead the whole test should run in
+      // multiple node versions.
+      setPathSeperator('\\');
+      // Regular expression that already considered OS specific path separator.
+      // When explictly construct RegExp instance, the string needs to be escaped first.
+      // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
+      expect('\\foo\\bar').toMatch(exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]));
+      expect('\\foo\\bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
+    });
+  })
 });

--- a/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
+++ b/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
@@ -20,7 +20,7 @@ describe('exclusionList', () => {
   function setPathSeperator(sep: string) {
     // $FlowFixMe: property sep is not writable.
     path.sep = sep;
-  };
+  }
 
   beforeEach(() => {
     originalSeparator = path.sep;
@@ -47,7 +47,9 @@ describe('exclusionList', () => {
       // Regular expression that already considered OS specific path separator.
       // When explictly construct RegExp instance, the string needs to be escaped first.
       // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
-      expect('/foo/bar').toMatch(exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]));
+      expect('/foo/bar').toMatch(
+        exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]),
+      );
       expect('/foo/bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
     });
 
@@ -55,9 +57,10 @@ describe('exclusionList', () => {
       setPathSeperator('/');
       // Simple case
       expect('a/b/c').toMatch(exclusionList(['a/b/c']));
-      expect('a/b/c').toMatch(exclusionList(['a[/]b[/]c']));
-      // Strings that already considered OS specific path separator.
-      expect('/foo/bar').toMatch(exclusionList(['.*[/\\]foo[/\\]bar']));
+      // Make sure the special characters are escaped properly
+      expect('^.*[/\\1-9]{3}(foo)s+[/\\]bars?$').toMatch(
+        exclusionList(['^.*[/\\1-9]{3}(foo)s+[/\\]bars?$']),
+      );
     });
 
     it('converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below', () => {
@@ -69,7 +72,9 @@ describe('exclusionList', () => {
       // Regular expression that already considered OS specific path separator.
       // When explictly construct RegExp instance, the string needs to be escaped first.
       // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
-      expect('/foo/bar').toMatch(exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]));
+      expect('/foo/bar').toMatch(
+        exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]),
+      );
       expect('/foo/bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
     });
   });
@@ -83,7 +88,9 @@ describe('exclusionList', () => {
       // Regular expression that already considered OS specific path separator.
       // When explictly construct RegExp instance, the string needs to be escaped first.
       // eg. /.*[/\\]foo[/\\]bar/ => '.*[/\\\\]foo[/\\\\]bar'
-      expect('\\foo\\bar').toMatch(exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]));
+      expect('\\foo\\bar').toMatch(
+        exclusionList([new RegExp('.*[/\\\\]foo[/\\\\]bar')]),
+      );
       expect('\\foo\\bar').toMatch(exclusionList([/.*[/\\]foo[/\\]bar/]));
     });
 
@@ -91,9 +98,10 @@ describe('exclusionList', () => {
       setPathSeperator('\\');
       // Simple case
       expect('a\\b\\c').toMatch(exclusionList(['a/b/c']));
-      expect('a\\b\\c').toMatch(exclusionList(['a[/]b[/]c']));
-      // Strings that already considered OS specific path separator.
-      expect('\\foo\\bar').toMatch(exclusionList(['.*[/\\]foo[/\\]bar']));
+      // Make sure the special characters are escaped properly
+      expect('^.*[\\\\1-9]{3}(foo)s+[\\\\]bars?$').toMatch(
+        exclusionList(['^.*[/\\1-9]{3}(foo)s+[/\\]bars?$']),
+      );
     });
 
     it('converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below', () => {
@@ -105,8 +113,10 @@ describe('exclusionList', () => {
       // Regular expression that already considered OS specific path separator.
       // When explictly construct RegExp instance, the string needs to be escaped first.
       // eg. /.*[\/\\]foo[\/\\]bar/ => '.*[\\/\\\\]foo[\\/\\\\]bar'
-      expect('\\foo\\bar').toMatch(exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]));
+      expect('\\foo\\bar').toMatch(
+        exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]),
+      );
       expect('\\foo\\bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
     });
-  })
+  });
 });

--- a/packages/metro-config/src/defaults/exclusionList.js
+++ b/packages/metro-config/src/defaults/exclusionList.js
@@ -15,10 +15,19 @@ var list = [/website\/node_modules\/.*/, /.*\/__tests__\/.*/];
 
 function escapeRegExp(pattern) {
   if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
-    return pattern.source.replace(/\//g, path.sep);
+    // the forward slash may or may not be escaped in regular expression depends
+    // on if it's in brackets. eg. /foo\/bar/ and /[/\\]foo/ are both valid.
+    // We should replace all forward slashes to proper OS specific separators.
+    // The separator needs to be escaped in the regular expression source string,
+    // hence the '\\' prefix.
+    return pattern.source.replace(/\/|\\\//g, '\\' + path.sep);
   } else if (typeof pattern === 'string') {
-    var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
-    // convert the '/' into an escaped local file separator
+    // escape back slashes in regular expression so that when
+    // it's used in RegExp constructor, the back slashes are preserved.
+    // var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+    var escaped = pattern.replace(/\\/g, '\\$&');
+    // convert the '/' into an escaped local file separator. The separator needs
+    // to be escaped in the regular expression source string, hence the '\\' prefix.
     return escaped.replace(/\//g, '\\' + path.sep);
   } else {
     throw new Error('Unexpected exclusion pattern: ' + pattern);

--- a/packages/metro-config/src/defaults/exclusionList.js
+++ b/packages/metro-config/src/defaults/exclusionList.js
@@ -16,7 +16,9 @@ var list = [/website\/node_modules\/.*/, /.*\/__tests__\/.*/];
 function escapeRegExp(pattern) {
   if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
     // the forward slash may or may not be escaped in regular expression depends
-    // on if it's in brackets. eg. /foo\/bar/ and /[/\\]foo/ are both valid.
+    // on if it's in brackets. See this post for details
+    // https://github.com/nodejs/help/issues/3039. The or condition in string
+    // replace regexp is to cover both use cases.
     // We should replace all forward slashes to proper OS specific separators.
     // The separator needs to be escaped in the regular expression source string,
     // hence the '\\' prefix.
@@ -24,7 +26,6 @@ function escapeRegExp(pattern) {
   } else if (typeof pattern === 'string') {
     // escape back slashes in regular expression so that when
     // it's used in RegExp constructor, the back slashes are preserved.
-    // var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
     var escaped = pattern.replace(/\\/g, '\\$&');
     // convert the '/' into an escaped local file separator. The separator needs
     // to be escaped in the regular expression source string, hence the '\\' prefix.

--- a/packages/metro-config/src/defaults/exclusionList.js
+++ b/packages/metro-config/src/defaults/exclusionList.js
@@ -24,9 +24,9 @@ function escapeRegExp(pattern) {
     // hence the '\\' prefix.
     return pattern.source.replace(/\/|\\\//g, '\\' + path.sep);
   } else if (typeof pattern === 'string') {
-    // escape back slashes in regular expression so that when
-    // it's used in RegExp constructor, the back slashes are preserved.
-    var escaped = pattern.replace(/\\/g, '\\$&');
+    // Make sure all the special characters used by regular expression are properly
+    // escaped. The string inputs are supposed to match as is.
+    var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
     // convert the '/' into an escaped local file separator. The separator needs
     // to be escaped in the regular expression source string, hence the '\\' prefix.
     return escaped.replace(/\//g, '\\' + path.sep);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This pull request fixes #578 we have in regular expression treatment for converting OS specific path separators. When running in node js version 12, forward slashes in brackets (eg. `/[/\\]foo/` won't be escaped automatically (Also see another issue I filed in nodejs project https://github.com/nodejs/help/issues/3039). That is causing backward compatibility issue in our use case, where we assume they will always be escaped and replaced the string accordingly.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Added new tests to cover this edge case. Those new tests should pass in both nodejs 10 and nodejs 12.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Before:
```
xch at xch-mbp in ~/oss/metro/packages/metro-configfix_regexp_metro_config
$ nvm use 10
Now using node v10.19.0 (npm v6.13.4)

xch at xch-mbp in ~/oss/metro/packages/metro-configfix_regexp_metro_config [!]
$ jest src/defaults/
jest-haste-map: Watchman crawl failed. Retrying once with node crawler.
  Usually this happens when watchman isn't running. Create an empty `.watchmanconfig` file in your project's root folder or initialize a git or hg repository in your project.
  Error: Watchman error: N8watchman22CommandValidationErrorE: failed to validate command: resolve_projpath:  None of the files listed in global config root_files are present in path `/Users/xch/oss/metro/packages/metro-config` or any of its parent directories.  root_files is defined by the `/etc/watchman.json` config file and includes `.watchmanconfig`.  One or more of these files must be present in order to allow a watch. Try pulling and checking out a newer version of the project?. Make sure watchman is running for this project. See https://facebook.github.io/watchman/docs/troubleshooting.
jest-haste-map: duplicate manual mock found: cosmiconfig
  The following files share their name; please delete one of them:
    * <rootDir>/build/__mocks__/cosmiconfig.js
    * <rootDir>/src/__mocks__/cosmiconfig.js

 PASS  src/defaults/__tests__/exclusionList-test.js
  exclusionList
    ✓ proves we can write to path.sep for setting up the tests (2 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator in macOS/linux (2 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator in windows
    ✓ converts forward slashes in the string to the OS specific path separator in macOS/linux (1 ms)
    ✓ converts forward slashes in the string to the OS specific path separator in windows
    ✓ converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below (1 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        0.824 s, estimated 1 s
Ran all test suites matching /src\/defaults\//i.

xch at xch-mbp in ~/oss/metro/packages/metro-configfix_regexp_metro_config [!]
$ nvm use 12
Now using node v12.18.4 (npm v6.14.6)

xch at xch-mbp in ~/oss/metro/packages/metro-configfix_regexp_metro_config [!]
$ jest src/defaults/
jest-haste-map: Watchman crawl failed. Retrying once with node crawler.
  Usually this happens when watchman isn't running. Create an empty `.watchmanconfig` file in your project's root folder or initialize a git or hg repository in your project.
  Error: Watchman error: N8watchman22CommandValidationErrorE: failed to validate command: resolve_projpath:  None of the files listed in global config root_files are present in path `/Users/xch/oss/metro/packages/metro-config` or any of its parent directories.  root_files is defined by the `/etc/watchman.json` config file and includes `.watchmanconfig`.  One or more of these files must be present in order to allow a watch. Try pulling and checking out a newer version of the project?. Make sure watchman is running for this project. See https://facebook.github.io/watchman/docs/troubleshooting.
jest-haste-map: duplicate manual mock found: cosmiconfig
  The following files share their name; please delete one of them:
    * <rootDir>/build/__mocks__/cosmiconfig.js
    * <rootDir>/src/__mocks__/cosmiconfig.js

 FAIL  src/defaults/__tests__/exclusionList-test.js
  exclusionList
    ✓ proves we can write to path.sep for setting up the tests (2 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator in macOS/linux
    ✕ converts forward slashes in the RegExp to the OS specific path separator in windows (3 ms)
    ✓ converts forward slashes in the string to the OS specific path separator in macOS/linux (1 ms)
    ✓ converts forward slashes in the string to the OS specific path separator in windows
    ✓ converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below (1 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below

  ● exclusionList › converts forward slashes in the RegExp to the OS specific path separator in windows

    SyntaxError: Invalid regular expression: /(.*[\\\]foo[\\\]bar|website\\node_modules\\.*|.*\\__tests__\\.*)$/: Unterminated character class
        at new RegExp (<anonymous>)

      31 | 
      32 | function exclusionList(additionalExclusions) {
    > 33 |   return new RegExp(
         |          ^
      34 |     '(' +
      35 |       (additionalExclusions || [])
      36 |         .concat(list)

      at exclusionList (src/defaults/exclusionList.js:33:10)
      at Object.<anonymous> (src/defaults/__tests__/exclusionList-test.js:59:34)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 6 passed, 7 total
Snapshots:   0 total
Time:        0.757 s, estimated 1 s
Ran all test suites matching /src\/defaults\//i.
```

After:
```
xch at xch-mbp in ~/oss/metro/packages/metro-configfix_regexp_metro_config
$ nvm use 10
Now using node v10.19.0 (npm v6.13.4)

xch at xch-mbp in ~/oss/metro/packages/metro-configfix_regexp_metro_config
$ jest src/defaults/
jest-haste-map: Watchman crawl failed. Retrying once with node crawler.
  Usually this happens when watchman isn't running. Create an empty `.watchmanconfig` file in your project's root folder or initialize a git or hg repository in your project.
  Error: Watchman error: N8watchman22CommandValidationErrorE: failed to validate command: resolve_projpath:  None of the files listed in global config root_files are present in path `/Users/xch/oss/metro/packages/metro-config` or any of its parent directories.  root_files is defined by the `/etc/watchman.json` config file and includes `.watchmanconfig`.  One or more of these files must be present in order to allow a watch. Try pulling and checking out a newer version of the project?. Make sure watchman is running for this project. See https://facebook.github.io/watchman/docs/troubleshooting.
jest-haste-map: duplicate manual mock found: cosmiconfig
  The following files share their name; please delete one of them:
    * <rootDir>/build/__mocks__/cosmiconfig.js
    * <rootDir>/src/__mocks__/cosmiconfig.js

 PASS  src/defaults/__tests__/exclusionList-test.js
  exclusionList
    ✓ proves we can write to path.sep for setting up the tests (2 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator in macOS/linux (2 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator in windows
    ✓ converts forward slashes in the string to the OS specific path separator in macOS/linux (1 ms)
    ✓ converts forward slashes in the string to the OS specific path separator in windows
    ✓ converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below
    ✓ converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below (1 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        0.998 s, estimated 1 s
Ran all test suites matching /src\/defaults\//i.

xch at xch-mbp in ~/oss/metro/packages/metro-configfix_regexp_metro_config
$ nvm use 12
Now using node v12.18.4 (npm v6.14.6)

xch at xch-mbp in ~/oss/metro/packages/metro-configfix_regexp_metro_config
$ jest src/defaults/
jest-haste-map: Watchman crawl failed. Retrying once with node crawler.
  Usually this happens when watchman isn't running. Create an empty `.watchmanconfig` file in your project's root folder or initialize a git or hg repository in your project.
  Error: Watchman error: N8watchman22CommandValidationErrorE: failed to validate command: resolve_projpath:  None of the files listed in global config root_files are present in path `/Users/xch/oss/metro/packages/metro-config` or any of its parent directories.  root_files is defined by the `/etc/watchman.json` config file and includes `.watchmanconfig`.  One or more of these files must be present in order to allow a watch. Try pulling and checking out a newer version of the project?. Make sure watchman is running for this project. See https://facebook.github.io/watchman/docs/troubleshooting.
jest-haste-map: duplicate manual mock found: cosmiconfig
  The following files share their name; please delete one of them:
    * <rootDir>/build/__mocks__/cosmiconfig.js
    * <rootDir>/src/__mocks__/cosmiconfig.js

 PASS  src/defaults/__tests__/exclusionList-test.js
  exclusionList
    ✓ proves we can write to path.sep for setting up the tests (2 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator in macOS/linux (1 ms)
    ✓ converts forward slashes in the RegExp to the OS specific path separator in windows
    ✓ converts forward slashes in the string to the OS specific path separator in macOS/linux (1 ms)
    ✓ converts forward slashes in the string to the OS specific path separator in windows
    ✓ converts forward slashes in the RegExp to the OS specific path separator for macOS/linux in nodejs 10 or below
    ✓ converts forward slashes in the RegExp to the OS specific path separator for windows in nodejs 10 or below (1 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        0.741 s, estimated 1 s
Ran all test suites matching /src\/defaults\//i.
```
