### PR TITLE
Don't unnecessarily double-register Babel

### DIFF
--- a/packages/metro-babel-register/src/babel-register.js
+++ b/packages/metro-babel-register/src/babel-register.js
@@ -17,16 +17,6 @@ const path = require('path');
 let _only = [];
 
 function register(onlyList) {
-  // This prevents `babel-register` from transforming the code of the
-  // plugins/presets that we are require-ing themselves before setting up the
-  // actual config.
-  require('@babel/register')({
-    babelrc: false,
-    configFile: false,
-    // make sure we don't transpile any npm packages
-    ignore: [/\/node_modules\//],
-    only: [],
-  });
   require('@babel/register')({
     ...config(onlyList),
     extensions: [


### PR DESCRIPTION
Summary:
D5380795 (6 years ago) introduced a workaround for a Babel re-entrancy bug reported by React Native users in https://github.com/facebook/react-native/issues/14530.

Since https://github.com/babel/babel/pull/7588 (Babel 7.0), this bug was fixed upstream - it's now effectively a no-op to register Babel twice. The old workaround gets in the way of cleanly "unregistering" Babel because it pushes two hooks onto the `pirates` stack, and possibly has a slight perf impact.

Changelog: Internal

Differential Revision: D44627126

