### PR TITLE
Add allowDeclareFields to flow babel plugin

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -173,7 +173,13 @@ const getPreset = (src, options) => {
       // the flow strip types plugin must go BEFORE class properties!
       // there'll be a test case that fails if you don't.
       {
-        plugins: [require('@babel/plugin-transform-flow-strip-types')],
+        plugins: [
+          [
+            require('@babel/plugin-transform-flow-strip-types'),
+            // Can be removed when updating to babel 8 since this will be the default.
+            {allowDeclareFields: true},
+          ],
+        ],
       },
       {
         plugins: defaultPlugins,


### PR DESCRIPTION
## Summary

The recommended way to type context in class components when using typescript is to use the declare field syntax (`declare context: React.ContextType<typeof MyContext>`). This syntax triggers an error in `@babel/plugin-transform-flow-strip-types` since it needs the option `allowDeclareFields` (https://babeljs.io/docs/en/babel-plugin-transform-flow-strip-types#allowdeclarefields) to parse it.

## Test plan

Tested in an app using the following code:

```ts
const AppContext = React.createContext<{}>(null);

class App extends React.Component<any> {
  declare context: React.ContextType<typeof AppContext>;
}
```
