### PR TITLE
Fix missing dependency on `metro-transform-worker`

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -73,7 +73,7 @@ Specify any additional (to projectRoot) watch folders, this is used to know whic
 
 Type: `string`
 
-The path to the transformer to use.
+The absolute path of a module (or a package name resolvable from the `metro` package) exporting a `transform` function.
 
 #### `reporter`
 

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -138,7 +138,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
   projectRoot: projectRoot || path.resolve(__dirname, '../../..'),
   stickyWorkers: true,
   watchFolders: [],
-  transformerPath: require.resolve('metro-transform-worker'),
+  transformerPath: 'metro-transform-worker',
   maxWorkers: getMaxWorkers(),
   resetCache: false,
   reporter: new TerminalReporter(new Terminal(process.stdout)),


### PR DESCRIPTION
Summary:
Currently, `metro-config` calls `require.resolve('metro-transform-worker')` to establish the default value for `transformerPath`. However, `metro-config` doesn't list `metro-transform-worker` as a dependency, so this fails when `metro-config` is used as a standalone package.

It isn't strictly necessary for this value to be an an absolute path in the current implementation - it just needs to be `require`-able from within `metro` (specifically [`DeltaBundler/Worker.js`](https://github.com/facebook/metro/blob/347b1d7ed87995d7951aaa9fd597c04b06013dac/packages/metro/src/DeltaBundler/Worker.js#L61-L64)).

This diff documents that `transformerPath` may be a package name, and changes to the default config to just use the default package name `metro-transform-worker`, removing the dependency.

Fixes https://github.com/facebook/metro/issues/805

Differential Revision: D36208763

