### PR TITLE
Bump "image-size" version 0.6.0->1.0.2 and enable KTX support

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -30,7 +30,7 @@
     "error-stack-parser": "^2.0.6",
     "graceful-fs": "^4.2.4",
     "hermes-parser": "0.8.0",
-    "image-size": "^0.6.0",
+    "image-size": "^1.0.2",
     "invariant": "^2.2.4",
     "jest-worker": "^27.2.0",
     "lodash.throttle": "^4.1.1",

--- a/packages/metro/src/Bundler/util.js
+++ b/packages/metro/src/Bundler/util.js
@@ -19,6 +19,7 @@ const babylon = require('@babel/parser');
 const template = require('@babel/template').default;
 const babelTypes = require('@babel/types');
 const nullthrows = require('nullthrows');
+const getImageSize = require('image-size');
 
 // Structure of the object: dir.name.scale = asset
 export type RemoteFileMap = {
@@ -146,10 +147,34 @@ function generateRemoteAssetCodeFileAst(
 // If it's not one of these, we won't treat it as an image.
 function isAssetTypeAnImage(type: string): boolean {
   return (
-    ['png', 'jpg', 'jpeg', 'bmp', 'gif', 'webp', 'psd', 'svg', 'tiff'].indexOf(
-      type,
-    ) !== -1
+    [
+      'png',
+      'jpg',
+      'jpeg',
+      'bmp',
+      'gif',
+      'webp',
+      'psd',
+      'svg',
+      'tiff',
+      'ktx',
+    ].indexOf(type) !== -1
   );
+}
+
+function getAssetSize(
+  type: string,
+  content: Buffer,
+  filePath: string,
+): ?{+width: number, +height: number} {
+  if (!isAssetTypeAnImage(type)) {
+    return null;
+  }
+  if (content.length === 0) {
+    throw new Error(`Image asset \`${filePath}\` cannot be an empty file.`);
+  }
+  const {width, height} = getImageSize(content);
+  return {width, height};
 }
 
 function filterObject(
@@ -247,5 +272,6 @@ module.exports = {
   createRamBundleGroups,
   generateAssetCodeFileAst,
   generateRemoteAssetCodeFileAst,
+  getAssetSize,
   isAssetTypeAnImage,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,10 +3322,12 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-image-size@^0.6.0:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.3.tgz#e7e5c65bb534bd7cdcedd6cb5166272a85f75fb2"
-  integrity sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==
+image-size@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -5303,6 +5305,13 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
 
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Summary:
In this diff:
* `image-size` dependency is updated from 0.6.0 (which is five years old now) to 1.0.2. The goal is the KTX support [which was added](https://github.com/image-size/image-size/commit/0192f77a9e167fc81dae5861575f87080f1036bc) in v0.8.2
* Some of the relevant code that is used in `metro-buck-transform-worker` was factored back into the `metro` package - this is arguably a better encapsulation of this functionality, and also it's nice to have a single source of truth for the `image-source` dependency (because now `metro-buck-transform-worker` doesn't directly depend on it anymore)
* The KTX format is actually added as supported one

The net result is that metro-buck now treats KTX files as valid image assets, and process them correctly through the remote assets bundling pipeline.

Differential Revision: D45563991

