### PR TITLE
Remove `plugin-transform-for-of` from react-native-babel-preset

### DIFF
--- a/packages/metro-react-native-babel-preset/package.json
+++ b/packages/metro-react-native-babel-preset/package.json
@@ -38,7 +38,6 @@
     "@babel/plugin-transform-destructuring": "^7.0.0",
     "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
-    "@babel/plugin-transform-for-of": "^7.0.0",
     "@babel/plugin-transform-function-name": "^7.0.0",
     "@babel/plugin-transform-literals": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.0.0",

--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -43,8 +43,6 @@ const getPreset = (src, options) => {
 
   const isNull = src == null;
   const hasClass = isNull || src.indexOf('class') !== -1;
-  const hasForOf =
-    isNull || (src.indexOf('for') !== -1 && src.indexOf('of') !== -1);
 
   const extraPlugins = [];
   if (!options.useTransformReactJSXExperimental) {
@@ -123,12 +121,6 @@ const getPreset = (src, options) => {
   if (!isHermes && (isNull || src.indexOf('**') !== -1)) {
     extraPlugins.push([
       require('@babel/plugin-transform-exponentiation-operator'),
-    ]);
-  }
-  if (!isHermes && hasForOf) {
-    extraPlugins.push([
-      require('@babel/plugin-transform-for-of'),
-      {loose: true},
     ]);
   }
   if (


### PR DESCRIPTION
## Summary

As a follow-up to #789 , this PR removes `@babel/plugin-transform-for-of` from the preset for JavaScriptCore users.

## Test plan

All unit tests pass