### PR TITLE
Move the `SegmentedComponentIOS` away from React Native Core

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/lazy-imports.js
+++ b/packages/metro-react-native-babel-preset/src/configs/lazy-imports.js
@@ -32,7 +32,6 @@ module.exports = new Set([
   'SafeAreaView',
   'ScrollView',
   'SectionList',
-  'SegmentedControlIOS',
   'Slider',
   'Switch',
   'RefreshControl',


### PR DESCRIPTION
Summary: This Diff moves the `SegmentedComponentIOS` away from the core of React Native to move forward with the Lean Core effort

Differential Revision: D34304255

