### PR TITLE
Use explicit key for tracking dependencies in bundler

### DIFF
--- a/packages/metro/src/DeltaBundler/Serializers/helpers/__tests__/bytecode-test.js
+++ b/packages/metro/src/DeltaBundler/Serializers/helpers/__tests__/bytecode-test.js
@@ -33,14 +33,14 @@ beforeEach(() => {
         'bar',
         {
           absolutePath: '/bar',
-          data: {data: {asyncType: null, locs: []}, name: 'bar'},
+          data: {data: {asyncType: null, locs: [], key: 'bar'}, name: 'bar'},
         },
       ],
       [
         'baz',
         {
           absolutePath: '/baz',
-          data: {data: {asyncType: null, locs: []}, name: 'baz'},
+          data: {data: {asyncType: null, locs: [], key: 'baz'}, name: 'baz'},
         },
       ],
     ]),

--- a/packages/metro/src/DeltaBundler/Serializers/helpers/__tests__/js-test.js
+++ b/packages/metro/src/DeltaBundler/Serializers/helpers/__tests__/js-test.js
@@ -26,14 +26,14 @@ beforeEach(() => {
         'bar',
         {
           absolutePath: '/bar',
-          data: {data: {asyncType: null, locs: []}, name: 'bar'},
+          data: {data: {asyncType: null, locs: [], key: 'bar'}, name: 'bar'},
         },
       ],
       [
         'baz',
         {
           absolutePath: '/baz',
-          data: {data: {asyncType: null, locs: []}, name: 'baz'},
+          data: {data: {asyncType: null, locs: [], key: 'baz'}, name: 'baz'},
         },
       ],
     ]),

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/traverseDependencies-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/traverseDependencies-test.js.snap
@@ -5,11 +5,12 @@ Object {
   "dependencies": Map {
     "/bundle" => Object {
       "dependencies": Map {
-        "foo" => Object {
+        "C+7Hteo/D9vJXQ3UfzxbwnXaijM=" => Object {
           "absolutePath": "/foo",
           "data": Object {
             "data": Object {
               "asyncType": null,
+              "key": "C+7Hteo/D9vJXQ3UfzxbwnXaijM=",
               "locs": Array [],
             },
             "name": "foo",
@@ -32,21 +33,23 @@ Object {
     },
     "/foo" => Object {
       "dependencies": Map {
-        "bar" => Object {
+        "Ys23Ag/5IOWqZCw9QGaVDdHwH00=" => Object {
           "absolutePath": "/bar",
           "data": Object {
             "data": Object {
               "asyncType": null,
+              "key": "Ys23Ag/5IOWqZCw9QGaVDdHwH00=",
               "locs": Array [],
             },
             "name": "bar",
           },
         },
-        "baz" => Object {
+        "u+lgol6jEdIdQGaek98gA7qbkKI=" => Object {
           "absolutePath": "/baz",
           "data": Object {
             "data": Object {
               "asyncType": null,
+              "key": "u+lgol6jEdIdQGaek98gA7qbkKI=",
               "locs": Array [],
             },
             "name": "baz",
@@ -127,11 +130,12 @@ Object {
   "dependencies": Map {
     "/bundle" => Object {
       "dependencies": Map {
-        "foo" => Object {
+        "C+7Hteo/D9vJXQ3UfzxbwnXaijM=" => Object {
           "absolutePath": "/foo",
           "data": Object {
             "data": Object {
               "asyncType": null,
+              "key": "C+7Hteo/D9vJXQ3UfzxbwnXaijM=",
               "locs": Array [],
             },
             "name": "foo",

--- a/packages/metro/src/DeltaBundler/types.flow.js
+++ b/packages/metro/src/DeltaBundler/types.flow.js
@@ -31,10 +31,13 @@ export type TransformResultDependency = {
   +name: string,
 
   /**
-   * Extra data returned by the dependency extractor. Whatever is added here is
-   * blindly piped by Metro to the serializers.
+   * Extra data returned by the dependency extractor.
    */
   +data: {
+    /**
+     * A locally unique key for this dependency within the current module.
+     */
+    +key: string,
     /**
      * If not null, this dependency is due to a dynamic `import()` or `__prefetchImport()` call.
      */

--- a/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
@@ -1476,6 +1476,9 @@ class MockModuleDependencyRegistry<TSplitCondition>
       asyncType: qualifier.asyncType,
       isOptional: qualifier.optional ?? false,
       locs: [],
+
+      // Index = easy key for every dependency since we don't collapse/reorder
+      key: String(this._dependencies.length),
     };
 
     if (qualifier.splitCondition) {

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -52,6 +52,8 @@ export type RequireContextParams = $ReadOnly<{
 }>;
 
 type DependencyData<TSplitCondition> = $ReadOnly<{
+  // A locally unique key for this dependency within the current module.
+  key: string,
   // If null, then the dependency is synchronous.
   // (ex. `require('foo')`)
   asyncType: AsyncDependencyType | null,
@@ -777,6 +779,7 @@ class DefaultModuleDependencyRegistry<TSplitCondition = void>
         asyncType: qualifier.asyncType,
         locs: [],
         index: this._dependencies.size,
+        key: require('crypto').createHash('sha1').update(key).digest('base64'),
       };
 
       if (qualifier.optional) {


### PR DESCRIPTION
Summary:
Changes `collectDependencies` so it is responsible for providing a key with each extracted dependency. This key should be *stable* across builds and when dependencies are reordered, and *must* be locally unique within a given module.

NOTE: This is a similar concept to the [`key`](https://reactjs.org/docs/lists-and-keys.html#keys) prop in React. It's also used for a similar purpose - `traverseDependencies` is not unlike a tree diffing algorithm.

Previously, the `name` property ( = the first argument to `require` etc) *implicitly* served as this key in both `collectDependencies` and DeltaBundler, but since the addition of `require.context` dependency descriptors in https://github.com/facebook/metro/pull/821, this is no longer strictly correct. (This diff therefore unblocks implementing `require.context` in DeltaBundler.)

Instead of teaching DeltaBundler to internally re-derive suitable keys from the dependency descriptors - essentially duplicating the logic in `collectDependencies` - the approach taken here is to require `collectDependencies` to return an *explicit* key as part of each descriptor.

NOTE: Keys should be considered completely opaque. As an implementation detail (that may change without notice), we hash the keys to obfuscate them and deter downstream code from depending on the information in them.

Note that it's safe for multiple descriptors to resolve to a single module (as of D37194640 (https://github.com/facebook/metro/commit/fc29a1177f883144674cf85a813b58567f69d545)), so from DeltaBundler's perspective it's now perfectly valid for `collectDependencies` to not collapse dependencies at all (e.g. even generate one descriptor per `require` call site) as long as it provides a unique key with each one.

WARNING: This diff exposes a **preexisting** bug affecting optional dependencies (introduced in https://github.com/facebook/metro/pull/511) - see FIXME comment in `graphOperations.js` for the details. This will require more followup in a separate diff.

Differential Revision: D37205825

