### PR TITLE
Fix undefined assetDataPlugins issue in metro/Assets.js

### DIFF
--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -231,7 +231,7 @@ async function applyAssetDataPlugins(
   assetDataPlugins: $ReadOnlyArray<string>,
   assetData: AssetData,
 ): Promise<AssetData> {
-  if (!assetDataPlugins.length) {
+  if (!assetDataPlugins || !assetDataPlugins.length) {
     return assetData;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

After upgrading from Expo SDK39 to SDK40 metro stopped loading my custom otf fonts with the error message "Cannot read property "length" of undefined. The fonts are loaded with the `useFonts` hook from [expo-font](https://github.com/expo/expo/tree/master/packages/expo-font) and `require` like this:
```
const [fontsLoaded] = useFonts({
  'SharpGrotesk18': require('./assets/fonts/SharpGroteskBook18.otf'),
  'SharpGrotesk19': require('./assets/fonts/SharpGroteskBold19.otf'),
  'TuskerGrotesk-4500': require('./assets/fonts/TuskerGrotesk4500Medium.otf'),
  'TuskerGrotesk-5700': require('./assets/fonts/TuskerGrotesk5700Bold.otf'),
  'TuskerGrotesk-7700': require('./assets/fonts/TuskerGrotesk7700Bold.otf'),
});
```

I traced the issue to https://github.com/facebook/metro/blob/master/packages/metro/src/Assets.js#L234 and by changing the line to 
```
if (!assetDataPlugins || !assetDataPlugins.length) {
  return assetData; 
}
```
everything worked as expected again. 

The changed line is 3 years old so I suppose the reason for seeing this  cause is probably not metro but some other part of the expo build process
