### PR TITLE
feat: expose watch option

### DIFF
--- a/packages/metro/src/index.flow.js
+++ b/packages/metro/src/index.flow.js
@@ -65,6 +65,7 @@ export type RunServerOptions = {
   secureCert?: string, // deprecated
   secureKey?: string, // deprecated
   waitForBundler?: boolean,
+  watch?: boolean,
   websocketEndpoints?: {
     [path: string]: typeof ws.Server,
   },
@@ -225,6 +226,7 @@ exports.runServer = async (
     secureKey, // deprecated
     waitForBundler = false,
     websocketEndpoints = {},
+    watch,
   }: RunServerOptions,
 ): Promise<HttpServer | HttpsServer> => {
   await earlyPortCheck(host, config.server.port);
@@ -246,6 +248,7 @@ exports.runServer = async (
   const {middleware, end, metroServer} = await createConnectMiddleware(config, {
     hasReducedPerformance,
     waitForBundler,
+    watch,
   });
 
   serverApp.use(middleware);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

- Metro uses a pretty broad check to disable HMR. This PR exposes the `watch` option so Expo CLI can manually enable/disable file watching, then log to users that HMR is disabled.
- Related https://github.com/expo/expo-cli/issues/4418#issuecomment-1301338899

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

- flow types

