### PR TITLE
Update terser to v5, support async minifiers

### DIFF
--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -13,6 +13,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "terser": "^4.6.3"
+    "terser": "^5.3.8"
   }
 }

--- a/packages/metro-minify-terser/src/__tests__/minify-test.js
+++ b/packages/metro-minify-terser/src/__tests__/minify-test.js
@@ -15,10 +15,10 @@ import type {BasicSourceMap} from 'metro-source-map';
 
 jest.mock('terser', () => ({
   minify: jest.fn(code => {
-    return {
+    return Promise.resolve({
       code: code.replace(/(^|\W)\s+/g, '$1'),
       map: {},
-    };
+    });
   }),
 }));
 
@@ -57,12 +57,12 @@ describe('Minification:', () => {
     /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
      * error found when Flow v0.99 was deployed. To see the error, delete this
      * comment and run Flow. */
-    terser.minify.mockReturnValue({code: '', map: '{}'});
+    terser.minify.mockResolvedValue({code: '', map: '{}'});
     map = getFakeMap();
   });
 
-  it('passes file name, code, and source map to `terser`', () => {
-    minify({
+  it('passes file name, code, and source map to `terser`', async () => {
+    await minify({
       ...baseOptions,
       code,
       map,
@@ -80,21 +80,21 @@ describe('Minification:', () => {
     );
   });
 
-  it('returns the code provided by terser', () => {
+  it('returns the code provided by terser', async () => {
     /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
      * error found when Flow v0.99 was deployed. To see the error, delete this
      * comment and run Flow. */
-    terser.minify.mockReturnValue({code, map: '{}'});
-    const result = minify(baseOptions);
+    terser.minify.mockResolvedValue({code, map: '{}'});
+    const result = await minify(baseOptions);
     expect(result.code).toBe(code);
   });
 
-  it('parses the source map object provided by terser and sets the sources property', () => {
+  it('parses the source map object provided by terser and sets the sources property', async () => {
     /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
      * error found when Flow v0.99 was deployed. To see the error, delete this
      * comment and run Flow. */
-    terser.minify.mockReturnValue({map: JSON.stringify(map), code: ''});
-    const result = minify({...baseOptions, filename});
+    terser.minify.mockResolvedValue({map: JSON.stringify(map), code: ''});
+    const result = await minify({...baseOptions, filename});
     expect(result.map).toEqual({...map, sources: [filename]});
   });
 });

--- a/packages/metro-minify-terser/src/minifier.js
+++ b/packages/metro-minify-terser/src/minifier.js
@@ -15,8 +15,8 @@ const terser = require('terser');
 import type {BasicSourceMap} from 'metro-source-map';
 import type {MinifierResult, MinifierOptions} from 'metro-transform-worker';
 
-function minifier(options: MinifierOptions): MinifierResult {
-  const result = minify(options);
+async function minifier(options: MinifierOptions): Promise<MinifierResult> {
+  const result = await minify(options);
 
   if (!options.map || result.map == null) {
     return {code: result.code};
@@ -27,12 +27,12 @@ function minifier(options: MinifierOptions): MinifierResult {
   return {code: result.code, map: {...map, sources: [options.filename]}};
 }
 
-function minify({
+async function minify({
   code,
   map,
   reserved,
   config,
-}: MinifierOptions): {code: string, map: ?string} {
+}: MinifierOptions): Promise<{code: string, map: ?string}> {
   const options = {
     ...config,
     mangle: {
@@ -50,11 +50,7 @@ function minify({
   /* $FlowFixMe(>=0.111.0 site=react_native_fb) This comment suppresses an
    * error found when Flow v0.111 was deployed. To see the error, delete this
    * comment and run Flow. */
-  const result = terser.minify(code, options);
-
-  if (result.error) {
-    throw result.error;
-  }
+  const result = await terser.minify(code, options);
 
   return {
     code: result.code,

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -73,7 +73,9 @@ export type MinifierResult = {
   ...
 };
 
-export type Minifier = MinifierOptions => MinifierResult;
+export type Minifier = MinifierOptions =>
+  | Promise<MinifierResult>
+  | MinifierResult;
 
 export type Type = 'script' | 'module' | 'asset';
 
@@ -170,7 +172,7 @@ const minifyCode = async (
   const minify = getMinifier(config.minifierPath);
 
   try {
-    const minified = minify({
+    const minified = await minify({
       code,
       map: sourceMap,
       filename,


### PR DESCRIPTION
**Summary**

Update terser to the latest version that supports more modern js syntax like optional chaining. The main breaking change in v5 is that minify is now async. To support this I also needed to add async minifier support in metro-transform-worker.

**Test plan**

- Run tests
- Test building my app bundle with minifier terser and untransformed optional chaining
