### PR TITLE
Bump react-refresh to 0.11.x

### DIFF
--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -57,7 +57,7 @@
     "@babel/plugin-transform-typescript": "^7.5.0",
     "@babel/plugin-transform-unicode-regex": "^7.0.0",
     "@babel/template": "^7.0.0",
-    "react-refresh": "^0.4.0"
+    "react-refresh": "^0.11.0"
   },
   "peerDependencies": {
     "@babel/core": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6327,10 +6327,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-refresh@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.2.tgz#54a277a6caaac2803d88f1d6f13c1dcfbd81e334"
-  integrity sha512-kv5QlFFSZWo7OlJFNYbxRtY66JImuP2LcrFgyJfQaf85gSP+byzG21UbDQEYjU7f//ny8rwiEkO6py2Y+fEgAQ==
+react-refresh@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
+  integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
 read-cmd-shim@^1.0.1:
   version "1.0.5"


### PR DESCRIPTION
It has received a lot of small fixes since 0.4.x that would be nice to
use in react-native.