### PR TITLE
Enable react 17 new jsx transform

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -47,7 +47,7 @@ const getPreset = (src, options) => {
   const extraPlugins = [];
   if (!options.useTransformReactJSXExperimental) {
     extraPlugins.push([
-      require('@babel/plugin-transform-react-jsx', {useBuiltIns: true}),
+      require('@babel/plugin-transform-react-jsx', {runtime: 'automatic'}),
     ]);
   }
 


### PR DESCRIPTION
## Summary

See https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#runtime

Fixes #646

## Test plan

The transpiled output should contain the new jsx transform as detailed in https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
