### PR TITLE
Add content type support to metro server.

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -456,6 +456,7 @@ class Server {
       if (process.env.REACT_NATIVE_ENABLE_ASSET_CACHING === true) {
         res.setHeader('Cache-Control', 'max-age=31536000');
       }
+      res.setHeader("Content-Type", mime.lookup(path.basename(assetPath)));
       res.end(this._rangeRequestMiddleware(req, res, data, assetPath));
       process.nextTick(() => {
         log(createActionEndEntry(processingAssetRequestLogEntry));


### PR DESCRIPTION
## Summary

I'm a maintainer of `expo-image` on the web platform.
To support rendering svg assets by passing the URI to the `<img>` src prop, it's necessary for the asset url to return the correct content type.

The solution follows the code described in this issue, and was tested to work and allow using SVG assets on web in an expected way.

## Test plan

SVG returned as text without the patch in this PR:
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/5597580/226623531-2593cd45-2a91-4be8-a3ae-7eb6b0dc7ae0.png">

SVG rendered correctly on asset URL after applying the patch:
<img width="844" alt="image" src="https://user-images.githubusercontent.com/5597580/226623280-53c1ba4f-7f0e-4b59-840c-a7ee051851ad.png">

Expected content type:
<img width="241" alt="image" src="https://user-images.githubusercontent.com/5597580/226623703-fbe236bf-dd59-4ad5-be13-c1c538eee131.png">


