### PR TITLE
Bail out of Fast Refresh when a module in a cycle is updated

### DIFF
--- a/packages/metro-runtime/src/polyfills/__tests__/require-test.js
+++ b/packages/metro-runtime/src/polyfills/__tests__/require-test.js
@@ -2564,5 +2564,200 @@ describe('require', () => {
       expect(Refresh.performReactRefresh).not.toHaveBeenCalled();
       expect(Refresh.performFullRefresh).not.toHaveBeenCalled();
     });
+
+    it('bails out if the update involves a cycle', () => {
+      // NOTE: A sufficiently clever algorithm may be able to avoid bailing out
+      // in some cases, but right now this is how we handle cycles; it beats
+      // leaving stale versions of updated modules in the graph.
+
+      createModuleSystem(moduleSystem, true, '');
+      const Refresh = createReactRefreshMock(moduleSystem);
+
+      // This is the module graph:
+      // ┌─────────┐      ┌─────────┐ ────▶ ┌─────────┐
+      // |  Root*  | ───▶ │ MiddleA │ ◀──── | MiddleC |
+      // └─────────┘      └─────────┘       └─────────┘
+      //                     │ ▲              |
+      //                     │ │              |
+      //                     ▼ │              ▼
+      //                  ┌─────────┐       ┌────────┐
+      //                  | MiddleB | ────▶ |  Leaf  |
+      //                  └─────────┘       └────────┘
+      //
+      // * - refresh boundary (exports a component)
+
+      const ids = Object.fromEntries([
+        ['root.js', 0],
+        ['middleA.js', 1],
+        ['middleB.js', 2],
+        ['middleC.js', 3],
+        ['leaf.js', 4],
+      ]);
+
+      createModule(
+        moduleSystem,
+        ids['root.js'],
+        'root.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          require(ids['middleA.js']);
+          module.exports = function Root() {};
+        },
+      );
+      createModule(
+        moduleSystem,
+        ids['middleA.js'],
+        'middleA.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          const MB = require(ids['middleB.js']);
+          require(ids['middleC.js']);
+          module.exports = MB;
+        },
+      );
+      createModule(
+        moduleSystem,
+        ids['middleB.js'],
+        'middleB.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          require(ids['middleA.js']);
+          const L = require(ids['leaf.js']); // Import leaf
+          module.exports = L;
+        },
+      );
+      createModule(
+        moduleSystem,
+        ids['middleC.js'],
+        'middleC.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          require(ids['middleA.js']);
+          require(ids['leaf.js']);
+          module.exports = 0;
+        },
+      );
+      createModule(
+        moduleSystem,
+        ids['leaf.js'],
+        'leaf.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          module.exports = 'version 1';
+        },
+      );
+      moduleSystem.__r(ids['root.js']);
+
+      expect(moduleSystem.__r('middleA.js')).toBe('version 1');
+
+      moduleSystem.__accept(
+        ids['leaf.js'],
+        (global, require, importDefault, importAll, module, exports) => {
+          module.exports = 'version 2';
+        },
+        [],
+        // Inverse dependency map.
+        {
+          [ids['leaf.js']]: [ids['middleC.js'], ids['middleB.js']],
+          [ids['middleC.js']]: [ids['middleA.js']],
+          [ids['middleB.js']]: [ids['middleA.js']],
+          [ids['middleA.js']]: [
+            ids['middleC.js'],
+            ids['middleB.js'],
+            ids['root.js'],
+          ],
+          [ids['root.js']]: [],
+        },
+        undefined,
+      );
+
+      jest.runAllTimers();
+
+      expect(Refresh.performReactRefresh).not.toHaveBeenCalled();
+      expect(Refresh.performFullRefresh).toHaveBeenCalled();
+    });
+
+    it('performs an update when there is an unaffected cycle', () => {
+      createModuleSystem(moduleSystem, true, '');
+      const Refresh = createReactRefreshMock(moduleSystem);
+
+      // This is the module graph:
+      //                 ┌───────────────────┐
+      //                 │                   ▼
+      // ┌───────┐     ┌───┐     ┌───┐     ┌───┐
+      // │ Root* │ ──▶ │ A │ ──▶ │ B │ ──▶ │ C │
+      // └───────┘     └───┘     └───┘     └───┘
+      //                           ▲         │
+      //                           └─────────┘
+      // * - refresh boundary (exports a component)
+
+      const ids = Object.fromEntries([
+        ['root.js', 0],
+        ['A.js', 1],
+        ['B.js', 2],
+        ['C.js', 3],
+      ]);
+
+      createModule(
+        moduleSystem,
+        ids['root.js'],
+        'root.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          require(ids['A.js']);
+          module.exports = function Root() {};
+        },
+      );
+      createModule(
+        moduleSystem,
+        ids['A.js'],
+        'A.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          const B = require(ids['B.js']);
+          const C = require(ids['C.js']);
+          module.exports = 'A = ' + B + C + ' version 1';
+        },
+      );
+      createModule(
+        moduleSystem,
+        ids['B.js'],
+        'B.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          require(ids['C.js']);
+          module.exports = 'B';
+        },
+      );
+      createModule(
+        moduleSystem,
+        ids['C.js'],
+        'C.js',
+        (global, require, importDefault, importAll, module, exports) => {
+          require(ids['B.js']);
+          module.exports = 'C';
+        },
+      );
+      moduleSystem.__r(ids['root.js']);
+
+      expect(moduleSystem.__r(ids['A.js'])).toBe('A = BC version 1');
+
+      moduleSystem.__accept(
+        ids['A.js'],
+        (global, require, importDefault, importAll, module, exports) => {
+          const B = require(ids['B.js']);
+          const C = require(ids['C.js']);
+          module.exports = 'A = ' + B + C + ' version 2';
+        },
+        [],
+        // Inverse dependency map.
+        {
+          [ids['root.js']]: [],
+          [ids['A.js']]: [ids['root.js']],
+          [ids['B.js']]: [ids['A.js'], ids['C.js']],
+          [ids['C.js']]: [ids['A.js'], ids['B.js']],
+        },
+        undefined,
+      );
+
+      expect(moduleSystem.__r(ids['A.js'])).toBe('A = BC version 2');
+
+      jest.runAllTimers();
+
+      expect(Refresh.performReactRefresh).toHaveBeenCalled();
+      expect(Refresh.performFullRefresh).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -74,6 +74,7 @@ var modules = clear();
 // Don't use a Symbol here, it would pull in an extra polyfill with all sorts of
 // additional stuff (e.g. Array.from).
 const EMPTY = {};
+const CYCLE_DETECTED = {};
 const {hasOwnProperty} = {};
 
 if (__DEV__) {
@@ -542,56 +543,67 @@ if (__DEV__) {
     // have side effects and lead to confusing and meaningless crashes.
 
     let didBailOut = false;
-    const updatedModuleIDs = topologicalSort(
-      [id], // Start with the changed module and go upwards
-      pendingID => {
-        const pendingModule = modules[pendingID];
-        if (pendingModule == null) {
-          // Nothing to do.
-          return [];
-        }
-        const pendingHot = pendingModule.hot;
-        if (pendingHot == null) {
-          throw new Error(
-            '[Refresh] Expected module.hot to always exist in DEV.',
-          );
-        }
-        // A module can be accepted manually from within itself.
-        let canAccept = pendingHot._didAccept;
-        if (!canAccept && Refresh != null) {
-          // Or React Refresh may mark it accepted based on exports.
-          const isBoundary = isReactRefreshBoundary(
-            Refresh,
-            pendingModule.publicModule.exports,
-          );
-          if (isBoundary) {
-            canAccept = true;
-            refreshBoundaryIDs.add(pendingID);
+    let updatedModuleIDs;
+    try {
+      updatedModuleIDs = topologicalSort(
+        [id], // Start with the changed module and go upwards
+        pendingID => {
+          const pendingModule = modules[pendingID];
+          if (pendingModule == null) {
+            // Nothing to do.
+            return [];
           }
-        }
-        if (canAccept) {
-          // Don't look at parents.
-          return [];
-        }
-        // If we bubble through the roof, there is no way to do a hot update.
-        // Bail out altogether. This is the failure case.
-        const parentIDs = inverseDependencies[pendingID];
-        if (parentIDs.length === 0) {
-          // Reload the app because the hot reload can't succeed.
-          // This should work both on web and React Native.
-          performFullRefresh('No root boundary', {
-            source: mod,
-            failed: pendingModule,
-          });
-          didBailOut = true;
-          return [];
-        }
-        // This module can't handle the update but maybe all its parents can?
-        // Put them all in the queue to run the same set of checks.
-        return parentIDs;
-      },
-      () => didBailOut, // Should we stop?
-    ).reverse();
+          const pendingHot = pendingModule.hot;
+          if (pendingHot == null) {
+            throw new Error(
+              '[Refresh] Expected module.hot to always exist in DEV.',
+            );
+          }
+          // A module can be accepted manually from within itself.
+          let canAccept = pendingHot._didAccept;
+          if (!canAccept && Refresh != null) {
+            // Or React Refresh may mark it accepted based on exports.
+            const isBoundary = isReactRefreshBoundary(
+              Refresh,
+              pendingModule.publicModule.exports,
+            );
+            if (isBoundary) {
+              canAccept = true;
+              refreshBoundaryIDs.add(pendingID);
+            }
+          }
+          if (canAccept) {
+            // Don't look at parents.
+            return [];
+          }
+          // If we bubble through the roof, there is no way to do a hot update.
+          // Bail out altogether. This is the failure case.
+          const parentIDs = inverseDependencies[pendingID];
+          if (parentIDs.length === 0) {
+            // Reload the app because the hot reload can't succeed.
+            // This should work both on web and React Native.
+            performFullRefresh('No root boundary', {
+              source: mod,
+              failed: pendingModule,
+            });
+            didBailOut = true;
+            return [];
+          }
+          // This module can't handle the update but maybe all its parents can?
+          // Put them all in the queue to run the same set of checks.
+          return parentIDs;
+        },
+        () => didBailOut, // Should we stop?
+      ).reverse();
+    } catch (e) {
+      if (e === CYCLE_DETECTED) {
+        performFullRefresh('Dependency cycle', {
+          source: mod,
+        });
+        return;
+      }
+      throw e;
+    }
 
     if (didBailOut) {
       return;
@@ -601,7 +613,6 @@ if (__DEV__) {
     // Run the actual factories.
     const seenModuleIDs = new Set();
     for (let i = 0; i < updatedModuleIDs.length; i++) {
-      // Don't process twice if we have a cycle.
       const updatedID = updatedModuleIDs[i];
       if (seenModuleIDs.has(updatedID)) {
         continue;
@@ -709,24 +720,29 @@ if (__DEV__) {
   ): Array<T> {
     const result = [];
     const visited = new Set();
+    const stack = new Set();
     function traverseDependentNodes(node: T) {
+      if (stack.has(node)) {
+        throw CYCLE_DETECTED;
+      }
+      if (visited.has(node)) {
+        return;
+      }
       visited.add(node);
+      stack.add(node);
       const dependentNodes = getEdges(node);
       if (earlyStop(node)) {
+        stack.delete(node);
         return;
       }
       dependentNodes.forEach(dependent => {
-        if (visited.has(dependent)) {
-          return;
-        }
         traverseDependentNodes(dependent);
       });
+      stack.delete(node);
       result.push(node);
     }
     roots.forEach(root => {
-      if (!visited.has(root)) {
-        traverseDependentNodes(root);
-      }
+      traverseDependentNodes(root);
     });
     return result;
   };
@@ -806,7 +822,10 @@ if (__DEV__) {
 
   const performFullRefresh = (
     reason: string,
-    modules: $ReadOnly<{source: ModuleDefinition, failed: ModuleDefinition}>,
+    modules: $ReadOnly<{
+      source?: ModuleDefinition,
+      failed?: ModuleDefinition,
+    }>,
   ) => {
     /* global window */
     if (


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/metro/issues/788.

When a bundle first executes, it has a well-defined entry point, so cyclic dependencies are initialised in some deterministic order "from the top down". Our current algorithm for handling incremental updates / Fast Refresh eagerly re-executes modules "from the bottom up", without considering the possibility of cycles. This causes observable breakages such as https://github.com/facebook/metro/issues/788.

**The current diff** improves correctness at the cost of bailing out more often on certain inputs. We do this by explicitly maintaining a stack during the bottom-up traversal and throwing an error when we detect a cycle.

**The ideal solution** would be to rewrite the update propagation algorithm such that it can actually handle cycles without bailing out. gaearon and I discussed a potential approach, where Metro would:

1. Purge all affected modules from the cache.
2. Only directly re-execute Refresh boundaries.
3. Let other updated modules be re-executed "from the top down" implicitly, as a side effect of executing the boundary modules.

However, it seems nontrivial to do this while preserving behaviours such as D15958928 (https://github.com/facebook/metro/commit/c205f5ae8bec0fdfbbffbf37ad10389c543e3e03), which rely on the eager bottom-up evaluation scheme. More work is needed to get this type of solution working satisfactorily, so in the meantime I'm putting up this simpler and less-invasive fix.

Thanks to GitHub user ricmatsui for reporting this issue, along with the original test code and a proposed fix based on cycle detection.

Changelog:
* **[Fixed]** Fixed a bug where a module in a cycle could be stale after a Fast Refresh.

Differential Revision: D36764063

