### PR TITLE
Improve Fast Refresh responsiveness when watching a large number of files

### DIFF
--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -59,8 +59,6 @@ export type CacheManagerFactory = (
 export type ChangeEvent = {
   logger: ?RootPerfLogger,
   eventsQueue: EventsQueue,
-  snapshotFS: FileSystem,
-  moduleMap: ModuleMap,
 };
 
 export type ChangeEventMetadata = {

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -799,25 +799,6 @@ export default class HasteMap extends EventEmitter {
     return this._worker;
   }
 
-  _getSnapshot(data: InternalData): {
-    snapshotFS: FileSystem,
-    moduleMap: HasteModuleMap,
-  } {
-    const rootDir = this._options.rootDir;
-    return {
-      snapshotFS: new HasteFS({
-        files: new Map(data.files),
-        rootDir,
-      }),
-      moduleMap: new HasteModuleMap({
-        duplicates: new Map(data.duplicates),
-        map: new Map(data.map),
-        mocks: new Map(data.mocks),
-        rootDir,
-      }),
-    };
-  }
-
   _removeIfExists(data: InternalData, relativeFilePath: Path) {
     const fileMetadata = data.files.get(relativeFilePath);
     if (!fileMetadata) {
@@ -900,7 +881,6 @@ export default class HasteMap extends EventEmitter {
         const changeEvent: ChangeEvent = {
           logger: hmrPerfLogger,
           eventsQueue,
-          ...this._getSnapshot(data),
         };
         this.emit('change', changeEvent);
         eventsQueue = [];


### PR DESCRIPTION
Summary:
Following D40829941 (https://github.com/facebook/metro/commit/71911737805d905851fae8e4d4be67614e342318), where we changed the output of `metro-file-map`'s `build()` to return "live" references to the file system and the Haste module map (rather than snapshots), we no longer require further snapshots to be emitted as part of a change event payload. In fact, `ChangeEvent['snapshotFS']` and `ChangeEvent['moduleMap']` are currently only referenced in test code.

Removing them means we don't have to copy potentially large data structures on each emitted change.

With ~300k files and ~150k Haste map entries, this amounts to ~200ms more responsive fast refresh - in general this boost will be proportional to the total number of files+Haste modules watched.

After this, a `HasteFS` instance is only constructed once, on Metro startup. That clears the way for an alternative (more expensive to initialise) implementation capable of performing lookups through symlinks.

Changelog: [Performance] Improve Fast Refresh responsiveness when watching a large number of files.

Reviewed By: motiz88

Differential Revision: D42303139

