### PR TITLE
fix(metro): cannot read property 'toUpperCase' of undefined

### DIFF
--- a/packages/metro/src/lib/logToConsole.js
+++ b/packages/metro/src/lib/logToConsole.js
@@ -65,7 +65,8 @@ module.exports = (
       data[data.length - 1] = lastItem.trimEnd();
     }
 
-    const modePrefix = mode == 'BRIDGE' ? '' : `(${mode.toUpperCase()}) `;
+    const modePrefix =
+      !mode || mode == 'BRIDGE' ? '' : `(${mode.toUpperCase()}) `;
     terminal.log(
       color.bold(` ${modePrefix}${logFunction.toUpperCase()} `) +
         ''.padEnd(groupStack.length * 2, ' '),


### PR DESCRIPTION
**Summary**

Latest Metro crashes in React Native 0.65.0-rc.2:

```
/~/node_modules/metro-hermes-compiler/src/emhermesc.js:77
          throw ex;
          ^

RuntimeError: abort(TypeError: Cannot read property 'toUpperCase' of undefined). Build with -s ASSERTIONS=1 for more info.
    at process.abort (/~/node_modules/metro-hermes-compiler/src/emhermesc.js:440:13)
    at process.emit (node:events:406:35)
    at emit (node:internal/process/promises:136:22)
    at processPromiseRejections (node:internal/process/promises:242:25)
    at processTicksAndRejections (node:internal/process/task_queues:97:32)
Process terminated. Press <enter> to close the window
```

**Test plan**

```
npx react-native init RN065RC2 --version 0.65.0-rc.2
cd RN065RC2
yarn ios
```