### PR TITLE
Bump 'async' from v2.4.2 to v3.2.2 to fix a prototype pollution exploit

### DIFF
--- a/packages/buck-worker-tool/package.json
+++ b/packages/buck-worker-tool/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "src/worker-tool.js",
   "dependencies": {
-    "async": "^2.4.0",
+    "async": "^3.2.2",
     "duplexer": "^0.1.1",
     "invariant": "^2.2.4",
     "jsonparse": "^1.2.0",

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -22,7 +22,7 @@
     "@babel/types": "^7.0.0",
     "absolute-path": "^0.0.0",
     "accepts": "^1.3.7",
-    "async": "^2.4.0",
+    "async": "^3.2.2",
     "chalk": "^4.0.0",
     "ci-info": "^2.0.0",
     "connect": "^3.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,12 +1704,17 @@ async@^1.5.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.4.0, async@^2.6.2:
+async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
     lodash "^4.17.14"
+
+async@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
The PR is essentially to update [async](https://www.npmjs.com/package/async) to version [3.2.2](https://github.com/caolan/async/blob/master/CHANGELOG.md#v322) to fix t a  [prototype pollution exploit](https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827) found in versions < `3.2.2` . The vulnerability was discovered by [Snyk](https://snyk.io/) has discovered an exploit in  and labelled as **High Severity**.
