### PR TITLE
Add "exports" special case handling for @babel/runtime

### DIFF
--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -260,9 +260,21 @@ function resolvePackage(
     const exportsField = pkg?.packageJson.exports;
 
     if (pkg != null && exportsField != null) {
+      let conditionNamesOverride = context.unstable_conditionNames;
+
+      // HACK!: Do not assert the "import" condition for `@babel/runtime`. This
+      // is a workaround for ESM <-> CJS interop, as we need the CJS versions of
+      // `@babel/runtime` helpers.
+      // TODO(T154157178): Remove with better "require"/"import" solution
+      if (pkg.packageJson.name === '@babel/runtime') {
+        conditionNamesOverride = context.unstable_conditionNames.filter(
+          condition => condition !== 'import',
+        );
+      }
+
       try {
         const packageExportsResult = resolvePackageTargetFromExports(
-          context,
+          {...context, unstable_conditionNames: conditionNamesOverride},
           pkg.rootPath,
           modulePath,
           exportsField,


### PR DESCRIPTION
Summary:
This is a workaround for https://github.com/facebook/metro/issues/984 (and resolves #984). It adds a specific exception in the resolver for `'@babel/runtime'` to prevent asserting the `"import"` condition name on these modules (when using Package Exports). This is necessary so that the CJS version of these Babel helpers are resolved, which enable CJS/MJS interop for all other modules (given our current strategy of resolving both `"require"` and `"import"` in all other packages and using Babel-driven ESM compatibility).

This workaround is removable if/when any of:
- https://github.com/babel/babel/pull/15643 is merged and updated in React Native.
- We implement dynamic handling of `"require"` and `"import"` conditions via ESM support in a future version of Metro.

Changelog: **[Experimental]** Fix `@babel/runtime` issue when using Package Exports

Differential Revision: D46107056

