### PR TITLE
Replace deprecated `uglify-es` with `uglify-js`

### DIFF
--- a/packages/metro-minify-uglify/package.json
+++ b/packages/metro-minify-uglify/package.json
@@ -13,6 +13,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "uglify-es": "^3.1.9"
+    "uglify-js": "^3.15.3"
   }
 }

--- a/packages/metro-minify-uglify/src/__tests__/minify-test.js
+++ b/packages/metro-minify-uglify/src/__tests__/minify-test.js
@@ -15,7 +15,7 @@ import type {BasicSourceMap} from 'metro-source-map';
 
 const minify = require('..');
 
-jest.mock('uglify-es', () => ({
+jest.mock('uglify-js', () => ({
   minify: jest.fn(code => {
     return {
       code: code.replace(/(^|\W)\s+/g, '$1'),
@@ -49,7 +49,8 @@ describe('Minification:', () => {
   let uglify;
 
   beforeEach(() => {
-    uglify = require('uglify-es');
+    // $FlowIgnore[untyped-import]
+    uglify = require('uglify-js');
     /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
      * error found when Flow v0.99 was deployed. To see the error, delete this
      * comment and run Flow. */

--- a/packages/metro-minify-uglify/src/minifier.js
+++ b/packages/metro-minify-uglify/src/minifier.js
@@ -13,7 +13,8 @@
 import type {BasicSourceMap} from 'metro-source-map';
 import type {MinifierOptions, MinifierResult} from 'metro-transform-worker';
 
-const uglify = require('uglify-es');
+// $FlowIgnore[untyped-import]
+const uglify = require('uglify-js');
 
 function minifier(options: MinifierOptions): MinifierResult {
   const result = minify(options);

--- a/packages/metro-source-map/package.json
+++ b/packages/metro-source-map/package.json
@@ -24,6 +24,6 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/parser": "^7.14.0",
-    "uglify-es": "^3.1.9"
+    "uglify-js": "^3.15.3"
   }
 }

--- a/packages/metro-source-map/src/__tests__/composeSourceMaps-test.js
+++ b/packages/metro-source-map/src/__tests__/composeSourceMaps-test.js
@@ -20,7 +20,7 @@ const fs = require('fs');
 const invariant = require('invariant');
 const {add0, add1} = require('ob1');
 const path = require('path');
-const uglifyEs = require('uglify-es');
+const uglify = require('uglify-js');
 
 const TestScript1 =
   '/* Half of a program that throws */\
@@ -83,7 +83,7 @@ describe('composeSourceMaps', () => {
 
   it('verifies merged source maps work the same as applying them separately', () => {
     // Apply two tranformations: compression, then mangling.
-    const stage1 = uglifyEs.minify(
+    const stage1 = uglify.minify(
       {'test1.js': TestScript1, 'test2.js': TestScript2},
       {
         compress: true,
@@ -94,7 +94,7 @@ describe('composeSourceMaps', () => {
     invariant(!('error' in stage1), 'Minification error in stage1');
     // $FlowFixMe: this refinement doesn't work
     const {code: code1, map: map1} = stage1;
-    const stage2 = uglifyEs.minify(
+    const stage2 = uglify.minify(
       {'intermediate.js': code1},
       {compress: true, mangle: true, sourceMap: true},
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,11 +2237,6 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@~2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
-  integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -7545,18 +7540,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-uglify-es@^3.1.9:
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
-  integrity sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==
-  dependencies:
-    commander "~2.13.0"
-    source-map "~0.6.1"
-
 uglify-js@^3.1.4:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.2.tgz#d7dd6a46ca57214f54a2d0a43cad0f35db82ac99"
   integrity sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==
+
+uglify-js@^3.15.3:
+  version "3.15.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.3.tgz#9aa82ca22419ba4c0137642ba0df800cb06e0471"
+  integrity sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary

This PR replaces the deprecated `uglify-es` package (https://www.npmjs.com/package/uglify-es) with the `uglify-js` as suggested in the deprecation notice. 

<img width="1346" alt="Screenshot 2022-03-19 at 18 18 49" src="https://user-images.githubusercontent.com/719641/159132124-f2cb94ed-16fe-4577-a5f9-2d5bce7a4e93.png">

Affected packages are `metro-minify-uglify` and `metro-source-map`.

It looks like the switch should be quite trouble free, since there are almost no difference between packages APIs.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I have updated the dependencies and code, then I run the `test` script from the workspace root.