### PR TITLE
Update inspectorProxy with IPV6 localhost address

### DIFF
--- a/packages/metro-inspector-proxy/src/InspectorProxy.js
+++ b/packages/metro-inspector-proxy/src/InspectorProxy.js
@@ -98,7 +98,7 @@ class InspectorProxy {
   addWebSocketListener(server: HttpServer | HttpsServer) {
     const {port} = server.address();
     if (server.address().family === 'IPv6') {
-      this._serverAddressWithPort = `[::]:${port}`;
+      this._serverAddressWithPort = `[::1]:${port}`;
     } else {
       this._serverAddressWithPort = `localhost:${port}`;
     }


### PR DESCRIPTION
**Summary**

For IPV4 the webSocketDebuggerUrl defaults to `ws://localhost:8081` but for IPV6 this defaults to `ws://[::]:8081`. This causes issues since `ws://[::]` is not a valid websocket URL, I am guessing it should be `ws:[::1]` which is the IPV6 equivalent. 

**Test plan**

The webSocketDebuggerUrl should be `ws:[::1]` rather than `ws://[::]`.

This is related to this issue in Flipper https://github.com/facebook/flipper/issues/1520.