### PR TITLE
Separate package roots from watch folders

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -69,6 +69,9 @@ Object {
     ],
     "useWatchman": true,
   },
+  "roots": Array [
+    "/",
+  ],
   "serializer": Object {
     "createModuleIdFactory": [Function],
     "customSerializer": null,
@@ -212,6 +215,9 @@ Object {
     ],
     "useWatchman": true,
   },
+  "roots": Array [
+    "/",
+  ],
   "serializer": Object {
     "createModuleIdFactory": [Function],
     "customSerializer": null,
@@ -355,6 +361,9 @@ Object {
     ],
     "useWatchman": true,
   },
+  "roots": Array [
+    "/",
+  ],
   "serializer": Object {
     "createModuleIdFactory": [Function],
     "customSerializer": null,
@@ -498,6 +507,9 @@ Object {
     ],
     "useWatchman": true,
   },
+  "roots": Array [
+    "/",
+  ],
   "serializer": Object {
     "createModuleIdFactory": [Function],
     "customSerializer": null,

--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -151,6 +151,7 @@ describe('loadConfig', () => {
     let defaultConfig = await getDefaultConfig(process.cwd());
     defaultConfig = {
       ...defaultConfig,
+      roots: [defaultConfig.projectRoot, ...defaultConfig.roots],
       watchFolders: [defaultConfig.projectRoot, ...defaultConfig.watchFolders],
     };
 

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -120,6 +120,7 @@ type MetalConfigT = {|
   transformerPath: string,
   reporter: Reporter,
   resetCache: boolean,
+  roots: $ReadOnlyArray<string>,
   watchFolders: $ReadOnlyArray<string>,
 |};
 
@@ -185,6 +186,7 @@ export type YargArguments = {
   port?: string | number,
   host?: string,
   projectRoot?: string,
+  roots?: Array<string>,
   watchFolders?: Array<string>,
   assetExts?: Array<string>,
   sourceExts?: Array<string>,

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -134,6 +134,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
   // node_modules/metro/
   projectRoot: projectRoot || path.resolve(__dirname, '../../..'),
   stickyWorkers: true,
+  roots: [],
   watchFolders: [],
   transformerPath: require.resolve('metro-transform-worker'),
   maxWorkers: getMaxWorkers(),

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -221,6 +221,10 @@ function overrideConfigWithArguments(
     output.projectRoot = argv.projectRoot;
   }
 
+  if (argv.roots != null) {
+    output.roots = argv.roots;
+  }
+
   if (argv.watchFolders != null) {
     output.watchFolders = argv.watchFolders;
   }
@@ -302,13 +306,21 @@ async function loadConfig(
     };
   }
 
+  // Set the watchfolders to include the projectRoot, as Metro assumes that is
+  // the case
   overriddenConfig.watchFolders = [
     configWithArgs.projectRoot,
     ...configWithArgs.watchFolders,
   ];
 
-  // Set the watchfolders to include the projectRoot, as Metro assumes that is
-  // the case
+  // Ensure project roots are set. Default to watchFolders, if needed.
+  if (
+    !Array.isArray(configWithArgs.roots) ||
+    configWithArgs.roots.length === 0
+  ) {
+    overriddenConfig.roots = overriddenConfig.watchFolders;
+  }
+
   return mergeConfig(configWithArgs, overriddenConfig);
 }
 

--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -268,7 +268,7 @@ async function getAssetFiles(
 async function getAsset(
   relativePath: string,
   projectRoot: string,
-  watchFolders: $ReadOnlyArray<string>,
+  roots: $ReadOnlyArray<string>,
   platform: ?string = null,
   assetExts: $ReadOnlyArray<string>,
 ): Promise<Buffer> {
@@ -285,9 +285,9 @@ async function getAsset(
     );
   }
 
-  if (!pathBelongsToRoots(absolutePath, [projectRoot, ...watchFolders])) {
+  if (!pathBelongsToRoots(absolutePath, [projectRoot, ...roots])) {
     throw new Error(
-      `'${relativePath}' could not be found, because it cannot be found in the project root or any watch folder`,
+      `'${relativePath}' could not be found, because it cannot be found in the project root or any package root folder`,
     );
   }
 

--- a/packages/metro/src/DeltaBundler/Transformer.js
+++ b/packages/metro/src/DeltaBundler/Transformer.js
@@ -33,6 +33,7 @@ class Transformer {
   constructor(config: ConfigT, getSha1Fn: string => string) {
     this._config = config;
 
+    this._config.roots.forEach(verifyRootExists);
     this._config.watchFolders.forEach(verifyRootExists);
     this._cache = new Cache(config.cacheStores);
     this._getSha1 = getSha1Fn;

--- a/packages/metro/src/DeltaBundler/__tests__/Transformer-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/Transformer-test.js
@@ -45,6 +45,7 @@ describe('Transformer', function() {
       projectRoot: '/root',
       resetCache: false,
       transformerPath: '/path/to/transformer.js',
+      roots: ['/root'],
       watchFolders: ['/root'],
     };
 

--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -80,6 +80,7 @@ let resolver;
     reporter: require('../../lib/reporting').nullReporter,
     transformer: {},
     watch: true,
+    roots: [p('/root')],
     watchFolders: [p('/root')],
   };
 

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -404,7 +404,7 @@ class Server {
       const data = await getAsset(
         assetPath,
         this._config.projectRoot,
-        this._config.watchFolders,
+        this._config.roots,
         urlObj.query.platform,
         this._config.resolver.assetExts,
       );

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -69,6 +69,7 @@ describe('processRequest', () => {
 
   const config = getDefaultValues('/');
   config.projectRoot = '/root';
+  config.roots = ['/root'];
   config.watchFolders = ['/root'];
   config.resolver.blockList = null;
   config.cacheVersion = null;

--- a/packages/metro/src/commands/dependencies.js
+++ b/packages/metro/src/commands/dependencies.js
@@ -56,8 +56,7 @@ async function dependencies(args: any, config: any) {
     // (a) JS code to not depend on anything outside this directory, or
     // (b) Come up with a way to declare this dependency in Buck.
     const isInsideProjectRoots =
-      config.watchFolders.filter(root => modulePath.startsWith(root)).length >
-      0;
+      config.roots.filter(root => modulePath.startsWith(root)).length > 0;
     if (isInsideProjectRoots) {
       outStream.write(modulePath + '\n');
     }

--- a/packages/metro/src/integration_tests/metro.config.js
+++ b/packages/metro/src/integration_tests/metro.config.js
@@ -19,6 +19,7 @@ module.exports = {
   maxWorkers: 1,
   projectRoot: ROOT_PATH,
   reporter: {update() {}},
+  roots: [path.resolve(__dirname, '../../../')],
   watchFolders: [path.resolve(__dirname, '../../../')],
   server: {port: 10028},
   resolver: {

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -133,7 +133,7 @@ class DependencyGraph extends EventEmitter {
       retainAllFiles: true,
       resetCache: config.resetCache,
       rootDir: config.projectRoot,
-      roots: config.watchFolders,
+      roots: config.roots,
       throwOnModuleCollision: true,
       useWatchman: config.resolver.useWatchman,
       watch: watch == null ? !ci.isCI : watch,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When Metro runs, it gets the list of package root paths from the config property `watchFolders`. This means all packages, in-repo and external, must be watched for changes. In large mono-repos, this causes problems when thousands of external packages are used. File-watcher limits are hit, and a lot of CPU, memory and disk resources are used.

This PR adds a new `roots` Metro config property to explicitly separate package roots from watch folders. When `roots` is missing or empty, it is initialized using `watchFolders` for backward compatibility.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Update tests to include validation for `roots`.

Test a build of this PR locally with a separate project that does bundling and serving using Metro. Verify that setting `roots` and `watchFolders` to different values works. Additionally, verify that when `roots` is not set, it defaults to using `watchFolders`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
