### PR TITLE
Added named groups babel transform to rn babel preset

### DIFF
--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -42,6 +42,7 @@
     "@babel/plugin-transform-function-name": "^7.0.0",
     "@babel/plugin-transform-literals": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+    "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
     "@babel/plugin-transform-parameters": "^7.0.0",
     "@babel/plugin-transform-react-display-name": "^7.0.0",
     "@babel/plugin-transform-react-jsx": "^7.0.0",

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -34,6 +34,7 @@ const defaultPluginsBeforeRegenerator = [
 ];
 
 const defaultPluginsAfterRegenerator = [
+  [require('@babel/plugin-transform-named-capturing-groups-regex')],
   [require('@babel/plugin-transform-unicode-regex')],
 ];
 

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -31,7 +31,6 @@ const defaultPlugins = [
   [require('@babel/plugin-syntax-dynamic-import')],
   [require('@babel/plugin-syntax-export-default-from')],
   ...passthroughSyntaxPlugins,
-  [require('@babel/plugin-transform-named-capturing-groups-regex')],
   [require('@babel/plugin-transform-unicode-regex')],
 ];
 
@@ -92,6 +91,10 @@ const getPreset = (src, options) => {
     extraPlugins.push([require('@babel/plugin-transform-function-name')]);
     extraPlugins.push([require('@babel/plugin-transform-literals')]);
     extraPlugins.push([require('@babel/plugin-transform-sticky-regex')]);
+  } else {
+    extraPlugins.push([
+      require('@babel/plugin-transform-named-capturing-groups-regex'),
+    ]);
   }
   if (!isHermesCanary) {
     extraPlugins.push([


### PR DESCRIPTION
## Summary

Hermes currently does not support regex named groups. Whenever a library is included that uses named groups the rn build with hermes will fail (as it doesn't compile). This is already the case when using jest 27 as this includes a dependency (ansi-styles) that uses named-groups which is transitively included via pretty-format in HMRClient.

## Test plan

no test plan