### PR TITLE
Remove Codecov third party orb dependency in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.2.4
   win: circleci/windows@2.4.0
 
 references:
@@ -70,8 +69,12 @@ jobs:
       - checkout
       - yarn_install
       - run: yarn test-coverage
-      - codecov/upload:
-          file: ./coverage/coverage-final.json
+      - run:
+          name: Download Codecov Uploader
+          command: ./.circleci/scripts/install_codecov.sh
+      - run:
+          name: Upload coverage results
+          command: ./codecov -t ${CODECOV_TOKEN} -f ./coverage/coverage-final.json
 
   test-linux:
     <<: *secure_unset_publish_token

--- a/.circleci/scripts/install_codecov.sh
+++ b/.circleci/scripts/install_codecov.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Install Codecov Uploader
+# See https://docs.codecov.com/docs/codecov-uploader#using-the-uploader-with-codecovio-cloud
+
+CODECOV_URL="https://uploader.codecov.io"
+
+curl "${CODECOV_URL}/verification.gpg" | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl -Os "${CODECOV_URL}/latest/linux/codecov"
+curl -Os "${CODECOV_URL}/latest/linux/codecov.SHA256SUM"
+curl -Os "${CODECOV_URL}/latest/linux/codecov.SHA256SUM.sig"
+
+gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+shasum -a 256 -c codecov.SHA256SUM
+
+chmod +x codecov


### PR DESCRIPTION
Summary:
Restores CI runs following https://github.com/facebook/metro/pull/888, where our CircleCI security policy prevents the use of any third party orbs.

https://pxl.cl/2lbJL

Differential Revision: D41436440

