### PR TITLE
Make metro-minify-terser the default minifier

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -289,9 +289,9 @@ Use the hermes-parser package to use call Hermes parser via WASM instead of the 
 
 #### `minifierPath`
 
-Type: `string`
+Type: `string` (default: `'metro-minify-terser'`)
 
-Path to the minifier that minifies the code after transformation.
+Path, or package name resolvable from `metro-transform-worker`, to the minifier that minifies the code after transformation.
 
 #### `minifierConfig`
 

--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -129,7 +129,7 @@ Object {
       },
       "toplevel": false,
     },
-    "minifierPath": "metro-minify-uglify",
+    "minifierPath": "metro-minify-terser",
     "optimizationSizeLimit": 153600,
     "publicPath": "/assets",
     "transformVariants": Object {
@@ -290,7 +290,7 @@ Object {
       },
       "toplevel": false,
     },
-    "minifierPath": "metro-minify-uglify",
+    "minifierPath": "metro-minify-terser",
     "optimizationSizeLimit": 153600,
     "publicPath": "/assets",
     "transformVariants": Object {
@@ -451,7 +451,7 @@ Object {
       },
       "toplevel": false,
     },
-    "minifierPath": "metro-minify-uglify",
+    "minifierPath": "metro-minify-terser",
     "optimizationSizeLimit": 153600,
     "publicPath": "/assets",
     "transformVariants": Object {
@@ -612,7 +612,7 @@ Object {
       },
       "toplevel": false,
     },
-    "minifierPath": "metro-minify-uglify",
+    "minifierPath": "metro-minify-terser",
     "optimizationSizeLimit": 153600,
     "publicPath": "/assets",
     "transformVariants": Object {

--- a/packages/metro-config/src/defaults/defaults.js
+++ b/packages/metro-config/src/defaults/defaults.js
@@ -60,6 +60,6 @@ exports.moduleSystem = (require.resolve(
 
 exports.platforms = ['ios', 'android', 'windows', 'web'];
 
-exports.DEFAULT_METRO_MINIFIER_PATH = 'metro-minify-uglify';
+exports.DEFAULT_METRO_MINIFIER_PATH = 'metro-minify-terser';
 
 exports.defaultCreateModuleIdFactory = defaultCreateModuleIdFactory;

--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -13,6 +13,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "terser": "^5.14.0"
+    "terser": "^5.15.0"
   }
 }

--- a/packages/metro-transform-worker/package.json
+++ b/packages/metro-transform-worker/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "metro-memory-fs": "0.72.3",
-    "metro-minify-uglify": "0.72.3",
+    "metro-minify-terser": "0.72.3",
     "metro-react-native-babel-transformer": "0.72.3"
   }
 }

--- a/packages/metro-transform-worker/src/__tests__/index-test.js
+++ b/packages/metro-transform-worker/src/__tests__/index-test.js
@@ -21,7 +21,7 @@ jest
     inlinePlugin: () => ({}),
     constantFoldingPlugin: () => ({}),
   }))
-  .mock('metro-minify-uglify');
+  .mock('metro-minify-terser');
 
 import type {JsTransformerConfig} from '../index';
 import typeof TransformerType from '../index';

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -44,6 +44,7 @@
     "metro-file-map": "0.72.3",
     "metro-hermes-compiler": "0.72.3",
     "metro-inspector-proxy": "0.72.3",
+    "metro-minify-terser": "0.72.3",
     "metro-minify-uglify": "0.72.3",
     "metro-react-native-babel-preset": "0.72.3",
     "metro-resolver": "0.72.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7845,10 +7845,10 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser@^5.14.0:
-  version "5.14.2"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
-  integrity sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==
+terser@^5.15.0:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.15.0.tgz#e16967894eeba6e1091509ec83f0c60e179f2425"
+  integrity sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
Summary:
`uglify-es` has not been published for 4 years and is marked deprecated [on npm](https://www.npmjs.com/package/uglify-es). Increasingly it does not support syntax that we would otherwise be able to pass through untranspiled.

`terser` - is a fork of `uglify-es` that is currently the most downloaded JS minifier ([`terser`](https://www.npmjs.com/package/terser) vs [`uglify-js`](https://www.npmjs.com/package/uglify-js)).

Changelog:
**[Breaking]** Switch default minifier from `uglify-es` to `terser`

Reviewed By: huntie

Differential Revision: D34647616

