### PR TITLE
Update hash function for node 17 compatibility

### DIFF
--- a/packages/metro-cache/src/stableHash.js
+++ b/packages/metro-cache/src/stableHash.js
@@ -16,7 +16,7 @@ const canonicalize = require('metro-core/src/canonicalize');
 function stableHash(value: mixed): Buffer {
   return (
     crypto
-      .createHash('md4')
+      .createHash('md5')
       /* $FlowFixMe(>=0.95.0 site=react_native_fb) This comment suppresses an
        * error found when Flow v0.95 was deployed. To see the error, delete this
        * comment and run Flow. */


### PR DESCRIPTION
When running a RN project currently with node 17 it will fail because a deprecated hash function is used with the [node crypto library](https://nodejs.org/en/blog/release/v17.0.0/#openssl-3-0). The error is `ERR_OSSL_EVP_UNSUPPORTED` and will always appear unless a flag is explicitly set. Only the `metro-cache` package is affected. The stable version node 17 has been around for 3 months and will become active LTS in April of this year.

**Summary**

Switching from a 128 bit `md4` hash to another 128 bit `md5` hash that's safe is enough to fix the issue. However, note that I'm neither a hash function nor a metro cache expert.

**Test plan**

Tested with stable node 17, with LTS node 16 and also works fine with lowest supported node 12 version.
An already built project can be upgraded without the need to clear the cache.

Fixes #722

Couldn't find any related issues in the main RN repository.