### PR TITLE
Remove `@babel/plugin-transform-regenerator`

### DIFF
--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -47,7 +47,6 @@
     "@babel/plugin-transform-react-jsx": "^7.0.0",
     "@babel/plugin-transform-react-jsx-self": "^7.0.0",
     "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-    "@babel/plugin-transform-regenerator": "^7.0.0",
     "@babel/plugin-transform-async-to-generator": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/plugin-transform-shorthand-properties": "^7.0.0",

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -120,9 +120,7 @@ const getPreset = (src, options) => {
     extraPlugins.push([
       require('@babel/plugin-proposal-async-generator-functions'),
     ]);
-    extraPlugins.push([
-      require('@babel/plugin-transform-async-to-generator'),
-    ]);
+    extraPlugins.push([require('@babel/plugin-transform-async-to-generator')]);
   }
   if (!isHermes && (isNull || src.indexOf('**') !== -1)) {
     extraPlugins.push([

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -20,7 +20,7 @@ function isTSXSource(fileName) {
   return !!fileName && fileName.endsWith('.tsx');
 }
 
-const defaultPluginsBeforeRegenerator = [
+const defaultPlugins = [
   [require('@babel/plugin-syntax-flow')],
   [require('@babel/plugin-transform-block-scoping')],
   [
@@ -31,9 +31,6 @@ const defaultPluginsBeforeRegenerator = [
   [require('@babel/plugin-syntax-dynamic-import')],
   [require('@babel/plugin-syntax-export-default-from')],
   ...passthroughSyntaxPlugins,
-];
-
-const defaultPluginsAfterRegenerator = [
   [require('@babel/plugin-transform-unicode-regex')],
 ];
 
@@ -185,11 +182,7 @@ const getPreset = (src, options) => {
         plugins: [require('@babel/plugin-transform-flow-strip-types')],
       },
       {
-        plugins: [
-          ...defaultPluginsBeforeRegenerator,
-          isHermes ? null : require('@babel/plugin-transform-regenerator'),
-          ...defaultPluginsAfterRegenerator,
-        ].filter(Boolean),
+        plugins: defaultPlugins,
       },
       {
         test: isTypeScriptSource,

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -120,11 +120,9 @@ const getPreset = (src, options) => {
     extraPlugins.push([
       require('@babel/plugin-proposal-async-generator-functions'),
     ]);
-    if (isHermes) {
-      extraPlugins.push([
-        require('@babel/plugin-transform-async-to-generator'),
-      ]);
-    }
+    extraPlugins.push([
+      require('@babel/plugin-transform-async-to-generator'),
+    ]);
   }
   if (!isHermes && (isNull || src.indexOf('**') !== -1)) {
     extraPlugins.push([

--- a/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
@@ -237,7 +237,7 @@ Object {
 }
 `;
 
-exports[`transforms an es module with regenerator 1`] = `
+exports[`transforms an es module with asyncToGenerator 1`] = `
 "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], \\"@babel/runtime/helpers/interopRequireDefault\\");
 
@@ -246,23 +246,20 @@ exports[`transforms an es module with regenerator 1`] = `
   });
   exports.test = test;
 
-  var _regenerator = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], \\"@babel/runtime/regenerator\\"));
+  var _asyncToGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], \\"@babel/runtime/helpers/asyncToGenerator\\"));
 
   function test() {
-    return _regenerator.default.async(function test$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-          case \\"end\\":
-            return _context.stop();
-        }
-      }
-    }, null, this);
+    return _test.apply(this, arguments);
+  }
+
+  function _test() {
+    _test = (0, _asyncToGenerator2.default)(function* () {});
+    return _test.apply(this, arguments);
   }
 });"
 `;
 
-exports[`transforms an es module with regenerator 2`] = `
+exports[`transforms an es module with asyncToGenerator 2`] = `
 Object {
   "mappings": "AAA,OC",
   "names": Array [
@@ -281,32 +278,18 @@ exports[`transforms async generators 1`] = `
   });
   exports.test = test;
 
-  var _regenerator = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], \\"@babel/runtime/regenerator\\"));
+  var _awaitAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], \\"@babel/runtime/helpers/awaitAsyncGenerator\\"));
 
-  var _awaitAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[2], \\"@babel/runtime/helpers/awaitAsyncGenerator\\"));
-
-  var _wrapAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[3], \\"@babel/runtime/helpers/wrapAsyncGenerator\\"));
+  var _wrapAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[2], \\"@babel/runtime/helpers/wrapAsyncGenerator\\"));
 
   function test() {
     return _test.apply(this, arguments);
   }
 
   function _test() {
-    _test = (0, _wrapAsyncGenerator2.default)(_regenerator.default.mark(function _callee() {
-      return _regenerator.default.wrap(function _callee$(_context) {
-        while (1) {
-          switch (_context.prev = _context.next) {
-            case 0:
-              _context.next = 2;
-              return \\"ok\\";
-
-            case 2:
-            case \\"end\\":
-              return _context.stop();
-          }
-        }
-      }, _callee);
-    }));
+    _test = (0, _wrapAsyncGenerator2.default)(function* () {
+      yield \\"ok\\";
+    });
     return _test.apply(this, arguments);
   }
 });"

--- a/packages/metro-transform-worker/src/__tests__/index-test.js
+++ b/packages/metro-transform-worker/src/__tests__/index-test.js
@@ -176,7 +176,7 @@ it('transforms a module with dependencies', async () => {
   ]);
 });
 
-it('transforms an es module with regenerator', async () => {
+it('transforms an es module with asyncToGenerator', async () => {
   const result = await Transformer.transform(
     baseConfig,
     '/root',
@@ -189,13 +189,8 @@ it('transforms an es module with regenerator', async () => {
   );
 
   expect(result.output[0].type).toBe('js/module');
-  const code = result.output[0].data.code.split('\n');
-  // Ignore a small difference in regenerator output
-  if (code[code.length - 3] === '    }, null, null, null, Promise);') {
-    code[code.length - 3] = '    }, null, this);';
-  }
-  expect(code.join('\n')).toMatchSnapshot();
-  expect(result.output[0].data.map).toHaveLength(13);
+  expect(result.output[0].data.code).toMatchSnapshot();
+  expect(result.output[0].data.map).toHaveLength(6);
   expect(result.output[0].data.functionMap).toMatchSnapshot();
   expect(result.dependencies).toEqual([
     {
@@ -204,7 +199,7 @@ it('transforms an es module with regenerator', async () => {
     },
     {
       data: expect.objectContaining({asyncType: null}),
-      name: '@babel/runtime/regenerator',
+      name: '@babel/runtime/helpers/asyncToGenerator',
     },
   ]);
 });
@@ -226,10 +221,6 @@ it('transforms async generators', async () => {
     {
       data: expect.objectContaining({asyncType: null}),
       name: '@babel/runtime/helpers/interopRequireDefault',
-    },
-    {
-      data: expect.objectContaining({asyncType: null}),
-      name: '@babel/runtime/regenerator',
     },
     {
       data: expect.objectContaining({asyncType: null}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,13 +736,6 @@
     "@babel/plugin-syntax-jsx" "^7.12.13"
     "@babel/types" "^7.13.12"
 
-"@babel/plugin-transform-regenerator@^7.0.0":
-  version "7.13.15"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.13.15.tgz#e5eb28945bf8b6563e7f818945f966a8d2997f39"
-  integrity sha512-Bk9cOLSz8DiurcMETZ8E2YtIVJbFCPGW28DJWUakmyVWtQSm6Wsf0p4B4BfEr/eL2Nkhe/CICiUiMOCi1TPhuQ==
-  dependencies:
-    regenerator-transform "^0.14.2"
-
 "@babel/plugin-transform-runtime@^7.0.0":
   version "7.13.15"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.15.tgz#2eddf585dd066b84102517e10a577f24f76a9cd7"
@@ -842,13 +835,6 @@
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
   integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.8.4":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
-  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -6237,11 +6223,6 @@ pretty-format@^26.5.2, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-private@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
-  integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
-
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -6456,14 +6437,6 @@ regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
-
-regenerator-transform@^0.14.2:
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.4.tgz#5266857896518d1616a78a0479337a30ea974cc7"
-  integrity sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    private "^0.1.8"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary

Hermes added support for generators in 0.2.0, and JSC is ES6 feature complete since [r202125](https://webkit.org/blog/6756/es6-feature-complete/).

## Test plan

n/a