### PR TITLE
Allow customizing the babel transform runtime version

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -229,9 +229,12 @@ Whether we should use the `.babelrc` config file.
 
 #### `enableBabelRuntime`
 
-Type: `boolean` (default: `true`)
+Type: `boolean | string` (default: `true`)
 
 Whether the transformer should use the `@babel/transform/runtime` plugin.
+
+If the value is a string, it is treated as a runtime version number and passed as `version` to the `@babel/plugin-transform-runtime` configuration. This allows you to optimize the generated babel runtime based on the
+runtime in the app's node modules confugration.
 
 #### `getTransformOptions`
 

--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -30,7 +30,7 @@ type BabelTransformerOptions = $ReadOnly<{
   customTransformOptions?: CustomTransformOptions,
   dev: boolean,
   enableBabelRCLookup?: boolean,
-  enableBabelRuntime: boolean,
+  enableBabelRuntime: boolean | string,
   extendsBabelConfigPath?: string,
   experimentalImportSupport?: boolean,
   hermesParser?: boolean,

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -165,7 +165,7 @@ const getPreset = (src, options) => {
 
   if (!options || options.enableBabelRuntime !== false) {
     // Allows configuring a specific runtime version to optimize output
-    const isVersion = typeof options.enableBabelRuntime === 'string';
+    const isVersion = typeof options?.enableBabelRuntime === 'string';
 
     extraPlugins.push([
       require('@babel/plugin-transform-runtime'),

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -172,7 +172,7 @@ const getPreset = (src, options) => {
       {
         helpers: true,
         regenerator: !isHermes,
-        version: isVersion ? options.enableBabelRuntime : '7.0.0-beta.0',
+        ...(isVersion && {version: options.enableBabelRuntime}),
       },
     ]);
   }

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -164,11 +164,15 @@ const getPreset = (src, options) => {
   }
 
   if (!options || options.enableBabelRuntime !== false) {
+    // Allows configuring a specific runtime version to optimize output
+    const isVersion = typeof options.enableBabelRuntime === 'string';
+
     extraPlugins.push([
       require('@babel/plugin-transform-runtime'),
       {
         helpers: true,
         regenerator: !isHermes,
+        version: isVersion ? options.enableBabelRuntime : '7.0.0-beta.0',
       },
     ]);
   }

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -85,7 +85,7 @@ export type JsTransformerConfig = $ReadOnly<{|
   babelTransformerPath: string,
   dynamicDepsInPackages: DynamicRequiresBehavior,
   enableBabelRCLookup: boolean,
-  enableBabelRuntime: boolean,
+  enableBabelRuntime: boolean | string,
   experimentalImportBundleSupport: boolean,
   globalPrefix: string,
   hermesParser: boolean,


### PR DESCRIPTION
**Summary**

As described in PR #714 , when the bundle is built using a recent version of babel, some helpers are defined repeatedly instead of being referenced via the runtime. In our case, `_getRequireWildcardCache()` and `_interopRequireWildcard()`.

Since the react native preset configures `@babel/plugin-transform-runtime` when `enableBabelRuntime` is enabled, I thought it would be straightforward to overload this metro configuration option to allow the runtime version to be specified. Therefore, changing `babel.config.js` to be:
```javascript
module.exports = {
  presets: [
    [
      "module:metro-react-native-babel-preset",
      { enableBabelRuntime: "7.14.5" }
    ]
  ]
};
```
The above would both enable the runtime and configure it to use version `7.14.5` behaviors. An app developer can do `yarn why @babel/runtime` to determine the runtime version and specify it in this configuration.

Adding this option doesn't change the behavior for existing users who are using `true | false | undefined` for the babel runtime configuration.

**Test plan**

All unit tests pass.

I modified our application as specified above while referencing my modified build of metro. The bundle showed a 6% size reduction and `_interopRequireWildcard` was required via the runtime.
