### PR TITLE
Add human-readable device name to `/json[/list]` endpoint

### DIFF
--- a/packages/metro-inspector-proxy/src/InspectorProxy.js
+++ b/packages/metro-inspector-proxy/src/InspectorProxy.js
@@ -129,6 +129,7 @@ class InspectorProxy {
       type: 'node',
       webSocketDebuggerUrl,
       vm: page.vm,
+      deviceName: device.getName(),
     };
   }
 


### PR DESCRIPTION
## Summary

This is a proposal to add a human-readable reference to each inspector entries/pages.

### Context

I've been experimenting with adding Hermes inspector support to [`vscode-expo`](https://github.com/expo/vscode-expo#readme) by reusing the existing [`vscode-js-debug`](https://github.com/microsoft/vscode-js-debug) tooling. 

Unfortunately, this method of debugging only supports a single target. When multiple devices are connected, we have to ask the user to select one. Currently, there is no way to differentiate devices. In my case, I have both an Android and iOS device, which I simultaneously use to test things.

By adding a human-readable reference, such as `deviceName`, we can ask the user which device they would like to use.

### Does this break the `/json[/list]` endpoint?

I've tested this locally, and it doesn't seem to break anything. Note, we already deviate a bit [from the original spec](https://chromedevtools.github.io/devtools-protocol/#get-json-or-jsonlist) with the `vm` property.

## Test plan

- Start metro
- Connect a device
- Open `http://localhost:8081/json`, and check if `deviceName` matches the expected name.
