### PR TITLE
Allow for async minifiers

### DIFF
--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -72,7 +72,9 @@ export type MinifierResult = {
   ...
 };
 
-export type Minifier = MinifierOptions => MinifierResult;
+export type Minifier = MinifierOptions =>
+  | MinifierResult
+  | Promise<MinifierResult>;
 
 export type Type = 'script' | 'module' | 'asset';
 
@@ -218,7 +220,7 @@ const minifyCode = async (
   const minify = getMinifier(config.minifierPath);
 
   try {
-    const minified = minify({
+    const minified = await minify({
       code,
       map: sourceMap,
       filename,


### PR DESCRIPTION
**Summary**

Terser v5 is async, so if we want to upgrade to support the latest syntax we need this.

**Test plan**

Existing unit tests - this only adds an await clause, which is safe to do to non-promises, so it shouldn't break anything.
