### PR TITLE
feat: load `hermes-parser` conditionally when hermes is enabled

### DIFF
--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -14,7 +14,6 @@ import type {BabelCoreOptions} from '@babel/core';
 import type {FBSourceFunctionMap} from 'metro-source-map';
 
 const {parseSync, transformFromAstSync} = require('@babel/core');
-const HermesParser = require('hermes-parser');
 const {generateFunctionMap} = require('metro-source-map');
 const nullthrows = require('nullthrows');
 
@@ -81,7 +80,7 @@ function transform({filename, options, plugins, src}: BabelTransformerArgs) {
       sourceType: 'module',
     };
     const sourceAst = options.hermesParser
-      ? HermesParser.parse(src, {
+      ? require('hermes-parser').parse(src, {
           babel: true,
           sourceType: babelConfig.sourceType,
         })

--- a/packages/metro-react-native-babel-transformer/src/index.js
+++ b/packages/metro-react-native-babel-transformer/src/index.js
@@ -23,7 +23,6 @@ const {parseSync, transformFromAstSync} = require('@babel/core');
 const inlineRequiresPlugin = require('babel-preset-fbjs/plugins/inline-requires');
 const crypto = require('crypto');
 const fs = require('fs');
-const HermesParser = require('hermes-parser');
 const makeHMRConfig = require('metro-react-native-babel-preset/src/configs/hmr');
 const {generateFunctionMap} = require('metro-source-map');
 const nullthrows = require('nullthrows');
@@ -211,7 +210,7 @@ function transform({filename, options, src, plugins}: BabelTransformerArgs): {
       isTSXSource(filename) ||
       !options.hermesParser
         ? parseSync(src, babelConfig)
-        : HermesParser.parse(src, {
+        : require('hermes-parser').parse(src, {
             babel: true,
             sourceType: babelConfig.sourceType,
           });

--- a/packages/metro/src/ModuleGraph/output/util.js
+++ b/packages/metro/src/ModuleGraph/output/util.js
@@ -18,7 +18,6 @@ const generate = require('../worker/generate');
 const mergeSourceMaps = require('../worker/mergeSourceMaps');
 const reverseDependencyMapReferences = require('./reverse-dependency-map-references');
 const {parseSync, transformFromAstSync} = require('@babel/core');
-const HermesParser = require('hermes-parser');
 // flowlint-next-line untyped-import:off
 const {passthroughSyntaxPlugins} = require('metro-react-native-babel-preset');
 const {addParamsToDefineCall} = require('metro-transform-plugins');
@@ -179,7 +178,7 @@ function inlineModuleIds(
   const sourceAst =
     isTypeScriptSource(path) || isTSXSource(path) || !hermesParser
       ? parseSync(code, babelConfig)
-      : HermesParser.parse(code, {
+      : require('hermes-parser').parse(code, {
           babel: true,
           // $FlowFixMe[prop-missing]
           sourceType: babelConfig.sourceType,


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The package `hermes-parser` has a lot of JS that goes unused in web platforms, this leads to increased bundle time.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan


Before

```
transform[stdout]: parse: 89.201ms
transform[stdout]: parse: 94.381ms
transform[stdout]: parse: 107.966ms
transform[stdout]: parse: 127.707ms
transform[stdout]: parse: 411.933ms
transform[stdout]: parse: 88.575ms
transform[stdout]: parse: 114.977ms
transform[stdout]: parse: 119.187ms
```

After

```
transform[stdout]: parse: 32.369ms
transform[stdout]: parse: 36.327ms
transform[stdout]: parse: 46.021ms
transform[stdout]: parse: 74.98ms
transform[stdout]: parse: 306.212ms
transform[stdout]: parse: 33.792ms
transform[stdout]: parse: 52.749ms
transform[stdout]: parse: 71.474ms
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
