### PR TITLE
Fix missing content-length header when fetching assets

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -401,6 +401,8 @@ class Server {
       return data.slice(dataStart, dataEnd + 1);
     }
 
+    res.setHeader('Content-Length', String(Buffer.byteLength(data)));
+
     return data;
   }
 

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -782,22 +782,28 @@ describe('processRequest', () => {
       expect(response.getHeader('content-range')).toBe('bytes 0-3/10');
     });
 
-    it('should return content-type header for a png asset', async () => {
+    it('should return content-type and content-length header for a png asset', async () => {
       const mockData = 'i am image';
       getAsset.mockResolvedValue(mockData);
 
       const response = await makeRequest('/assets/imgs/a.png?platform=ios');
 
       expect(response.getHeader('content-type')).toBe('image/png');
+      expect(response.getHeader('content-length')).toBe(
+        String(Buffer.byteLength(mockData)),
+      );
     });
 
-    it('should return content-type header for an svg asset', async () => {
+    it('should return content-type and content-length header for an svg asset', async () => {
       const mockData = 'i am image';
       getAsset.mockResolvedValue(mockData);
 
       const response = await makeRequest('/assets/imgs/a.svg?platform=ios');
 
       expect(response.getHeader('content-type')).toBe('image/svg+xml');
+      expect(response.getHeader('content-length')).toBe(
+        String(Buffer.byteLength(mockData)),
+      );
     });
 
     it("should serve assets files's name contain non-latin letter", async () => {


### PR DESCRIPTION
## Summary

This PR relates to PR #953 and adds the `Content-Length` property when loading assets.

While this isn't mandatory for the apps, it's extremely useful for some debugging possibilities. At Expo, we are working on debugging improvements through Chrome DevTools, and one of these improvements is adding support for the Network inspector.

On the native side, we are limited to what we can infer automatically. One of these limitations is intercepting response bodies. We can't intercept these response bodies if it's larger than 1mb, and because of that, we rely on the `Content-Length` header to communicate the size of the response.

## Test plan

<img width="1312" alt="image" src="https://user-images.githubusercontent.com/1203991/228896070-61c4c3a4-578f-472a-b6e8-cfe7b2b8e624.png">

I can provide a repository to try this debugger, if it's necessary. You can also test this change by manually loading an existing asset (e.g. `http://localhost/assets/icon.png?platform=android`) and check the response headers in the same debugger. 
