### PR TITLE
Add `resolver.unstable_enableSymlinks` and remove symlinks+watchman restriction

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -83,6 +83,7 @@ Object {
       ],
     },
     "unstable_enablePackageExports": false,
+    "unstable_enableSymlinks": false,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -259,6 +260,7 @@ Object {
       ],
     },
     "unstable_enablePackageExports": false,
+    "unstable_enableSymlinks": false,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -435,6 +437,7 @@ Object {
       ],
     },
     "unstable_enablePackageExports": false,
+    "unstable_enableSymlinks": false,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -611,6 +614,7 @@ Object {
       ],
     },
     "unstable_enablePackageExports": false,
+    "unstable_enableSymlinks": false,
     "useWatchman": true,
   },
   "serializer": Object {

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -102,6 +102,7 @@ type ResolverConfigT = {
   disableHierarchicalLookup: boolean,
   dependencyExtractor: ?string,
   emptyModulePath: string,
+  unstable_enableSymlinks: boolean,
   extraNodeModules: {[name: string]: string, ...},
   hasteImplModulePath: ?string,
   nodeModulesPaths: $ReadOnlyArray<string>,

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -39,6 +39,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     blockList: exclusionList(),
     dependencyExtractor: undefined,
     disableHierarchicalLookup: false,
+    unstable_enableSymlinks: false,
     emptyModulePath: require.resolve(
       'metro-runtime/src/modules/empty-module.js',
     ),

--- a/packages/metro-file-map/src/HasteFS.js
+++ b/packages/metro-file-map/src/HasteFS.js
@@ -72,6 +72,10 @@ export default class HasteFS implements MutableFileSystem {
     if (visitResult.dependencies != null) {
       metadata[H.DEPENDENCIES] = visitResult.dependencies;
     }
+
+    if (visitResult.symlinkTarget != null) {
+      metadata[H.SYMLINK] = visitResult.symlinkTarget;
+    }
   }
 
   getSerializableSnapshot(): FileData {
@@ -91,6 +95,16 @@ export default class HasteFS implements MutableFileSystem {
   getSize(file: Path): ?number {
     const fileMetadata = this._getFileData(file);
     return (fileMetadata && fileMetadata[H.SIZE]) ?? null;
+  }
+
+  getSymlinkTarget(file: Path): ?string {
+    const fileMetadata = this._getFileData(file);
+    if (fileMetadata == null) {
+      return null;
+    }
+    return typeof fileMetadata[H.SYMLINK] === 'string'
+      ? fileMetadata[H.SYMLINK]
+      : null;
   }
 
   getType(file: Path): ?('f' | 'l') {

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -510,48 +510,12 @@ describe('HasteMap', () => {
     expect(deepNormalize(await hasteMap.read())).toEqual(cacheContent);
   });
 
-  it('throws if both symlinks and watchman is enabled', () => {
-    expect(
-      () => new HasteMap({...defaultConfig, enableSymlinks: true}),
-    ).toThrow(
-      'Set either `enableSymlinks` to false or `useWatchman` to false.',
-    );
-    expect(
-      () =>
-        new HasteMap({
-          ...defaultConfig,
-          enableSymlinks: true,
-          useWatchman: true,
-        }),
-    ).toThrow(
-      'Set either `enableSymlinks` to false or `useWatchman` to false.',
-    );
-
-    expect(
-      () =>
-        new HasteMap({
-          ...defaultConfig,
-          enableSymlinks: false,
-          useWatchman: true,
-        }),
-    ).not.toThrow();
-
-    expect(
-      () =>
-        new HasteMap({
-          ...defaultConfig,
-          enableSymlinks: true,
-          useWatchman: false,
-        }),
-    ).not.toThrow();
-  });
-
   describe('builds a haste map on a fresh cache with SHA-1s', () => {
     it.each([
-      // `enableSymlinks` is currently not permitted with `useWatchman`
       [false, false],
       [false, true],
       [true, false],
+      [true, true],
     ])(
       'uses watchman: %s, symlinks enabled: %s',
       async (useWatchman, enableSymlinks) => {

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -161,6 +161,7 @@ export interface FileSystem {
   getModuleName(file: Path): ?string;
   getSerializableSnapshot(): FileData;
   getSha1(file: Path): ?string;
+  getSymlinkTarget(file: Path): ?string;
   getType(file: Path): ?('f' | 'l');
 
   matchFiles(pattern: RegExp | string): Array<Path>;
@@ -241,6 +242,7 @@ export type VisitMetadata = {
   hasteId?: string,
   sha1?: ?string,
   dependencies?: string,
+  symlinkTarget?: string,
 };
 
 export type WatchmanClockSpec =
@@ -253,6 +255,7 @@ export type WorkerMessage = $ReadOnly<{
   computeSha1: boolean,
   dependencyExtractor?: ?string,
   enableHastePackages: boolean,
+  readLink: boolean,
   rootDir: string,
   filePath: string,
   hasteImplModulePath?: ?string,
@@ -263,4 +266,5 @@ export type WorkerMetadata = $ReadOnly<{
   id?: ?string,
   module?: ?ModuleMetaData,
   sha1?: ?string,
+  symlinkTarget?: ?string,
 }>;

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -324,14 +324,6 @@ export default class HasteMap extends EventEmitter {
           buildParameters,
         });
 
-    if (this._options.enableSymlinks && this._options.useWatchman) {
-      throw new Error(
-        'metro-file-map: enableSymlinks config option was set, but ' +
-          'is incompatible with watchman.\n' +
-          'Set either `enableSymlinks` to false or `useWatchman` to false.',
-      );
-    }
-
     this._buildPromise = null;
     this._worker = null;
     this._startupPerfLogger?.point('constructor_end');

--- a/packages/metro-file-map/src/worker.js
+++ b/packages/metro-file-map/src/worker.js
@@ -19,6 +19,7 @@ const dependencyExtractor = require('./lib/dependencyExtractor');
 const excludedExtensions = require('./workerExclusionList');
 const {createHash} = require('crypto');
 const fs = require('graceful-fs');
+const {promises: fsPromises} = require('fs');
 const path = require('path');
 
 const PACKAGE_JSON = path.sep + 'package.json';
@@ -53,11 +54,13 @@ async function worker(
   let id /*: WorkerMetadata['id'] */;
   let module /*: WorkerMetadata['module'] */;
   let sha1 /*: WorkerMetadata['sha1'] */;
+  let symlinkTarget /*: WorkerMetadata['symlinkTarget'] */;
 
   const {
     computeDependencies,
     computeSha1,
     enableHastePackages,
+    readLink,
     rootDir,
     filePath,
   } = data;
@@ -115,7 +118,11 @@ async function worker(
     sha1 = sha1hex(getContent());
   }
 
-  return {dependencies, id, module, sha1};
+  if (readLink) {
+    symlinkTarget = await fsPromises.readlink(filePath);
+  }
+
+  return {dependencies, id, module, sha1, symlinkTarget};
 }
 
 module.exports = {

--- a/packages/metro/src/node-haste/DependencyGraph/createHasteMap.js
+++ b/packages/metro/src/node-haste/DependencyGraph/createHasteMap.js
@@ -70,6 +70,7 @@ function createHasteMap(
     computeDependencies,
     computeSha1: true,
     dependencyExtractor: config.resolver.dependencyExtractor,
+    enableSymlinks: config.resolver.unstable_enableSymlinks,
     extensions: Array.from(
       new Set([
         ...config.resolver.sourceExts,


### PR DESCRIPTION
Summary:
**Note: this change does not mean that symlinks are respected by the resolver (yet)!**

Add `resolver.unstable_enableSymlinks` (default: `false`) option to Metro config, and pass it though to the existing `enableSymlinks` option in `metro-file-map`.

At this point this is purely for ease of testing end-to-end behaviour as we incrementally change Fast Refresh and resolution to cope with symlinks.

Removes the Jest-inherited prohibition on using `enableSymlinks` with `useWatchman`, which is no longer necessary or relevant to the new implementation.

**Bikeshed: Why under `resolver`?**
Symlink support is mostly relevant to the resolver, in that if the resolver resolves to a file through a link, that fact is transparent to the rest of Metro. Third-party solutions for symlink-based projects have focused on the resolver. The fact that 90% of the work for this solution is within `metro-file-map` is an implementation detail of in-memory resolution. That said, we'll have an opportunity to revisit this when the config is promoted from `unstable_`

Changlog: [Experimental] - Add `resolver.unstable_enableSymlinks` config for first phase of symlink support.

Reviewed By: jacdebug

Differential Revision: D42552674

