### PR TITLE
Reset npm token before yarn install to fix npm publish script 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ commands:
             - dependencies-{{ .Branch }}-
       - run:
           name: Installing dependencies
-          command: yarn --frozen-lockfile --non-interactive
+          # Before yarn install, reset npm token to not leak it to external libraries.
+          command: NPM_TOKEN= yarn --frozen-lockfile --non-interactive
           working_directory: << parameters.working_directory >>
       - save_cache:
           paths:


### PR DESCRIPTION
## Summary

**Issue:**
Last two release of metro is not published to npm `v0.73.5` and `v0.73.4`, npm still have [v0.73.3](https://www.npmjs.com/package/metro). 

**Reason:**
In circle CI the job `publish-to-npm` is failing because of a preinstall [validation](https://github.com/facebook/metro/blob/5f9ba404ca5510386c509cb649295810cfd87f5f/scripts/preinstall.js#L14) which checks for presence of `NPM_TOKEN` while running `yarn install`. 

**Fix:**
From file blame I see previously NPM_TOKEN were reset just before yarn install. I am restoring the fix with a comment to make it clear. 

## Test plan

ssh into circle-ci and ran `NPM_TOKEN= yarn --frozen-lockfile --non-interactive` and can see yarn install working as expected. 

**Before:**
```
circleci@host:~/project$ yarn --frozen-lockfile --non-interactive
yarn install v1.22.18
$ node ./scripts/preinstall.js
yarn has been executed with a NPM_TOKEN environment variable set.
This poses a risk since that token can be leaked to external libraries.
Please make sure that any token gets deleted before running yarn.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

**After:**
```
circleci@host:~/project$ NPM_TOKEN= yarn --frozen-lockfile --non-interactive
yarn install v1.22.18
$ node ./scripts/preinstall.js
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > eslint-plugin-ft-flow@2.0.1" has unmet peer dependency "@babel/eslint-parser@^7.12.0".
warning "eslint-plugin-jest > @typescript-eslint/utils > @typescript-eslint/typescript-estree > tsutils@3.21.0" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
[4/4] Building fresh packages...
$ node ./scripts/build.js
Building packages (using Babel v7.14.0)
buck-worker-tool...............................................................[  OK  ]
metro..........................................................................[  OK  ]
metro-babel-register...........................................................[  OK  ]
metro-babel-transformer........................................................[  OK  ]
metro-cache....................................................................[  OK  ]
metro-cache-key................................................................[  OK  ]
metro-config...................................................................[  OK  ]
metro-core.....................................................................[  OK  ]
metro-file-map.................................................................[  OK  ]
metro-hermes-compiler..........................................................[BABEL] Note: The code generator has deoptimised the styling of /home/circleci/project/packages/metro-hermes-compiler/src/emhermesc.js as it exceeds the max of 500KB.
[  OK  ]
metro-inspector-proxy..........................................................[  OK  ]
metro-memory-fs................................................................[  OK  ]
metro-minify-terser............................................................[  OK  ]
metro-minify-uglify............................................................[  OK  ]
metro-react-native-babel-preset................................................[  OK  ]
metro-react-native-babel-transformer...........................................[  OK  ]
metro-react-native-interop-tools...............................................[  OK  ]
metro-resolver.................................................................[  OK  ]
metro-runtime..................................................................[  OK  ]
metro-source-map...............................................................[  OK  ]
metro-symbolicate..............................................................[  OK  ]
metro-transform-plugins........................................................[  OK  ]
metro-transform-worker.........................................................[  OK  ]
ob1............................................................................[  OK  ]

Done in 23.03s.
```
