### PR TITLE
docs: fix runMetro example usage

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -40,8 +40,8 @@ const http = require('http');
 const Metro = require('metro');
 
 // We first load the config from the file system
-Metro.loadConfig().then(config => {
-  const metroBundlerServer = Metro.runMetro(config);
+Metro.loadConfig().then(async (config) => {
+  const metroBundlerServer = await Metro.runMetro(config);
 
   const httpServer = http.createServer(
     metroBundlerServer.processRequest.bind(metroBundlerServer),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
example of `runMetro` method on Metro docs is missing async/await

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Example runs without error.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
