### PR TITLE
Add configuration for disabling preferNativePlatform

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -154,6 +154,12 @@ Type: `boolean`
 
 Whether to disable [looking up modules in `node_modules` folders](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders). This only affects the default search through the directory tree, not other Metro options like `extraNodeModules` or `nodeModulesPaths`. Defaults to `false`.
 
+#### `preferNativePlatform`
+
+Type: `boolean`
+
+If set to false, will disable lookups for `.native` file extensions (used in react-native) and will use only extensions specified in `platforms`.
+
 #### `emptyModulePath`
 
 Type: `string`

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "start": "node packages/metro/src/cli",
     "test-ci": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest-coverage -i && node scripts/mapCoverage.js && codecov",
     "test-smoke": "yarn start build --config packages/metro/src/integration_tests/metro.config.js TestBundle.js --out /tmp/TestBundle",
-    "test": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest",
+    "test": "yarn run lint && yarn run build && yarn run jest",
     "typecheck": "flow check",
     "update-version": "node ./scripts/updateVersion"
   },

--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -58,6 +58,7 @@ Object {
       "windows",
       "web",
     ],
+    "preferNativePlatform": true,
     "requireCycleIgnorePatterns": Array [
       /\\(\\^\\|\\\\/\\|\\\\\\\\\\)node_modules\\(\\$\\|\\\\/\\|\\\\\\\\\\)/,
     ],
@@ -219,6 +220,7 @@ Object {
       "windows",
       "web",
     ],
+    "preferNativePlatform": true,
     "requireCycleIgnorePatterns": Array [
       /\\(\\^\\|\\\\/\\|\\\\\\\\\\)node_modules\\(\\$\\|\\\\/\\|\\\\\\\\\\)/,
     ],
@@ -380,6 +382,7 @@ Object {
       "windows",
       "web",
     ],
+    "preferNativePlatform": true,
     "requireCycleIgnorePatterns": Array [
       /\\(\\^\\|\\\\/\\|\\\\\\\\\\)node_modules\\(\\$\\|\\\\/\\|\\\\\\\\\\)/,
     ],
@@ -541,6 +544,7 @@ Object {
       "windows",
       "web",
     ],
+    "preferNativePlatform": true,
     "requireCycleIgnorePatterns": Array [
       /\\(\\^\\|\\\\/\\|\\\\\\\\\\)node_modules\\(\\$\\|\\\\/\\|\\\\\\\\\\)/,
     ],

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -92,6 +92,7 @@ type ResolverConfigT = {
   blacklistRE?: RegExp | Array<RegExp>,
   blockList: RegExp | Array<RegExp>,
   disableHierarchicalLookup: boolean,
+  preferNativePlatform: boolean,
   dependencyExtractor: ?string,
   emptyModulePath: string,
   extraNodeModules: {[name: string]: string, ...},

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -39,6 +39,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     blockList: exclusionList(),
     dependencyExtractor: undefined,
     disableHierarchicalLookup: false,
+    preferNativePlatform: true,
     emptyModulePath: require.resolve(
       'metro-runtime/src/modules/empty-module.js',
     ),

--- a/packages/metro/src/ModuleGraph/node-haste/node-haste.flow.js
+++ b/packages/metro/src/ModuleGraph/node-haste/node-haste.flow.js
@@ -59,7 +59,7 @@ type HasteMapOptions = {
   files: Array<string>,
   moduleCache: ModuleCache,
   platforms: Platforms,
-  preferNativePlatform: true,
+  preferNativePlatform: boolean,
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/packages/metro/src/ModuleGraph/node-haste/node-haste.js
+++ b/packages/metro/src/ModuleGraph/node-haste/node-haste.js
@@ -38,6 +38,7 @@ type ResolveOptions = $ReadOnly<{
   assetExts: $ReadOnlyArray<string>,
   assetResolutions: $ReadOnlyArray<string>,
   disableHierarchicalLookup: boolean,
+  preferNativePlatform: boolean,
   emptyModulePath: string,
   extraNodeModules: {[id: string]: string, ...},
   mainFields: $ReadOnlyArray<string>,
@@ -150,6 +151,7 @@ exports.createResolveFn = function (options: ResolveOptions): ResolveFn {
     additionalExts,
     platform,
     platforms,
+    preferNativePlatform,
   } = options;
   const files = Object.keys(transformedFiles);
   function getTransformedFile(path: string): TransformedCodeFile {
@@ -191,7 +193,8 @@ exports.createResolveFn = function (options: ResolveOptions): ResolveFn {
       rootDir: '',
     }),
     nodeModulesPaths: options.nodeModulesPaths,
-    preferNativePlatform: true,
+    preferNativePlatform:
+      typeof preferNativePlatform === 'boolean' ? preferNativePlatform : true,
     projectRoot: '',
     resolveAsset: (
       dirPath: string,

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -183,7 +183,10 @@ class DependencyGraph extends EventEmitter {
       moduleCache: this._moduleCache,
       moduleMap: this._moduleMap,
       nodeModulesPaths: this._config.resolver.nodeModulesPaths,
-      preferNativePlatform: true,
+      preferNativePlatform:
+        typeof this._config.resolver.preferNativePlatform === 'boolean'
+          ? this._config.resolver.preferNativePlatform
+          : true,
       projectRoot: this._config.projectRoot,
       resolveAsset: (dirPath: string, assetName: string, extension: string) => {
         const basePath = dirPath + path.sep + assetName;

--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -58,6 +58,7 @@ export type ModuleishCache<TModule, TPackage> = interface {
 type Options<TModule, TPackage> = {
   +dirExists: DirExistsFn,
   +disableHierarchicalLookup: boolean,
+  +preferNativePlatform: boolean,
   +doesFileExist: DoesFileExist,
   +emptyModulePath: string,
   +extraNodeModules: ?Object,


### PR DESCRIPTION
## Summary

Currently, it is impossible to disable `preferNativePlatform`. This PR enables it

## Test plan

In an application directory, create a `blah.native.js` file, then import it in your bundle entry point without its extension. If `preferNativePlatform` is enabled (or not present) in `metro.config.js`, the bundle should succeed. If it is disabled, the bundle should fail. 

## Note
I wasn't able to fully get my local environment working and some tests and flow checks were failing. I also did not update the snapshots, which will need to be refreshed.