### PR TITLE
Add explicit dependency on `@babel/runtime` to `metro-runtime`

### DIFF
--- a/packages/metro-runtime/package.json
+++ b/packages/metro-runtime/package.json
@@ -12,6 +12,9 @@
     "cleanup-release": "test ! -e build && mv src build && mv src.real src"
   },
   "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.14.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,10 +858,10 @@
     core-js-pure "^3.19.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
-  integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
   dependencies:
     regenerator-runtime "^0.13.4"
 


### PR DESCRIPTION
Summary:
Previously, `babel/runtime` was a transitive dependency of RN projects via `metro-react-native-babel-preset` -> `babel/plugin-transform-regenerator`.

`babel/runtime` is a dependency of injected babel helpers, so we need it to be a transitive dependency of an RN project under `react-native`.

Removing the previous implicit dependency broke RN builds, this adds the dependency to `metro-runtime` to make it explicit.

I've created a 0.70.x branch for Metro from 0.70.2 and will cherry pick this up as a hotfix 0.70.3 release.

Reviewed By: motiz88

Differential Revision: D36165366

