### PR TITLE
Fixed typo causing option to not be applied

### DIFF
--- a/packages/metro-react-native-babel-preset/src/configs/main.js
+++ b/packages/metro-react-native-babel-preset/src/configs/main.js
@@ -47,7 +47,8 @@ const getPreset = (src, options) => {
   const extraPlugins = [];
   if (!options.useTransformReactJSXExperimental) {
     extraPlugins.push([
-      require('@babel/plugin-transform-react-jsx', {runtime: 'automatic'}),
+      require('@babel/plugin-transform-react-jsx'),
+      {runtime: 'automatic'},
     ]);
   }
 


### PR DESCRIPTION
## Summary

Follow up to https://github.com/facebook/metro/commit/1b6dd6f05a18836f169f49a4e3b1730d1467e84a

The option did not get applied as the object was passed to require instead of babel as a result of the `)` being set in the wrong place.

Very sorry to cause you extra work @dmitryrykun @motiz88
