### PR TITLE
Fix a $FlowFixMe

### DIFF
--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -154,8 +154,9 @@ async function getAbsoluteAssetRecord(
 
   if (!record) {
     throw new Error(
-      /* $FlowFixMe: platform can be null */
-      `Asset not found: ${assetPath} for platform: ${platform}`,
+      `Asset not found: ${assetPath} for platform: ${
+        platform ?? '(unspecified)'
+      }`,
     );
   }
 


### PR DESCRIPTION
Summary:
Removing the `$FlowFixMe: platform can be null` resulted in:

Cannot coerce `platform` to string because  null or undefined [1] should not be coerced.

The getAbsoluteAssetRecord method is called by various other methods in Assets.js. When researching whether the type for the platform parameter could be changed to a non-nullable string, I found that in upstream functions the platform can be identied from file sub-extensions (like `index.ios.js` as mentioned in `parsePlatformFilePath` for instance).

This means the platform parameter should indeed be optional, and therefore displaying it as '(unspecified)' when throwing an error seems reasonable as we can assume it will be present when it can be known.

Reviewed By: robhogan

Differential Revision: D37753953

