### PR TITLE
Add `.prettierrc` to open source repo.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "requirePragma": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": false,
+  "jsxBracketSameLine": true,
+  "arrowParens": "avoid"
+}


### PR DESCRIPTION
**Summary**
VSCode cannot properly format stuff in the Metro repository because the `.prettierrc` file is missing. This is a copy of the file from the [`react-native` repo](https://github.com/facebook/react-native/blob/main/.prettierrc).

**Test plan**
* Change a file in VSCode.
* It's formatted correctly.