### PR TITLE
Emit JSC-safe URLs in HMR, `//# sourceURL`, `Content-Location`

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -615,7 +615,7 @@ The possibility to add custom middleware to the server response chain.
 
 Type: `string => string`
 
-A function that will be called every time Metro processes a URL. Metro will use the return value of this function as if it were the original URL provided by the client. This applies to all incoming HTTP requests (after any custom middleware), as well as bundle URLs in `/symbolicate` request payloads and within the hot reloading protocol.
+A function that will be called every time Metro processes a URL, after normalization of non-standard query-string delimiters using [`jsc-safe-url`](https://www.npmjs.com/package/jsc-safe-url). Metro will use the return value of this function as if it were the original URL provided by the client. This applies to all incoming HTTP requests (after any custom middleware), as well as bundle URLs in `/symbolicate` request payloads and within the hot reloading protocol.
 
 #### `runInspectorProxy`
 

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -33,6 +33,7 @@
     "image-size": "^1.0.2",
     "invariant": "^2.2.4",
     "jest-worker": "^27.2.0",
+    "jsc-safe-url": "^0.2.2",
     "lodash.throttle": "^4.1.1",
     "metro-babel-transformer": "0.76.4",
     "metro-cache": "0.76.4",

--- a/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
+++ b/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
@@ -15,6 +15,7 @@ import type {MixedOutput, Module} from '../../types.flow';
 import type {JsOutput} from 'metro-transform-worker';
 
 const invariant = require('invariant');
+const jscSafeUrl = require('jsc-safe-url');
 const {addParamsToDefineCall} = require('metro-transform-plugins');
 const path = require('path');
 
@@ -59,7 +60,9 @@ function getModuleParams(module: Module<>, options: Options): Array<mixed> {
         // Construct a server-relative URL for the split bundle, propagating
         // most parameters from the main bundle's URL.
 
-        const {searchParams} = new URL(options.sourceUrl);
+        const {searchParams} = new URL(
+          jscSafeUrl.toNormalUrl(options.sourceUrl),
+        );
         searchParams.set('modulesOnly', 'true');
         searchParams.set('runModule', 'false');
 

--- a/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
+++ b/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
@@ -16,6 +16,7 @@ import type {DeltaResult, Module, ReadOnlyGraph} from '../types.flow';
 import type {HmrModule} from 'metro-runtime/src/modules/types.flow';
 
 const {isJsModule, wrapModule} = require('./helpers/js');
+const jscSafeUrl = require('jsc-safe-url');
 const {addParamsToDefineCall} = require('metro-transform-plugins');
 const path = require('path');
 const url = require('url');
@@ -53,7 +54,7 @@ function generateModules(
       };
 
       const sourceMappingURL = getURL('map');
-      const sourceURL = getURL('bundle');
+      const sourceURL = jscSafeUrl.toJscSafeUrl(getURL('bundle'));
       const code =
         prepareModule(module, graph, options) +
         `\n//# sourceMappingURL=${sourceMappingURL}\n` +

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -906,7 +906,7 @@ class Server {
         bundle: bundleCode,
       };
     },
-    finish({req, mres, result}) {
+    finish({req, mres, serializerOptions, result}) {
       if (
         // We avoid parsing the dates since the client should never send a more
         // recent date than the one returned by the Delta Bundler (if that's the
@@ -923,6 +923,9 @@ class Server {
           String(result.numModifiedFiles),
         );
         mres.setHeader(DELTA_ID_HEADER, String(result.nextRevId));
+        if (serializerOptions?.sourceUrl != null) {
+          mres.setHeader('Content-Location', serializerOptions.sourceUrl);
+        }
         mres.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
         mres.setHeader('Last-Modified', result.lastModifiedDate.toUTCString());
         mres.setHeader(

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -334,7 +334,7 @@ describe('processRequest', () => {
           '__d(function() {foo();},1,[],"foo.js");',
           'require(0);',
           '//# sourceMappingURL=//localhost:8081/mybundle.map?runModule=true',
-          '//# sourceURL=http://localhost:8081/mybundle.bundle?runModule=true',
+          '//# sourceURL=http://localhost:8081/mybundle.bundle//&runModule=true',
         ].join('\n'),
       );
     },
@@ -349,7 +349,7 @@ describe('processRequest', () => {
         '__d(function() {entry();},0,[1],"mybundle.js");',
         '__d(function() {foo();},1,[],"foo.js");',
         '//# sourceMappingURL=//localhost:8081/mybundle.map?runModule=false',
-        '//# sourceURL=http://localhost:8081/mybundle.bundle?runModule=false',
+        '//# sourceURL=http://localhost:8081/mybundle.bundle//&runModule=false',
       ].join('\n'),
     );
   });
@@ -370,6 +370,14 @@ describe('processRequest', () => {
     return makeRequest('mybundle.bundle?runModule=true').then(response => {
       expect(response.getHeader('Content-Length')).toEqual(
         '' + Buffer.byteLength(response._getString()),
+      );
+    });
+  });
+
+  it('returns Content-Location header on request of *.bundle', () => {
+    return makeRequest('mybundle.bundle?runModule=true').then(response => {
+      expect(response.getHeader('Content-Location')).toEqual(
+        'http://localhost:8081/mybundle.bundle//&runModule=true',
       );
     });
   });
@@ -451,7 +459,7 @@ describe('processRequest', () => {
         '__d(function() {entry();},0,[1],"mybundle.js");',
         '__d(function() {foo();},1,[],"foo.js");',
         '//# sourceMappingURL=//localhost:8081/mybundle.map?modulesOnly=true&runModule=false',
-        '//# sourceURL=http://localhost:8081/mybundle.bundle?modulesOnly=true&runModule=false',
+        '//# sourceURL=http://localhost:8081/mybundle.bundle//&modulesOnly=true&runModule=false',
       ].join('\n'),
     );
   });
@@ -466,7 +474,7 @@ describe('processRequest', () => {
       [
         '__d(function() {entry();},0,[1],"mybundle.js");',
         '//# sourceMappingURL=//localhost:8081/mybundle.map?shallow=true&modulesOnly=true&runModule=false',
-        '//# sourceURL=http://localhost:8081/mybundle.bundle?shallow=true&modulesOnly=true&runModule=false',
+        '//# sourceURL=http://localhost:8081/mybundle.bundle//&shallow=true&modulesOnly=true&runModule=false',
       ].join('\n'),
     );
   });
@@ -730,7 +738,7 @@ describe('processRequest', () => {
           '__d(function() {foo();},1,[],"foo.js");',
           'require(0);',
           '//# sourceMappingURL=//localhost:8081/mybundle.map?runModule=true&TEST_URL_WAS_REWRITTEN=true',
-          '//# sourceURL=http://localhost:8081/mybundle.bundle?runModule=true&TEST_URL_WAS_REWRITTEN=true',
+          '//# sourceURL=http://localhost:8081/mybundle.bundle//&runModule=true&TEST_URL_WAS_REWRITTEN=true',
         ].join('\n'),
       );
     },

--- a/packages/metro/src/__tests__/HmrServer-test.js
+++ b/packages/metro/src/__tests__/HmrServer-test.js
@@ -339,12 +339,12 @@ describe('HmrServer', () => {
                   id('/root/hi') +
                   ',[],"hi",{});\n' +
                   '//# sourceMappingURL=http://localhost/hi.map?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n' +
-                  '//# sourceURL=http://localhost/hi.bundle?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n',
+                  '//# sourceURL=http://localhost/hi.bundle//&platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n',
               ],
               sourceMappingURL:
                 'http://localhost/hi.map?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
               sourceURL:
-                'http://localhost/hi.bundle?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
+                'http://localhost/hi.bundle//&platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
             },
           ],
           deleted: [id('/root/bye')],
@@ -423,11 +423,11 @@ describe('HmrServer', () => {
                   id('/root/hi') +
                   ',[],"hi",{});\n' +
                   '//# sourceMappingURL=http://localhost/hi.map?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n' +
-                  '//# sourceURL=http://localhost/hi.bundle?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n',
+                  '//# sourceURL=http://localhost/hi.bundle//&platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n',
               ],
 
               sourceURL:
-                'http://localhost/hi.bundle?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
+                'http://localhost/hi.bundle//&platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
               sourceMappingURL:
                 'http://localhost/hi.map?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
             },
@@ -482,10 +482,10 @@ describe('HmrServer', () => {
                   id('/root/hi') +
                   ',[],"hi",{});\n' +
                   '//# sourceMappingURL=http://localhost/hi.map?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n' +
-                  '//# sourceURL=http://localhost/hi.bundle?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n',
+                  '//# sourceURL=http://localhost/hi.bundle//&platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true\n',
               ],
               sourceURL:
-                'http://localhost/hi.bundle?platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
+                'http://localhost/hi.bundle//&platform=ios&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
             },
           ],
           deleted: [id('/root/bye')],
@@ -536,7 +536,7 @@ describe('HmrServer', () => {
             {
               module: expect.any(Array),
               sourceURL:
-                'http://localhost/hi.bundle?platform=ios&unusedExtraParam=42&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
+                'http://localhost/hi.bundle//&platform=ios&unusedExtraParam=42&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
             },
           ],
           deleted: [id('/root/bye')],
@@ -587,7 +587,7 @@ describe('HmrServer', () => {
             {
               module: expect.any(Array),
               sourceURL:
-                'http://localhost/hi.bundle?platform=ios&TEST_URL_WAS_REWRITTEN=true&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
+                'http://localhost/hi.bundle//&platform=ios&TEST_URL_WAS_REWRITTEN=true&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true',
             },
           ],
           deleted: [id('/root/bye')],

--- a/packages/metro/src/lib/parseOptionsFromUrl.js
+++ b/packages/metro/src/lib/parseOptionsFromUrl.js
@@ -39,10 +39,10 @@ const getTransformProfile = (transformProfile: string): TransformProfile =>
     : 'default';
 
 module.exports = function parseOptionsFromUrl(
-  requestUrl: string,
+  normalizedRequestUrl: string,
   platforms: Set<string>,
 ): BundleOptions {
-  const parsedURL = nullthrows(url.parse(requestUrl, true)); // `true` to parse the query param as an object.
+  const parsedURL = nullthrows(url.parse(normalizedRequestUrl, true)); // `true` to parse the query param as an object.
   const query = nullthrows(parsedURL.query);
   const pathname =
     query.bundleEntry ||
@@ -77,7 +77,7 @@ module.exports = function parseOptionsFromUrl(
         platform != null && platform.match(/^(android|ios)$/) ? 'http' : '',
       pathname: pathname.replace(/\.(bundle|delta)$/, '.map'),
     }),
-    sourceUrl: requestUrl,
+    sourceUrl: normalizedRequestUrl,
     unstable_transformProfile: getTransformProfile(
       query.unstable_transformProfile,
     ),

--- a/packages/metro/src/lib/parseOptionsFromUrl.js
+++ b/packages/metro/src/lib/parseOptionsFromUrl.js
@@ -17,6 +17,7 @@ import type {TransformProfile} from 'metro-babel-transformer';
 const parsePlatformFilePath = require('../node-haste/lib/parsePlatformFilePath');
 const parseCustomResolverOptions = require('./parseCustomResolverOptions');
 const parseCustomTransformOptions = require('./parseCustomTransformOptions');
+const jscSafeUrl = require('jsc-safe-url');
 const nullthrows = require('nullthrows');
 const path = require('path');
 const url = require('url');
@@ -77,7 +78,7 @@ module.exports = function parseOptionsFromUrl(
         platform != null && platform.match(/^(android|ios)$/) ? 'http' : '',
       pathname: pathname.replace(/\.(bundle|delta)$/, '.map'),
     }),
-    sourceUrl: normalizedRequestUrl,
+    sourceUrl: jscSafeUrl.toJscSafeUrl(normalizedRequestUrl),
     unstable_transformProfile: getTransformProfile(
       query.unstable_transformProfile,
     ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4483,6 +4483,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsc-safe-url@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/jsc-safe-url/-/jsc-safe-url-0.2.2.tgz#9ce79116d6271fce4b3d1b59b879e66b82457be1"
+  integrity sha512-F6ezJ+Ys7yUaZ2tG7VVGwDgmCB8T1kaDB2AlxhLnPIfTpJqgFWSjptCAU04wz7RB3oEta/SiDuy4vQxh2F4jXg==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"


### PR DESCRIPTION
Summary:
The remaining Metro part of the implementation of https://github.com/react-native-community/discussions-and-proposals/pull/646, to fix (along with an RN change):
 - https://github.com/facebook/react-native/issues/36794 and
 - https://github.com/expo/expo/issues/22008

This ensures that Metro always and consistently emits "JSC-safe" (i.e., `//&` query-delimited) URLs where they are used as a "source URL" for evaluated JS. This includes:
 - `sourceURL` within the JSON HMR payload (`HmrModule`)
 - `//# sourceURL` comments within the body of a base or HMR bundle
 - The new `Content-Location` header delivered in response to an HTTP bundle request.

Clients will be expected to use these as source URL arguments to JS engines, in preference to the URL on which they might have connected/requested the bundle originally.

```
* **[Fix]**: Emit source URLs in a format that will not be stripped by JavaScriptCore
```

Differential Revision: D45983876

