### PR TITLE
Add `"react-native"` to `resolverMainFields` defaults

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -117,7 +117,7 @@ An array of source extensions to include in the bundle. For example, if you woul
 
 Type: `Array<string>`
 
-Specify the fields in package.json files that will be used by the module resolver to do redirections when requiring certain packages. The default is `['browser', 'main']`, so the resolver will use the `browser` field if it exists and `main` otherwise.
+Specify the fields in package.json files that will be used by the module resolver to do redirections when requiring certain packages. The default is `['react-native', 'browser', 'main']`, so the resolver will use the `react-native` field if it exists, alternatively the `browser` and `main` otherwise.
 
 #### `disableHierarchicalLookup`
 

--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -60,6 +60,7 @@ Object {
     ],
     "resolveRequest": null,
     "resolverMainFields": Array [
+      "react-native",
       "browser",
       "main",
     ],
@@ -206,6 +207,7 @@ Object {
     ],
     "resolveRequest": null,
     "resolverMainFields": Array [
+      "react-native",
       "browser",
       "main",
     ],
@@ -352,6 +354,7 @@ Object {
     ],
     "resolveRequest": null,
     "resolverMainFields": Array [
+      "react-native",
       "browser",
       "main",
     ],
@@ -498,6 +501,7 @@ Object {
     ],
     "resolveRequest": null,
     "resolverMainFields": Array [
+      "react-native",
       "browser",
       "main",
     ],

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -45,7 +45,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     unstable_hasteMapModulePath: undefined,
     nodeModulesPaths: [],
     resolveRequest: null,
-    resolverMainFields: ['browser', 'main'],
+    resolverMainFields: ['react-native', 'browser', 'main'],
     useWatchman: true,
   },
 


### PR DESCRIPTION
## Summary

This fixes #807 by adding `'react-native'` to the list of default values for the `resolver.resolverMainFields`.

## Test plan

This is a very small change. I verified the snapshot tests failed and updated them accordingly.
