### PR TITLE
Change actions trigger to use `main` branch

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - "master"
+      - "main"
     paths:
       - "docs/**"
       - "website/**"


### PR DESCRIPTION
This hasn't been updated since we renamed from `master`, and resulted in deploy not triggering.