### PR TITLE
Use Node 16 for `deploy-website` GitHub action

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,7 +17,7 @@ jobs:
 
     env:
       working-directory: website
-      node-version: 12.x
+      node-version: 16.x
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The `deploy-website` GH action is [currently broken](https://github.com/facebook/metro/runs/5422096469) due to a docusaurus requirement for Node >= 14. This updates to 16 (current LTS).