### PR TITLE
Remove (no)deps suffix from cache name

### DIFF
--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -129,11 +129,7 @@ class DependencyGraph extends EventEmitter {
       ignorePattern: this._getIgnorePattern(config),
       maxWorkers: config.maxWorkers,
       mocksPattern: '',
-      name:
-        'metro-' +
-        JEST_HASTE_MAP_CACHE_BREAKER +
-        // TODO: Remove the deps/nodeps suffix once https://github.com/facebook/jest/pull/11916 lands
-        (computeDependencies ? '-deps' : '-nodeps'),
+      name: 'metro-' + JEST_HASTE_MAP_CACHE_BREAKER,
       platforms: config.resolver.platforms,
       retainAllFiles: true,
       resetCache: config.resetCache,


### PR DESCRIPTION
Summary: Now that https://github.com/facebook/jest/pull/11916 has landed and we have bumped metro's requirements to `jest-haste-map@^2.3.1` (https://github.com/facebook/metro/pull/743), `computeDependencies` is already included in the cache key and we can remove this TODO.

Reviewed By: GijsWeterings

Differential Revision: D32668457

