### PR TITLE
Fix CircleCI: Node JS 14.17 is now the minimum supported version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ version: 2.1
 jobs:
   run-js-checks:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.17
     steps:
       - checkout
       - yarn_install
@@ -48,7 +48,7 @@ jobs:
 
   test-node-14:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.17
     steps:
       - checkout
       - yarn_install
@@ -57,7 +57,7 @@ jobs:
 
   publish-to-npm:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:lts
     steps:
       - checkout
       - yarn_install

--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ version: 2.1
 jobs:
   run-js-checks:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - yarn_install
@@ -46,9 +46,9 @@ jobs:
           command: test-smoke
 
 
-  test-node-12:
+  test-node-14:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - yarn_install
@@ -57,7 +57,7 @@ jobs:
 
   publish-to-npm:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - yarn_install
@@ -71,7 +71,7 @@ workflows:
   build-and-deploy:
     jobs:
       - run-js-checks
-      - test-node-12
+      - test-node-14
       - publish-to-npm:
           filters:
             branches:


### PR DESCRIPTION
## Summary

CI tests are failing because [Jest 29](https://github.com/facebook/metro/commit/69607ae715626f11eaecab1e0c05857c85f20662) introduces a dependency on Node `^14.15.0`. This updates our CI setup to Node 14, and in particular Node `^14.17.0`, which is the minimum version of Node 14 supported by ESLint.

Also take the opportunity to switch from `circleci` (legacy convenience image) to `cimg` (convenience image), as [recommended](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034).

## Test plan

CircleCI