### PR TITLE
Normalize file paths for require context on Windows

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -58,6 +58,7 @@
     "nullthrows": "^1.1.1",
     "rimraf": "^2.5.4",
     "serialize-error": "^2.1.0",
+    "slash": "^3.0.0",
     "source-map": "^0.5.6",
     "strip-ansi": "^6.0.0",
     "temp": "0.8.3",

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -58,7 +58,6 @@
     "nullthrows": "^1.1.1",
     "rimraf": "^2.5.4",
     "serialize-error": "^2.1.0",
-    "slash": "^3.0.0",
     "source-map": "^0.5.6",
     "strip-ansi": "^6.0.0",
     "temp": "0.8.3",

--- a/packages/metro/src/lib/__tests__/__snapshots__/contextModuleTemplates-test.js.snap
+++ b/packages/metro/src/lib/__tests__/__snapshots__/contextModuleTemplates-test.js.snap
@@ -5,11 +5,11 @@ exports[`getContextModuleTemplate creates a lazy template 1`] = `
 const map = Object.defineProperties({}, {
   \\"./foo.js\\": { enumerable: true, get() { return import(\\"/path/to/project/src/foo.js\\"); } },
 });
-  
+
 function metroContext(request) {
     return map[request];
 }
-  
+
 // Return the keys that can be resolved.
 metroContext.keys = function metroContextKeys() {
   return Object.keys(map);
@@ -29,11 +29,11 @@ const map = Object.defineProperties({}, {
   \\"./another/bar.js\\": { enumerable: true, get() { return import(\\"/path/to/project/src/another/bar.js\\"); } },
   \\"./foo.js\\": { enumerable: true, get() { return import(\\"/path/to/project/src/foo.js\\"); } },
 });
-  
+
 function metroContext(request) {
     return map[request];
 }
-  
+
 // Return the keys that can be resolved.
 metroContext.keys = function metroContextKeys() {
   return Object.keys(map);
@@ -52,11 +52,11 @@ exports[`getContextModuleTemplate creates a sync template 1`] = `
 const map = Object.defineProperties({}, {
   \\"./foo.js\\": { enumerable: true, get() { return require(\\"/path/to/project/src/foo.js\\"); } },
 });
-  
+
 function metroContext(request) {
     return map[request];
 }
-  
+
 // Return the keys that can be resolved.
 metroContext.keys = function metroContextKeys() {
   return Object.keys(map);
@@ -75,13 +75,13 @@ exports[`getContextModuleTemplate creates an eager template 1`] = `
 const map = Object.defineProperties({}, {
   \\"./foo.js\\": { enumerable: true, get() { return require(\\"/path/to/project/src/foo.js\\"); } },
 });
-  
+
 function metroContext(request) {
     // Here Promise.resolve().then() is used instead of new Promise() to prevent
   // uncaught exception popping up in devtools
   return Promise.resolve().then(() => map[request]);
 }
-  
+
 // Return the keys that can be resolved.
 metroContext.keys = function metroContextKeys() {
   return Object.keys(map);

--- a/packages/metro/src/lib/__tests__/__snapshots__/contextModuleTemplates-test.js.snap
+++ b/packages/metro/src/lib/__tests__/__snapshots__/contextModuleTemplates-test.js.snap
@@ -113,3 +113,26 @@ metroEmptyContext.resolve = function metroContextResolve(request) {
 
 module.exports = metroEmptyContext;"
 `;
+
+exports[`getContextModuleTemplate creates posix paths on windows for sync template 1`] = `
+"// All of the requested modules are loaded behind enumerable getters.
+const map = Object.defineProperties({}, {
+  \\"./foo.js\\": { enumerable: true, get() { return require(\\"C:\\\\\\\\path\\\\\\\\to\\\\\\\\project\\\\\\\\src\\\\\\\\foo.js\\"); } },
+});
+
+function metroContext(request) {
+    return map[request];
+}
+
+// Return the keys that can be resolved.
+metroContext.keys = function metroContextKeys() {
+  return Object.keys(map);
+};
+
+// Return the module identifier for a user request.
+metroContext.resolve = function metroContextResolve(request) {
+  throw new Error('Unimplemented Metro module context functionality');
+}
+
+module.exports = metroContext;"
+`;

--- a/packages/metro/src/lib/__tests__/contextModuleTemplates-test.js
+++ b/packages/metro/src/lib/__tests__/contextModuleTemplates-test.js
@@ -49,4 +49,15 @@ describe('getContextModuleTemplate', () => {
 
     expect(template).toMatchSnapshot();
   });
+
+  test('creates posix paths on windows for sync template', () => {
+    jest.resetModules();
+    jest.mock('path', () => jest.requireActual('path').win32);
+    const { getContextModuleTemplate: getWindowsTemplate } = require('../contextModuleTemplates');
+    const template = getWindowsTemplate('sync', 'c:/path/to/project/src', [
+      'C:\\path\\to\\project\\src\\foo.js',
+    ]);
+    expect(template).toMatch(/foo\.js/);
+    expect(template).toMatchSnapshot();
+  });
 });

--- a/packages/metro/src/lib/__tests__/contextModuleTemplates-test.js
+++ b/packages/metro/src/lib/__tests__/contextModuleTemplates-test.js
@@ -53,7 +53,9 @@ describe('getContextModuleTemplate', () => {
   test('creates posix paths on windows for sync template', () => {
     jest.resetModules();
     jest.mock('path', () => jest.requireActual('path').win32);
-    const { getContextModuleTemplate: getWindowsTemplate } = require('../contextModuleTemplates');
+    const {
+      getContextModuleTemplate: getWindowsTemplate,
+    } = require('../contextModuleTemplates');
     const template = getWindowsTemplate('sync', 'c:/path/to/project/src', [
       'C:\\path\\to\\project\\src\\foo.js',
     ]);

--- a/packages/metro/src/lib/contextModuleTemplates.js
+++ b/packages/metro/src/lib/contextModuleTemplates.js
@@ -10,6 +10,8 @@
  */
 
 import * as path from 'path';
+import * as os from 'os';
+import slash from 'slash';
 import type {ContextMode} from '../ModuleGraph/worker/collectDependencies';
 
 function createFileMap(
@@ -34,10 +36,11 @@ function createFileMap(
       if (!filePath.startsWith('.')) {
         filePath = `.${path.sep}` + filePath;
       }
-      // NOTE(byCedric): On Windows, normalize the backslashes to forward slashes to match the behavior in Webpack.
-      if (path.sep === '\\') {
-        filePath = filePath.replace(/\\/g, '/');
+
+      if (os.platform() === 'win32') {
+        filePath = slash(filePath);
       }
+
       const key = JSON.stringify(filePath);
       // NOTE(EvanBacon): Webpack uses `require.resolve` in order to load modules on demand,
       // Metro doesn't have this functionality so it will use getters instead. Modules need to

--- a/packages/metro/src/lib/contextModuleTemplates.js
+++ b/packages/metro/src/lib/contextModuleTemplates.js
@@ -28,17 +28,17 @@ function createFileMap(
     .forEach(file => {
       let filePath = path.relative(modulePath, file);
 
+      if (os.platform() === 'win32') {
+        filePath = slash(filePath);
+      }
+
       // NOTE(EvanBacon): I'd prefer we prevent the ability for a module to require itself (`require.context('./')`)
       // but Webpack allows this, keeping it here provides better parity between bundlers.
 
       // Ensure relative file paths start with `./` so they match the
       // patterns (filters) used to include them.
       if (!filePath.startsWith('.')) {
-        filePath = `.${path.sep}` + filePath;
-      }
-
-      if (os.platform() === 'win32') {
-        filePath = slash(filePath);
+        filePath = `./${filePath}`;
       }
 
       const key = JSON.stringify(filePath);

--- a/packages/metro/src/lib/contextModuleTemplates.js
+++ b/packages/metro/src/lib/contextModuleTemplates.js
@@ -11,7 +11,6 @@
 
 import * as path from 'path';
 import * as os from 'os';
-import slash from 'slash';
 import type {ContextMode} from '../ModuleGraph/worker/collectDependencies';
 
 function createFileMap(
@@ -29,7 +28,7 @@ function createFileMap(
       let filePath = path.relative(modulePath, file);
 
       if (os.platform() === 'win32') {
-        filePath = slash(filePath);
+        filePath = filePath.replaceAll(path.sep, '/');
       }
 
       // NOTE(EvanBacon): I'd prefer we prevent the ability for a module to require itself (`require.context('./')`)

--- a/packages/metro/src/lib/contextModuleTemplates.js
+++ b/packages/metro/src/lib/contextModuleTemplates.js
@@ -34,6 +34,10 @@ function createFileMap(
       if (!filePath.startsWith('.')) {
         filePath = `.${path.sep}` + filePath;
       }
+      // NOTE(byCedric): On Windows, normalize the backslashes to forward slashes to match the behavior in Webpack.
+      if (path.sep === '\\') {
+        filePath = filePath.replace(/\\/g, '/');
+      }
       const key = JSON.stringify(filePath);
       // NOTE(EvanBacon): Webpack uses `require.resolve` in order to load modules on demand,
       // Metro doesn't have this functionality so it will use getters instead. Modules need to
@@ -79,11 +83,11 @@ const map = ${createFileMap(
     files,
     moduleId => `${importSyntax}(${JSON.stringify(moduleId)})`,
   )};
-  
+
 function metroContext(request) {
   ${getContextTemplate}
 }
-  
+
 // Return the keys that can be resolved.
 metroContext.keys = function metroContextKeys() {
   return Object.keys(map);

--- a/packages/metro/src/lib/contextModuleTemplates.js
+++ b/packages/metro/src/lib/contextModuleTemplates.js
@@ -28,7 +28,7 @@ function createFileMap(
       let filePath = path.relative(modulePath, file);
 
       if (os.platform() === 'win32') {
-        filePath = filePath.replaceAll(path.sep, '/');
+        filePath = filePath.replace(/\\/g, '/');
       }
 
       // NOTE(EvanBacon): I'd prefer we prevent the ability for a module to require itself (`require.context('./')`)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

On Windows, the `require.context` resolves modules to non-posix paths. This seems to diverge from the expected behavior compared to Webpack, where the modules are resolved as posix paths. Because of this, we are running into unfortunate issues like https://github.com/expo/router/issues/13.

When inspecting the [`contextModuleTemplates`](https://github.com/facebook/metro/blob/main/packages/metro/src/lib/contextModuleTemplates.js#L44-L46), using [this example repo](https://github.com/byCedric/expo-router-context-windows-issue), you can see this happening.

![image](https://user-images.githubusercontent.com/1203991/192898803-f5030e8f-b9b3-4b88-8f2d-636f713d7e89.png)

This change normalizes the file path keys to be posix, matching the default Webpack behavior. It does not change the absolute file reference. (based on [this piece of code](https://github.com/facebook/metro/blob/main/packages/metro/src/Assets.js#L201-L204))

## Test plan

- Added a windows style test case, copied from [this test in `metro-file-map`](https://github.com/facebook/metro/blob/main/packages/metro-file-map/src/lib/__tests__/normalizePathSep-test.js#L21-L26)
- Ran the tests on my local Windows machine
  ![image](https://user-images.githubusercontent.com/1203991/192899575-371aec94-032b-46c8-b884-cd1e1c44f1b1.png)
- Patched the [test repo](https://github.com/byCedric/expo-router-context-windows-issue) with [this change](https://github.com/byCedric/expo-router-context-windows-issue/blob/main/patches/metro%2B0.72.3.patch) and validated the output on Windows
  ![image](https://user-images.githubusercontent.com/1203991/192900417-bd38c02c-d8c9-4598-8bc0-b39fbbdcb3c7.png)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


