### PR TITLE
Fix a $FlowFixMe

### DIFF
--- a/scripts/babelJestTransformer.js
+++ b/scripts/babelJestTransformer.js
@@ -14,7 +14,6 @@ const babelJest = require('babel-jest');
 
 const BABEL_CONFIG_PATH = require.resolve('../babel.config.js');
 
-// $FlowFixME
 const transformer /*: any */ = babelJest.createTransformer({
   configFile: BABEL_CONFIG_PATH,
 });


### PR DESCRIPTION
Summary: After removing the $FlowFixMe found in babelJestTransformer.js we get no error. I've simply removed the $FlowFixMe.

Reviewed By: robhogan

Differential Revision: D37002177

