### PR TITLE
feat!: use Terser's default for comments

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -131,7 +131,6 @@ Object {
       },
       "output": Object {
         "ascii_only": true,
-        "comments": false,
         "quote_style": 3,
         "wrap_iife": true,
       },
@@ -309,7 +308,6 @@ Object {
       },
       "output": Object {
         "ascii_only": true,
-        "comments": false,
         "quote_style": 3,
         "wrap_iife": true,
       },
@@ -487,7 +485,6 @@ Object {
       },
       "output": Object {
         "ascii_only": true,
-        "comments": false,
         "quote_style": 3,
         "wrap_iife": true,
       },
@@ -665,7 +662,6 @@ Object {
       },
       "output": Object {
         "ascii_only": true,
-        "comments": false,
         "quote_style": 3,
         "wrap_iife": true,
       },

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -110,7 +110,6 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
       },
       output: {
         ascii_only: true,
-        comments: false,
         quote_style: 3,
         wrap_iife: true,
       },


### PR DESCRIPTION
## Summary

By default, Terser keeps JSDoc-style comments that contain `@license` or `@preserve`: https://terser.org/docs/api-reference#format-options

Note that this is potentially a breaking change as it may change the output bundle (increase in size).

## Test plan

All current tests should pass.