### PR TITLE
chore(docs): display last update time

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,6 +18,7 @@ const siteConfig = {
           path: '../docs',
           editUrl: 'https://github.com/facebook/metro/edit/main/docs',
           sidebarPath: require.resolve('./sidebars.json'),
+          showLastUpdateTime: true,
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Prior this PR, there was no way to tell if we are reading a new version of the docs besides reading it entirely.

Now we'll get something like this:

![image](https://user-images.githubusercontent.com/13461315/148601214-a369c88c-bc0f-4730-9170-ecb8f20f9d8d.png)