### PR TITLE
Update troubleshooting docs for metro cache tmpdir

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -8,7 +8,7 @@ Uh oh, something went wrong? Use this guide to resolve issues with Metro.
  1. Clear watchman watches: `watchman watch-del-all`
  2. Delete `node_modules` and run `yarn install`
  3. Reset Metro's cache by passing the `--reset-cache` flag, or adding `resetCache: true` to your metro configuration file.
- 4. Remove the cache: `rm -rf /tmp/metro-*`
+ 4. Remove the cache: `rm -rf ${TMPDIR:-/tmp}/metro-*`
  5. Update Metro to the [latest version](https://www.npmjs.com/package/metro)
 
 ### Still unresolved?


### PR DESCRIPTION
**Summary**

Use os default temp directory by checking POSIX $TMPDIR envvar for portability, with current `/tmpdir` as fallback.

For instance, on macos, this resolves to some long name like `/var/folders/yn/t9rvkpyj4b13s_gmtwgh1lw80000gn/T//metro-cache`


Reference:
- Metro default config uses node.js `os.tmpdir()` https://github.com/facebook/metro/blob/b2528d40c46085a32adbae370d0e47b6a24e3c8c/packages/metro-config/src/defaults/index.js#L122
- node.js `os.tmpdir()` returns system default https://nodejs.org/api/os.html#os_os_tmpdir
- system default is usually made available in $TMPDIR https://en.wikipedia.org/wiki/TMPDIR



**Test plan**

None
