### PR TITLE
Replace /tmp with $TMPDIR in help message

### DIFF
--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -218,7 +218,7 @@ class ModuleResolver<TModule: Moduleish, TPackage: Packageish> {
             ' 1. Clear watchman watches: watchman watch-del-all',
             ' 2. Delete node_modules and run yarn install',
             " 3. Reset Metro's cache: yarn start --reset-cache",
-            ' 4. Remove the cache: rm -rf /tmp/metro-*',
+            ' 4. Remove the cache: rm -rf $TMPDIR/metro-*',
           ].join('\n'),
         );
       }


### PR DESCRIPTION
Taken from https://github.com/expo/expo/blob/5471ac832e26328ca8228f5535d9e514e02d8a3e/docs/pages/troubleshooting/clear-cache-macos-linux.md#expo-cli-and-yarn

/tmp and $TMPDIR are different directories on macOS (at least 11.4 Big Sur).

Metro, Yarn... use $TMPDIR

```zsh
% ls /tmp/metro-*
zsh: no matches found: /tmp/metro-*

% ls $TMPDIR/metro-*
00	1a	34	4e	68	82	9c	b6	d0	ea
...
```
