### PR TITLE
Prevent `@babel/traverse` path cache side-effects in `generateFunctionMap`

### DIFF
--- a/flow-typed/babel-traverse.js
+++ b/flow-typed/babel-traverse.js
@@ -1845,6 +1845,8 @@ declare module '@babel/traverse' {
   declare export var visitors: Visitors;
 
   declare export type Cache = {
+    path: $ReadOnlyWeakMap<BabelNode, mixed>,
+    scope: $ReadOnlyWeakMap<BabelNode, mixed>,
     clear(): void,
     clearPath(): void,
     clearScope(): void,

--- a/packages/metro-source-map/package.json
+++ b/packages/metro-source-map/package.json
@@ -23,6 +23,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@babel/core": "^7.20.0",
     "@babel/parser": "^7.20.0",
     "uglify-es": "^3.1.9"
   }

--- a/packages/metro-source-map/src/generateFunctionMap.js
+++ b/packages/metro-source-map/src/generateFunctionMap.js
@@ -165,11 +165,21 @@ function forEachMapping(
     },
   };
 
+  // Traversing populates/pollutes the path cache (`traverse.cache.path`) with
+  // values missing the `hub` property needed by Babel transformation, so we
+  // save, clear, and restore the cache around our traversal.
+  // See: https://github.com/facebook/metro/pull/854#issuecomment-1336499395
+  const previousCache = traverse.cache.path;
+  traverse.cache.clearPath();
   traverse(ast, {
+    // Our visitor doesn't care about scope
+    noScope: true,
+
     Function: visitor,
     Program: visitor,
     Class: visitor,
   });
+  traverse.cache.path = previousCache;
 }
 
 const ANONYMOUS_NAME = '<anonymous>';


### PR DESCRIPTION
Summary:
## Motivation
For performance reasons, we'd like to have the option to re-use an AST (without cloning) after deriving source map information from it. However, due to https://github.com/babel/babel/issues/6437, traversing the AST within `generateFunctionMap` causes the `babel/traverse` path cache to be populated with entries Babel transform plugins can't use - in particular because `hub` is assumed to be set.

## Change
This diffs saves and clears the traverse cache before traversal, and then restores it afterwards. This isn't pretty but it's the cleanest approach I could find - we include tests to verify that this is (and continues to be) necessary.

## Other approaches
I tried some other things before resorting to manipulating `babel/traverse` internals:
 - Actually providing a `hub` so that it's set on the cache means adding a dependency on `babel/core`, and requires a similar level of hackery / assumptions of Babel internals.
 - Clearing the bad cache with `traverse.clearNode(ast)` or `traverse.cache.clearPath()` doesn't work because other tools (eg, Jest) rely on `properties` held in the path cache.

Changelog: [Internal]

Differential Revision: D42068914

