### PR TITLE
removed deprecated `Prop Types` from lazy imports

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/lazy-imports.js
+++ b/packages/metro-react-native-babel-preset/src/configs/lazy-imports.js
@@ -90,10 +90,4 @@ module.exports = new Set([
   'Platform',
   'processColor',
   'requireNativeComponent',
-
-  // Prop Types
-  'DeprecatedColorPropType',
-  'DeprecatedEdgeInsetsPropType',
-  'DeprecatedPointPropType',
-  'DeprecatedViewPropTypes',
 ]);


### PR DESCRIPTION
## Summary
This props were removed from core.
1. https://github.com/facebook/react-native/commit/10199b158138b8645550b5579df87e654213fe42
2. https://github.com/facebook/react-native/commit/cdfddb4dad7c69904850d7e5f089a32a1d3445d1

## Test plan
