### PR TITLE
replace uglify-es with uglify-js

### DIFF
--- a/flow-typed/uglify.js
+++ b/flow-typed/uglify.js
@@ -96,7 +96,7 @@ type _SourceMapOptions =
 type _Error = {|error: Error|};
 type _Result = {|code: string, warnings?: Array<string>|};
 
-declare module 'uglify-es' {
+declare module 'uglify-js' {
   declare function minify(code: _Input, options?: _Options): _Error | _Result;
   declare function minify(
     code: _Input,

--- a/packages/metro-minify-uglify/package.json
+++ b/packages/metro-minify-uglify/package.json
@@ -13,6 +13,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "uglify-es": "^3.1.9"
+    "uglify-js": "^3.13.0"
   }
 }

--- a/packages/metro-minify-uglify/src/__tests__/minify-test.js
+++ b/packages/metro-minify-uglify/src/__tests__/minify-test.js
@@ -13,7 +13,7 @@
 
 import type {BasicSourceMap} from 'metro-source-map';
 
-jest.mock('uglify-es', () => ({
+jest.mock('uglify-js', () => ({
   minify: jest.fn(code => {
     return {
       code: code.replace(/(^|\W)\s+/g, '$1'),
@@ -49,7 +49,7 @@ describe('Minification:', () => {
   let uglify;
 
   beforeEach(() => {
-    uglify = require('uglify-es');
+    uglify = require('uglify-js');
     /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
      * error found when Flow v0.99 was deployed. To see the error, delete this
      * comment and run Flow. */

--- a/packages/metro-minify-uglify/src/minifier.js
+++ b/packages/metro-minify-uglify/src/minifier.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const uglify = require('uglify-es');
+const uglify = require('uglify-js');
 
 import type {BasicSourceMap} from 'metro-source-map';
 import type {MinifierResult, MinifierOptions} from 'metro-transform-worker';

--- a/packages/metro-source-map/package.json
+++ b/packages/metro-source-map/package.json
@@ -24,6 +24,6 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/parser": "^7.0.0",
-    "uglify-es": "^3.1.9"
+    "uglify-js": "^3.13.0"
   }
 }

--- a/packages/metro-source-map/src/__tests__/composeSourceMaps-test.js
+++ b/packages/metro-source-map/src/__tests__/composeSourceMaps-test.js
@@ -19,7 +19,7 @@ const composeSourceMaps = require('../composeSourceMaps');
 const fs = require('fs');
 const invariant = require('invariant');
 const path = require('path');
-const uglifyEs = require('uglify-es');
+const uglifyEs = require('uglify-js');
 
 const {add0, add1} = require('ob1');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,11 +1906,6 @@ commander@^2.11.0, commander@^2.20.0, commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@~2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
-  integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -6702,14 +6697,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-uglify-es@^3.1.9:
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
-  integrity sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==
-  dependencies:
-    commander "~2.13.0"
-    source-map "~0.6.1"
-
 uglify-js@^3.1.4:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.8.0.tgz#f3541ae97b2f048d7e7e3aa4f39fd8a1f5d7a805"
@@ -6717,6 +6704,11 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"
+
+uglify-js@^3.13.0:
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.4.tgz#592588bb9f47ae03b24916e2471218d914955574"
+  integrity sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==
 
 ultron@1.0.x:
   version "1.0.2"


### PR DESCRIPTION
**Summary**

Replace uglify-es with uglify-js because of deprecation message from uglify-es

> support for ECMAScript is superseded by `uglify-js` as of v3.13.0


**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
