### PR TITLE
RN preset: support async iterators, for await of

### DIFF
--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.14.0",
+    "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-export-default-from": "^7.0.0",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -114,11 +114,15 @@ const getPreset = (src, options) => {
       {loose: true}, // dont 'a'.concat('b'), just use 'a'+'b'
     ]);
   }
-  if (isHermes && (isNull || src.indexOf('async') !== -1)) {
+  if (isNull || src.indexOf('async') !== -1) {
     extraPlugins.push([
       require('@babel/plugin-proposal-async-generator-functions'),
     ]);
-    extraPlugins.push([require('@babel/plugin-transform-async-to-generator')]);
+    if (isHermes) {
+      extraPlugins.push([
+        require('@babel/plugin-transform-async-to-generator'),
+      ]);
+    }
   }
   if (!isHermes && (isNull || src.indexOf('**') !== -1)) {
     extraPlugins.push([

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -115,6 +115,9 @@ const getPreset = (src, options) => {
     ]);
   }
   if (isHermes && (isNull || src.indexOf('async') !== -1)) {
+    extraPlugins.push([
+      require('@babel/plugin-proposal-async-generator-functions'),
+    ]);
     extraPlugins.push([require('@babel/plugin-transform-async-to-generator')]);
   }
   if (!isHermes && (isNull || src.indexOf('**') !== -1)) {

--- a/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
@@ -281,18 +281,32 @@ exports[`transforms async generators 1`] = `
   });
   exports.test = test;
 
-  var _awaitAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], \\"@babel/runtime/helpers/awaitAsyncGenerator\\"));
+  var _regenerator = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], \\"@babel/runtime/regenerator\\"));
 
-  var _wrapAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[2], \\"@babel/runtime/helpers/wrapAsyncGenerator\\"));
+  var _awaitAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[2], \\"@babel/runtime/helpers/awaitAsyncGenerator\\"));
+
+  var _wrapAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[3], \\"@babel/runtime/helpers/wrapAsyncGenerator\\"));
 
   function test() {
     return _test.apply(this, arguments);
   }
 
   function _test() {
-    _test = (0, _wrapAsyncGenerator2.default)(function* () {
-      yield \\"ok\\";
-    });
+    _test = (0, _wrapAsyncGenerator2.default)(_regenerator.default.mark(function _callee() {
+      return _regenerator.default.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.next = 2;
+              return \\"ok\\";
+
+            case 2:
+            case \\"end\\":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
     return _test.apply(this, arguments);
   }
 });"

--- a/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
@@ -272,6 +272,32 @@ Object {
 }
 `;
 
+exports[`transforms async generators 1`] = `
+"__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+  var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], \\"@babel/runtime/helpers/interopRequireDefault\\");
+
+  Object.defineProperty(exports, \\"__esModule\\", {
+    value: true
+  });
+  exports.test = test;
+
+  var _awaitAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], \\"@babel/runtime/helpers/awaitAsyncGenerator\\"));
+
+  var _wrapAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[2], \\"@babel/runtime/helpers/wrapAsyncGenerator\\"));
+
+  function test() {
+    return _test.apply(this, arguments);
+  }
+
+  function _test() {
+    _test = (0, _wrapAsyncGenerator2.default)(function* () {
+      yield \\"ok\\";
+    });
+    return _test.apply(this, arguments);
+  }
+});"
+`;
+
 exports[`transforms import/export syntax when experimental flag is on 1`] = `
 Array [
   Array [

--- a/packages/metro-transform-worker/src/__tests__/index-test.js
+++ b/packages/metro-transform-worker/src/__tests__/index-test.js
@@ -211,6 +211,36 @@ it('transforms an es module with regenerator', async () => {
   ]);
 });
 
+it('transforms async generators', async () => {
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    'local/file.js',
+    'export async function* test() { yield "ok"; }',
+    {
+      dev: true,
+      type: 'module',
+      unstable_transformProfile: 'hermes-stable',
+    },
+  );
+
+  expect(result.output[0].data.code).toMatchSnapshot();
+  expect(result.dependencies).toEqual([
+    {
+      data: expect.objectContaining({asyncType: null}),
+      name: '@babel/runtime/helpers/interopRequireDefault',
+    },
+    {
+      data: expect.objectContaining({asyncType: null}),
+      name: '@babel/runtime/helpers/awaitAsyncGenerator',
+    },
+    {
+      data: expect.objectContaining({asyncType: null}),
+      name: '@babel/runtime/helpers/wrapAsyncGenerator',
+    },
+  ]);
+});
+
 it('transforms import/export syntax when experimental flag is on', async () => {
   const contents = ['import c from "./c";'].join('\n');
 

--- a/packages/metro-transform-worker/src/__tests__/index-test.js
+++ b/packages/metro-transform-worker/src/__tests__/index-test.js
@@ -220,7 +220,6 @@ it('transforms async generators', async () => {
     {
       dev: true,
       type: 'module',
-      unstable_transformProfile: 'hermes-stable',
     },
   );
 
@@ -229,6 +228,10 @@ it('transforms async generators', async () => {
     {
       data: expect.objectContaining({asyncType: null}),
       name: '@babel/runtime/helpers/interopRequireDefault',
+    },
+    {
+      data: expect.objectContaining({asyncType: null}),
+      name: '@babel/runtime/regenerator',
     },
     {
       data: expect.objectContaining({asyncType: null}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,6 +383,15 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.7.tgz#0c3ed4a2eb07b165dfa85b3cc45c727334c4edae"
   integrity sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==
 
+"@babel/plugin-proposal-async-generator-functions@^7.0.0":
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.15.tgz#80e549df273a3b3050431b148c892491df1bcc5b"
+  integrity sha512-VapibkWzFeoa6ubXy/NgV5U2U4MVnUlvnx6wo1XhlsaTrLYWE0UFpDQsVrmn22q5CzeloqJ8gEMHSKxuee6ZdA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-remap-async-to-generator" "^7.13.0"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+
 "@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz#146376000b94efd001e57a40a88a525afaab9f37"


### PR DESCRIPTION
**Summary**

Async Generators and `for await` are part of ES2018. This PR adds `plugin-proposal-async-generator-functions` to the react native preset.
See https://babeljs.io/docs/en/babel-plugin-proposal-async-generator-functions

Fixes #551 

**Test plan**

I added a test `transforms async generators` to `index-test.js`.
