### PR TITLE
fix: asset path not found for images with space

### DIFF
--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -134,6 +134,7 @@ async function getAbsoluteAssetRecord(
   assetPath: string,
   platform: ?string = null,
 ): Promise<{|files: Array<string>, scales: Array<number>|}> {
+  assetPath = decodeURIComponent(assetPath)
   const filename = path.basename(assetPath);
   const dir = path.dirname(assetPath);
   const files = await readDir(dir);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Solves error for images having space in their name. 

> Asset not found: /Users/varunb/Desktop/project-emma/src/assests/images/avatars/Allan%20Munger@2x.png for platform: ios

**Test plan**

Tested inside my project where I was facing the above error
