### PR TITLE
Fix Babel registration when running Metro from source

### DIFF
--- a/packages/metro-babel-register/src/babel-register.js
+++ b/packages/metro-babel-register/src/babel-register.js
@@ -115,7 +115,7 @@ function registerForMetroMonorepo() {
   // Noop if we are in NODE_ENV=production or seem to be outside of the Metro
   // source tree.
   if (
-    process.env.NODE_ENV !== 'production' ||
+    process.env.NODE_ENV === 'production' ||
     !__dirname.endsWith(
       ['', 'packages', 'metro-babel-register', 'src'].join(path.sep),
     )


### PR DESCRIPTION
## Summary

Currently, Babel doesn't register when attempting to run Metro from source unless using `NODE_ENV === 'production'`. This is apparently just a typo.

## Test plan
### Before
```
yarn run test-smoke
yarn run v1.22.5
$ yarn start build --config packages/metro/src/integration_tests/metro.config.js TestBundle.js --out /tmp/TestBundle
/Users/rob/workspace/metro2/packages/metro/src/index.flow.js:13
import type {Graph} from './DeltaBundler';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1032:15)
    at Module._compile (node:internal/modules/cjs/loader:1067:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/rob/workspace/metro2/packages/metro/src/index.js:22:18)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
```

### After
```
yarn run test-smoke
yarn run v1.22.5
$ yarn start build --config packages/metro/src/integration_tests/metro.config.js TestBundle.js --out /tmp/TestBundle
$ node packages/metro/src/cli build --config packages/metro/src/integration_tests/metro.config.js TestBundle.js --out /tmp/TestBundle
 BUNDLE  ./TestBundle.js ░░░░░░░░░░░░░░░░ 0.0% (0/1)Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
 BUNDLE  ./TestBundle.js

 BUNDLE  ./TestBundle.js ▓▓▓▓░░░░░░░░░░░░ 25.0% (3/6)Writing bundle output to: /tmp/TestBundle.js
Done writing bundle output
✨  Done in 2.01s.
```