### PR TITLE
Enable `loose` on `plugin-transform-classes` for smaller bundles

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -77,7 +77,12 @@ const getPreset = (src, options) => {
   }
 
   if (hasClass) {
-    extraPlugins.push([require('@babel/plugin-transform-classes')]);
+    // If the code makes heavy use of classes, we can save a lot of bytes by
+    // avoiding injecting `@babel/runtime` helpers.
+    extraPlugins.push([
+      require('@babel/plugin-transform-classes'),
+      {loose: !options.dev},
+    ]);
   }
 
   // TODO(gaearon): put this back into '=>' indexOf bailout


### PR DESCRIPTION
## Summary

`plugin-transform-classes` currently injects lots of helper functions for every class it encounters. If a codebase makes heavy use of classes, there is a lot to be saved by enabling loose mode.

## Test plan

The output should be smaller, but it's functionally the same.