### PR TITLE
Require babel helpers instead of inlining

### DIFF
--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -56,6 +56,7 @@
     "@babel/plugin-transform-template-literals": "^7.0.0",
     "@babel/plugin-transform-typescript": "^7.5.0",
     "@babel/plugin-transform-unicode-regex": "^7.0.0",
+    "@babel/runtime": "^7.0.0",
     "@babel/template": "^7.0.0",
     "react-refresh": "^0.4.0"
   },

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -162,6 +162,7 @@ const getPreset = (src, options) => {
       {
         helpers: true,
         regenerator: !isHermes,
+        version: require('@babel/runtime/package.json').version,
       },
     ]);
   }

--- a/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
@@ -239,7 +239,7 @@ Object {
 
 exports[`transforms an es module with regenerator 1`] = `
 "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-  var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], \\"@babel/runtime/helpers/interopRequireDefault\\");
+  var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], \\"@babel/runtime/helpers/interopRequireDefault\\").default;
 
   Object.defineProperty(exports, \\"__esModule\\", {
     value: true

--- a/packages/metro-transform-worker/src/__tests__/index-test.js
+++ b/packages/metro-transform-worker/src/__tests__/index-test.js
@@ -153,7 +153,7 @@ it('transforms a module with dependencies', async () => {
       HEADER_DEV,
       '  "use strict";',
       '',
-      '  var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/interopRequireDefault");',
+      '  var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/interopRequireDefault").default;',
       '',
       '  var _c = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], "./c"));',
       '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -812,7 +812,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.8.4":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==


### PR DESCRIPTION
**Summary**

It's unclear exactly why or when this regression was introduced, but in my project somewhere when going from babel 7.12.x to 7.15.x due to an upgrade of the `metro-react-native-babel-preset` package our bundle size ballooned with ~8%. Upon inspecting the generated code I found that `@babel/runtime` helper functions were littered all over the place. This also happens in a freshly created `react-native` project, I've tried with 0.64.2, 0.65.1 and 066.1

To avoid the inlining/duplication this PR simply passes the [`version`](https://babeljs.io/docs/en/babel-plugin-transform-runtime#version) option of whatever version of `@babel/runtime` is installed. 

For a `react-native init` project, this reduces the JS bundle size from 756K to 675K = 10,7% reduction. 

**Test plan**

```bash
npx react-native init Example
cd Example
yarn react-native bundle --platform ios --dev false --entry-file ./index.js --bundle-output bundle.js --minify false --reset-cache

grep -o 'function _getRequireWildcardCache' bundle.js | wc -l
-> before=216; after=2;

du -h bundle.js
-> before=1.7M; after=1.5M;
```