### PR TITLE
Added documentation about React Native CLI defaults

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -11,6 +11,8 @@ A Metro config can be created in these three ways (ordered by priority):
 
 You can also give a custom file to the configuration by specifying `--config <path/to/config>` when calling the CLI.
 
+> **Note:** When Metro is started via the React Native CLI, some defaults are different from those mentioned below. See the [React Native repository](https://github.com/react-native-community/cli/blob/master/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts) for details.
+
 ## Configuration Structure
 
 The configuration is based on [our concepts](./Concepts.md), which means that for every module we have a separate config option. A common configuration structure in Metro looks like this:
@@ -119,7 +121,7 @@ Type: `Array<string>`
 
 Specify the fields in package.json files that will be used by the module resolver to do redirections when requiring certain packages. The default is `['browser', 'main']`, so the resolver will use the `browser` field if it exists and `main` otherwise.
 
-> **Note:**  When Metro is started via the React Native CLI this will default to `['react-native', 'browser', 'main']`.
+> **Note:** When Metro is started via the React Native CLI this will default to `['react-native', 'browser', 'main']`.
 
 #### `disableHierarchicalLookup`
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -11,7 +11,12 @@ A Metro config can be created in these three ways (ordered by priority):
 
 You can also give a custom file to the configuration by specifying `--config <path/to/config>` when calling the CLI.
 
-> **Note:** When Metro is started via the React Native CLI, some defaults are different from those mentioned below. See the [React Native repository](https://github.com/react-native-community/cli/blob/master/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts) for details.
+:::note
+
+When Metro is started via the React Native CLI, some defaults are different from those mentioned below.
+See the [React Native repository](https://github.com/react-native-community/cli/blob/master/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts) for details.
+
+:::
 
 ## Configuration Structure
 
@@ -121,7 +126,11 @@ Type: `Array<string>`
 
 Specify the fields in package.json files that will be used by the module resolver to do redirections when requiring certain packages. The default is `['browser', 'main']`, so the resolver will use the `browser` field if it exists and `main` otherwise.
 
-> **Note:** When Metro is started via the React Native CLI this will default to `['react-native', 'browser', 'main']`.
+:::note
+
+When Metro is started via the React Native CLI this will default to `['react-native', 'browser', 'main']`.
+
+:::
 
 #### `disableHierarchicalLookup`
 
@@ -367,8 +376,12 @@ Using the `metro-config` package it is possible to merge multiple configurations
 | --------------------------------------- | ---------------------------------------------------------------------- |
 | `mergeConfig(...configs): MergedConfig` | Returns the merged configuration of two or more configuration objects. |
 
-> **Note:** Arrays and function based config parameters do not deeply merge and will instead override any pre-existing config parameters.
-> This allows overriding and removing default config parameters such as `platforms` or `getModulesRunBeforeMainModule` that may not be required in your environment.
+:::note
+
+Arrays and function based config parameters do not deeply merge and will instead override any pre-existing config parameters.
+This allows overriding and removing default config parameters such as `platforms` or `getModulesRunBeforeMainModule` that may not be required in your environment.
+
+:::
 
 #### Merging Example
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -119,6 +119,8 @@ Type: `Array<string>`
 
 Specify the fields in package.json files that will be used by the module resolver to do redirections when requiring certain packages. The default is `['browser', 'main']`, so the resolver will use the `browser` field if it exists and `main` otherwise.
 
+> **Note:**  When Metro is started via the React Native CLI this will default to `['react-native', 'browser', 'main']`.
+
 #### `disableHierarchicalLookup`
 
 Type: `boolean`


### PR DESCRIPTION
## Summary

As suggested in https://github.com/facebook/metro/issues/807#issuecomment-1106403161 this adds a general note on the fact that React Native CLI is setting its own defaults. I'm using the same block-quote style note as used in the "Merging Configurations" section of the document.

## Test plan

Only documentation is changed. No need for testing.
