### PR TITLE
Use node devtools url

### DIFF
--- a/packages/metro-inspector-proxy/src/InspectorProxy.js
+++ b/packages/metro-inspector-proxy/src/InspectorProxy.js
@@ -119,7 +119,7 @@ class InspectorProxy {
     const debuggerUrl = `${this._serverAddressWithPort}${WS_DEBUGGER_URL}?device=${deviceId}&page=${page.id}`;
     const webSocketDebuggerUrl = 'ws://' + debuggerUrl;
     const devtoolsFrontendUrl =
-      'chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=' +
+      'devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=' +
       encodeURIComponent(debuggerUrl);
     return {
       id: `${deviceId}-${page.id}`,


### PR DESCRIPTION
**Summary**

This uses the new chrome devtools ui, this is the one used by the nodejs inspector. It is more focused on js debugging / profiling instead of general browser devtools.

**Test plan**

Tested that it works in Flipper and also when opened directly in chrome.

### Before

<img width="1396" alt="image" src="https://user-images.githubusercontent.com/2677334/150821665-1e27e6bb-62da-4d1c-8f0b-2b980c2135fe.png">

### After

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/2677334/150821129-ac55243f-3a77-47cf-907c-651568e7215b.png">
