### PR TITLE
Serialize tree structure in file map cache

### DIFF
--- a/packages/metro-file-map/src/Watcher.js
+++ b/packages/metro-file-map/src/Watcher.js
@@ -39,7 +39,7 @@ const MAX_WAIT_TIME = 240000;
 type CrawlResult = {
   changedFiles: FileData,
   clocks?: WatchmanClocks,
-  removedFiles: FileData,
+  removedFiles: Set<Path>,
 };
 
 type WatcherOptions = {

--- a/packages/metro-file-map/src/__tests__/includes_dotfiles-test.js
+++ b/packages/metro-file-map/src/__tests__/includes_dotfiles-test.js
@@ -47,7 +47,11 @@ test('watchman crawler and node crawler both include dotfiles', async () => {
   ]);
 
   expect(
-    builtHasteMapWithWatchman.fileSystem.matchFiles('.eslintrc.js'),
+    Array.from(
+      builtHasteMapWithWatchman.fileSystem.matchFiles({
+        filter: /\.eslintrc\.js/,
+      }),
+    ),
   ).toHaveLength(1);
 
   expect(builtHasteMapWithWatchman.fileSystem.getAllFiles().sort()).toEqual(

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -48,7 +48,7 @@ jest.mock('../crawlers/watchman', () =>
       includeSymlinks,
     } = options;
     const list = mockChangedFiles || mockFs;
-    const removedFiles = new Map();
+    const removedFiles = new Set();
     const changedFiles = new Map();
 
     previousState.clocks = mockClocks;
@@ -76,7 +76,7 @@ jest.mock('../crawlers/watchman', () =>
         } else {
           const fileData = previousState.files.get(relativeFilePath);
           if (fileData) {
-            removedFiles.set(relativeFilePath, fileData);
+            removedFiles.add(relativeFilePath);
           }
         }
       }
@@ -568,7 +568,7 @@ describe('HasteMap', () => {
 
           return Promise.resolve({
             changedFiles,
-            removedFiles: new Map(),
+            removedFiles: new Set(),
           });
         });
 
@@ -1255,7 +1255,7 @@ describe('HasteMap', () => {
       changedFiles.set(invalidFilePath, ['', 34, 44, 0, [], null, 0]);
       return {
         changedFiles,
-        removedFiles: new Map(),
+        removedFiles: new Set(),
       };
     });
 
@@ -1359,7 +1359,7 @@ describe('HasteMap', () => {
         changedFiles: createMap({
           [path.join('fruits', 'Banana.js')]: ['', 32, 42, 0, '', null, 0],
         }),
-        removedFiles: new Map(),
+        removedFiles: new Set(),
       });
     });
 
@@ -1396,7 +1396,7 @@ describe('HasteMap', () => {
         changedFiles: createMap({
           [path.join('fruits', 'Banana.js')]: ['', 32, 42, 0, '', null, 0],
         }),
-        removedFiles: new Map(),
+        removedFiles: new Set(),
       });
     });
 

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -283,7 +283,7 @@ describe('HasteMap', () => {
       // Kiwi!
     `;
     const {fileSystem} = await new HasteMap(config).build();
-    expect(fileSystem.matchFiles(/Kiwi/)).toEqual([]);
+    expect([...fileSystem.matchFiles({filter: /Kiwi/})]).toEqual([]);
   });
 
   it('ignores vcs directories without ignore pattern', async () => {
@@ -291,7 +291,7 @@ describe('HasteMap', () => {
       // test
     `;
     const {fileSystem} = await new HasteMap(defaultConfig).build();
-    expect(fileSystem.matchFiles('.git')).toEqual([]);
+    expect([...fileSystem.matchFiles({filter: /\.git/})]).toEqual([]);
   });
 
   it('ignores vcs directories with ignore pattern regex', async () => {
@@ -304,8 +304,8 @@ describe('HasteMap', () => {
       // test
     `;
     const {fileSystem} = await new HasteMap(config).build();
-    expect(fileSystem.matchFiles(/Kiwi/)).toEqual([]);
-    expect(fileSystem.matchFiles('.git')).toEqual([]);
+    expect([...fileSystem.matchFiles({filter: /Kiwi/})]).toEqual([]);
+    expect([...fileSystem.matchFiles({filter: /\.git/})]).toEqual([]);
   });
 
   it('throw on ignore pattern except for regex', async () => {

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -74,8 +74,7 @@ jest.mock('../crawlers/watchman', () =>
             ]);
           }
         } else {
-          const fileData = previousState.files.get(relativeFilePath);
-          if (fileData) {
+          if (previousState.fileSystem.exists(relativeFilePath)) {
             removedFiles.add(relativeFilePath);
           }
         }

--- a/packages/metro-file-map/src/cache/DiskCacheManager.js
+++ b/packages/metro-file-map/src/cache/DiskCacheManager.js
@@ -12,8 +12,8 @@
 import type {
   BuildParameters,
   CacheData,
+  CacheDelta,
   CacheManager,
-  FileData,
 } from '../flow-types';
 
 import rootRelativeCacheKeys from '../lib/rootRelativeCacheKeys';
@@ -81,7 +81,7 @@ export class DiskCacheManager implements CacheManager {
 
   async write(
     dataSnapshot: CacheData,
-    {changed, removed}: $ReadOnly<{changed: FileData, removed: FileData}>,
+    {changed, removed}: CacheDelta,
   ): Promise<void> {
     if (changed.size > 0 || removed.size > 0) {
       writeFileSync(this._cachePath, serialize(dataSnapshot));

--- a/packages/metro-file-map/src/crawlers/__tests__/integration-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/integration-test.js
@@ -9,6 +9,7 @@
  * @oncall react_native
  */
 
+import TreeFS from '../../lib/TreeFS';
 import nodeCrawl from '../node';
 import watchmanCrawl from '../watchman';
 import {execSync} from 'child_process';
@@ -109,7 +110,10 @@ describe.each(Object.keys(CRAWLERS))(
         invariant(crawl, 'crawl should not be null within maybeTest');
         const result = await crawl({
           previousState: {
-            files: new Map([['removed.js', ['', 123, 234, 0, '', null, 0]]]),
+            fileSystem: new TreeFS({
+              rootDir: FIXTURES_DIR,
+              files: new Map([['removed.js', ['', 123, 234, 0, '', null, 0]]]),
+            }),
             clocks: new Map(),
           },
           includeSymlinks,

--- a/packages/metro-file-map/src/crawlers/__tests__/integration-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/integration-test.js
@@ -126,9 +126,7 @@ describe.each(Object.keys(CRAWLERS))(
         // Map comparison is unordered, which is what we want
         expect(result).toMatchObject({
           changedFiles: expectedChangedFiles,
-          removedFiles: new Map([
-            ['removed.js', ['', 123, 234, 0, '', null, 0]],
-          ]),
+          removedFiles: new Set(['removed.js']),
         });
         if (crawlerName === 'watchman') {
           expect(result.clocks).toBeInstanceOf(Map);

--- a/packages/metro-file-map/src/crawlers/__tests__/node-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/node-test.js
@@ -9,6 +9,7 @@
  */
 
 import {AbortController} from 'node-abort-controller';
+import TreeFS from '../../lib/TreeFS';
 
 jest.useRealTimers();
 
@@ -124,6 +125,8 @@ const createMap = obj =>
   new Map(Object.keys(obj).map(key => [normalize(key), obj[key]]));
 
 const rootDir = '/project';
+const emptyFS = new TreeFS({rootDir, files: new Map()});
+const getFS = (files: FileData) => new TreeFS({rootDir, files});
 let mockResponse;
 let mockSpawnExit;
 let nodeCrawl;
@@ -154,9 +157,7 @@ describe('node crawler', () => {
     ].join('\n');
 
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {
-        files: new Map(),
-      },
+      previousState: {fileSystem: emptyFS},
       extensions: ['js', 'json'],
       ignore: pearMatcher,
       rootDir,
@@ -205,7 +206,7 @@ describe('node crawler', () => {
     });
 
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {files},
+      previousState: {fileSystem: getFS(files)},
       extensions: ['js'],
       ignore: pearMatcher,
       rootDir,
@@ -234,7 +235,7 @@ describe('node crawler', () => {
     });
 
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {files},
+      previousState: {fileSystem: getFS(files)},
       extensions: ['js'],
       ignore: pearMatcher,
       rootDir,
@@ -258,9 +259,7 @@ describe('node crawler', () => {
     nodeCrawl = require('../node');
 
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {
-        files: new Map(),
-      },
+      previousState: {fileSystem: emptyFS},
       extensions: ['js'],
       ignore: pearMatcher,
       rootDir,
@@ -289,9 +288,7 @@ describe('node crawler', () => {
     nodeCrawl = require('../node');
 
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {
-        files: new Map(),
-      },
+      previousState: {fileSystem: emptyFS},
       extensions: ['js'],
       ignore: pearMatcher,
       rootDir,
@@ -311,9 +308,8 @@ describe('node crawler', () => {
     childProcess = require('child_process');
     nodeCrawl = require('../node');
 
-    const files = new Map();
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {files},
+      previousState: {fileSystem: emptyFS},
       extensions: ['js'],
       forceNodeFilesystemAPI: true,
       ignore: pearMatcher,
@@ -334,9 +330,8 @@ describe('node crawler', () => {
   it('completes with empty roots', async () => {
     nodeCrawl = require('../node');
 
-    const files = new Map();
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {files},
+      previousState: {fileSystem: emptyFS},
       extensions: ['js'],
       forceNodeFilesystemAPI: true,
       ignore: pearMatcher,
@@ -351,9 +346,8 @@ describe('node crawler', () => {
   it('completes with fs.readdir throwing an error', async () => {
     nodeCrawl = require('../node');
 
-    const files = new Map();
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {files},
+      previousState: {fileSystem: emptyFS},
       extensions: ['js'],
       forceNodeFilesystemAPI: true,
       ignore: pearMatcher,
@@ -369,9 +363,8 @@ describe('node crawler', () => {
     nodeCrawl = require('../node');
     const fs = require('graceful-fs');
 
-    const files = new Map();
     const {changedFiles, removedFiles} = await nodeCrawl({
-      previousState: {files},
+      previousState: {fileSystem: emptyFS},
       extensions: ['js'],
       forceNodeFilesystemAPI: true,
       ignore: pearMatcher,
@@ -398,9 +391,7 @@ describe('node crawler', () => {
     await expect(
       nodeCrawl({
         abortSignal: abortSignalWithReason(err),
-        previousState: {
-          files: new Map(),
-        },
+        previousState: {fileSystem: emptyFS},
         extensions: ['js', 'json'],
         ignore: pearMatcher,
         rootDir,
@@ -431,9 +422,7 @@ describe('node crawler', () => {
       nodeCrawl({
         perfLogger: fakePerfLogger,
         abortSignal: abortController.signal,
-        previousState: {
-          files: new Map(),
-        },
+        previousState: {fileSystem: emptyFS},
         extensions: ['js', 'json'],
         ignore: pearMatcher,
         rootDir,

--- a/packages/metro-file-map/src/crawlers/__tests__/node-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/node-test.js
@@ -191,7 +191,7 @@ describe('node crawler', () => {
       }),
     );
 
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
   });
 
   it('updates only changed files', async () => {
@@ -219,7 +219,7 @@ describe('node crawler', () => {
       }),
     );
 
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
   });
 
   it('returns removed files', async () => {
@@ -247,11 +247,7 @@ describe('node crawler', () => {
         'fruits/tomato.js': ['', 33, 42, 0, '', null, 0],
       }),
     );
-    expect(removedFiles).toEqual(
-      createMap({
-        'fruits/previouslyExisted.js': ['', 30, 40, 1, '', null, 0],
-      }),
-    );
+    expect(removedFiles).toEqual(new Set(['fruits/previouslyExisted.js']));
   });
 
   it('uses node fs APIs with incompatible find binary', async () => {
@@ -282,7 +278,7 @@ describe('node crawler', () => {
         'fruits/tomato.js': ['', 32, 42, 0, '', null, 0],
       }),
     );
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
   });
 
   it('uses node fs APIs without find binary', async () => {
@@ -308,7 +304,7 @@ describe('node crawler', () => {
         'fruits/tomato.js': ['', 32, 42, 0, '', null, 0],
       }),
     );
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
   });
 
   it('uses node fs APIs if "forceNodeFilesystemAPI" is set to true, regardless of platform', async () => {
@@ -332,7 +328,7 @@ describe('node crawler', () => {
         'fruits/tomato.js': ['', 32, 42, 0, '', null, 0],
       }),
     );
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
   });
 
   it('completes with empty roots', async () => {
@@ -349,7 +345,7 @@ describe('node crawler', () => {
     });
 
     expect(changedFiles).toEqual(new Map());
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
   });
 
   it('completes with fs.readdir throwing an error', async () => {
@@ -366,7 +362,7 @@ describe('node crawler', () => {
     });
 
     expect(changedFiles).toEqual(new Map());
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
   });
 
   it('uses the withFileTypes option with readdir', async () => {
@@ -389,7 +385,7 @@ describe('node crawler', () => {
         'fruits/tomato.js': ['', 32, 42, 0, '', null, 0],
       }),
     );
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
     // once for /project/fruits, once for /project/fruits/directory
     expect(fs.readdir).toHaveBeenCalledTimes(2);
     // once for strawberry.js, once for tomato.js

--- a/packages/metro-file-map/src/crawlers/__tests__/watchman-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/watchman-test.js
@@ -9,6 +9,7 @@
  */
 
 import {AbortController} from 'node-abort-controller';
+import TreeFS from '../../lib/TreeFS';
 
 const path = require('path');
 
@@ -45,6 +46,7 @@ let watchman;
 let watchmanCrawl;
 let mockResponse;
 let mockFiles;
+const getFS = files => new TreeFS({files, rootDir: ROOT_MOCK});
 
 const ROOT_MOCK = path.sep === '/' ? '/root-mock' : 'M:\\root-mock';
 const FRUITS_RELATIVE = 'fruits';
@@ -129,7 +131,7 @@ describe('watchman watch', () => {
     const {changedFiles, clocks, removedFiles} = await watchmanCrawl({
       previousState: {
         clocks: new Map(),
-        files: new Map(),
+        fileSystem: getFS(new Map()),
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -204,7 +206,7 @@ describe('watchman watch', () => {
         clocks: createMap({
           '': 'c:fake-clock:1',
         }),
-        files: mockFiles,
+        fileSystem: getFS(mockFiles),
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -272,7 +274,7 @@ describe('watchman watch', () => {
         clocks: createMap({
           '': 'c:fake-clock:1',
         }),
-        files: mockFiles,
+        fileSystem: getFS(mockFiles),
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -352,7 +354,7 @@ describe('watchman watch', () => {
           [FRUITS_RELATIVE]: 'c:fake-clock:1',
           [VEGETABLES_RELATIVE]: 'c:fake-clock:2',
         }),
-        files: mockFiles,
+        fileSystem: getFS(mockFiles),
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -407,7 +409,7 @@ describe('watchman watch', () => {
     const {changedFiles, clocks, removedFiles} = await watchmanCrawl({
       previousState: {
         clocks: new Map(),
-        files: new Map(),
+        fileSystem: getFS(new Map()),
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -470,7 +472,7 @@ describe('watchman watch', () => {
       computeSha1: true,
       previousState: {
         clocks: new Map(),
-        files: new Map(),
+        fileSystem: getFS(new Map()),
       },
       extensions: ['js', 'json'],
       rootDir: ROOT_MOCK,

--- a/packages/metro-file-map/src/crawlers/__tests__/watchman-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/watchman-test.js
@@ -168,7 +168,7 @@ describe('watchman watch', () => {
 
     expect(changedFiles).toEqual(mockFiles);
 
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
 
     expect(client.end).toBeCalled();
   });
@@ -224,11 +224,7 @@ describe('watchman watch', () => {
       }),
     );
 
-    expect(removedFiles).toEqual(
-      createMap({
-        [TOMATO_RELATIVE]: ['', 31, 41, 0, '', null, 0],
-      }),
-    );
+    expect(removedFiles).toEqual(new Set([TOMATO_RELATIVE]));
   });
 
   test('resets the file map and tracks removedFiles when watchman is fresh', async () => {
@@ -306,10 +302,7 @@ describe('watchman watch', () => {
     expect(changedFiles.get(TOMATO_RELATIVE)).not.toBe(mockTomatoMetadata);
 
     expect(removedFiles).toEqual(
-      createMap({
-        [MELON_RELATIVE]: ['', 33, 43, 0, '', null, 0],
-        [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, '', null, 0],
-      }),
+      new Set([MELON_RELATIVE, STRAWBERRY_RELATIVE]),
     );
   });
 
@@ -382,10 +375,7 @@ describe('watchman watch', () => {
     );
 
     expect(removedFiles).toEqual(
-      createMap({
-        [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, '', null, 0],
-        [TOMATO_RELATIVE]: ['', 31, 41, 0, '', null, 0],
-      }),
+      new Set([STRAWBERRY_RELATIVE, TOMATO_RELATIVE]),
     );
   });
 
@@ -454,7 +444,7 @@ describe('watchman watch', () => {
 
     expect(changedFiles).toEqual(new Map());
 
-    expect(removedFiles).toEqual(new Map());
+    expect(removedFiles).toEqual(new Set());
 
     expect(client.end).toBeCalled();
   });
@@ -553,11 +543,7 @@ describe('watchman watch', () => {
       }),
     );
 
-    expect(removedFiles).toEqual(
-      createMap({
-        [TOMATO_RELATIVE]: ['', 31, 41, 0, '', null, 0],
-      }),
-    );
+    expect(removedFiles).toEqual(new Set([TOMATO_RELATIVE]));
   });
 
   it('aborts the crawl on pre-aborted signal', async () => {

--- a/packages/metro-file-map/src/crawlers/node/index.js
+++ b/packages/metro-file-map/src/crawlers/node/index.js
@@ -10,7 +10,12 @@
  */
 
 import type {Path, FileMetaData} from '../../flow-types';
-import type {CrawlerOptions, FileData, IgnoreMatcher} from '../../flow-types';
+import type {
+  CanonicalPath,
+  CrawlerOptions,
+  FileData,
+  IgnoreMatcher,
+} from '../../flow-types';
 
 import hasNativeFindSupport from './hasNativeFindSupport';
 import H from '../../constants';
@@ -163,7 +168,7 @@ function findNative(
 }
 
 module.exports = async function nodeCrawl(options: CrawlerOptions): Promise<{
-  removedFiles: FileData,
+  removedFiles: Set<CanonicalPath>,
   changedFiles: FileData,
 }> {
   const {
@@ -191,7 +196,7 @@ module.exports = async function nodeCrawl(options: CrawlerOptions): Promise<{
   return new Promise((resolve, reject) => {
     const callback = (list: Result) => {
       const changedFiles = new Map<Path, FileMetaData>();
-      const removedFiles = new Map(previousState.files);
+      const removedFiles = new Set(previousState.files.keys());
       for (const fileData of list) {
         const [filePath, mtime, size, symlink] = fileData;
         const relativeFilePath = fastPath.relative(rootDir, filePath);

--- a/packages/metro-file-map/src/crawlers/watchman/index.js
+++ b/packages/metro-file-map/src/crawlers/watchman/index.js
@@ -20,7 +20,6 @@ import type {
 } from '../../flow-types';
 import type {WatchmanQueryResponse, WatchmanWatchResponse} from 'fb-watchman';
 
-import H from '../../constants';
 import * as fastPath from '../../lib/fast_path';
 import normalizePathSeparatorsToSystem from '../../lib/normalizePathSeparatorsToSystem';
 import {planQuery} from './planQuery';
@@ -244,22 +243,15 @@ module.exports = async function watchmanCrawl({
   }
 
   let removedFiles: Set<CanonicalPath> = new Set();
-  const changedFiles: FileData = new Map();
+  let changedFiles: FileData = new Map();
   let results: Map<string, WatchmanQueryResponse>;
   let isFresh = false;
   let queryError: ?Error;
   try {
     const watchmanRoots = await getWatchmanRoots(roots);
     const watchmanFileResults = await queryWatchmanForDirs(watchmanRoots);
-
-    // Reset the file map if watchman was restarted and sends us a list of
-    // files.
-    if (watchmanFileResults.isFresh) {
-      removedFiles = new Set(previousState.files.keys());
-      isFresh = true;
-    }
-
     results = watchmanFileResults.results;
+    isFresh = watchmanFileResults.isFresh;
   } catch (e) {
     queryError = e;
   }
@@ -291,6 +283,8 @@ module.exports = async function watchmanCrawl({
 
   perfLogger?.point('watchmanCrawl/processResults_start');
 
+  const freshFileData: FileData = new Map();
+
   for (const [watchRoot, response] of results) {
     const fsRoot = normalizePathSeparatorsToSystem(watchRoot);
     const relativeFsRoot = fastPath.relative(rootDir, fsRoot);
@@ -306,23 +300,13 @@ module.exports = async function watchmanCrawl({
       const filePath =
         fsRoot + path.sep + normalizePathSeparatorsToSystem(fileData.name);
       const relativeFilePath = fastPath.relative(rootDir, filePath);
-      const existingFileData = previousState.files.get(relativeFilePath);
-
-      // If watchman is fresh, the removed files map starts with all files
-      // and we remove them as we verify they still exist.
-      if (isFresh && existingFileData && fileData.exists) {
-        removedFiles.delete(relativeFilePath);
-      }
 
       if (!fileData.exists) {
-        // No need to act on files that do not exist and were not tracked.
-        if (existingFileData) {
-          // If watchman is not fresh, we will know what specific files were
-          // deleted since we last ran and can track only those files.
-          if (!isFresh) {
-            removedFiles.add(relativeFilePath);
-          }
+        if (!isFresh) {
+          removedFiles.add(relativeFilePath);
         }
+        // Whether watchman can return exists: false in a fresh instance
+        // response is unknown, but there's nothing we need to do in that case.
       } else if (!ignore(filePath)) {
         const {mtime_ms, size} = fileData;
         invariant(
@@ -331,10 +315,6 @@ module.exports = async function watchmanCrawl({
         );
         const mtime =
           typeof mtime_ms === 'number' ? mtime_ms : mtime_ms.toNumber();
-
-        if (existingFileData && existingFileData[H.MTIME] === mtime) {
-          continue;
-        }
 
         let sha1hex = fileData['content.sha1hex'];
         if (typeof sha1hex !== 'string' || sha1hex.length !== 40) {
@@ -346,7 +326,7 @@ module.exports = async function watchmanCrawl({
           symlinkInfo = fileData['symlink_target'] ?? 1;
         }
 
-        let nextData: FileMetaData = [
+        const nextData: FileMetaData = [
           '',
           mtime,
           size,
@@ -356,29 +336,20 @@ module.exports = async function watchmanCrawl({
           symlinkInfo,
         ];
 
-        if (
-          existingFileData &&
-          sha1hex != null &&
-          existingFileData[H.SHA1] === sha1hex &&
-          // File is still of the same type
-          (existingFileData[H.SYMLINK] !== 0) === (fileData.type === 'l')
-        ) {
-          // Special case - file touched but not modified, so we can reuse the
-          // metadata and just update mtime.
-          nextData = [
-            existingFileData[0],
-            mtime,
-            existingFileData[2],
-            existingFileData[3],
-            existingFileData[4],
-            existingFileData[5],
-            typeof symlinkInfo === 'string' ? symlinkInfo : existingFileData[6],
-          ];
+        // If watchman is fresh, the removed files map starts with all files
+        // and we remove them as we verify they still exist.
+        if (isFresh) {
+          freshFileData.set(relativeFilePath, nextData);
+        } else {
+          changedFiles.set(relativeFilePath, nextData);
         }
-
-        changedFiles.set(relativeFilePath, nextData);
       }
     }
+  }
+
+  if (isFresh) {
+    ({changedFiles, removedFiles} =
+      previousState.fileSystem.getDifference(freshFileData));
   }
 
   perfLogger?.point('watchmanCrawl/processResults_end');

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -186,27 +186,20 @@ export interface FileSystem {
    */
   linkStats(file: Path): ?FileStats;
 
-  matchFiles(
-    pattern: RegExp | string,
-    opts?: $ReadOnly<{follow?: boolean}>,
-  ): Array<Path>;
-
-  /**
-   * Given a search context, return a list of file paths matching the query.
-   * The query matches against normalized paths which start with `./`,
-   * for example: `a/b.js` -> `./a/b.js`
-   */
-  matchFilesWithContext(
-    root: Path,
-    context: $ReadOnly<{
-      /* Should search for files recursively. */
-      recursive: boolean,
-      /* Filter relative paths against a pattern. */
-      filter: RegExp,
-      /* Follow symlinks when enumerating paths. */
-      follow: boolean,
-    }>,
-  ): Array<Path>;
+  matchFiles(opts: {
+    /* Filter relative paths against a pattern. */
+    filter?: RegExp | null,
+    /* `filter` is applied against absolute paths, vs rootDir-relative. (default: false) */
+    filterCompareAbsolute?: boolean,
+    /* `filter` is applied against posix-delimited paths, even on Windows. (default: false) */
+    filterComparePosix?: boolean,
+    /* Follow symlinks when enumerating paths. (default: false) */
+    follow?: boolean,
+    /* Should search for files recursively. (default: true) */
+    recursive?: boolean,
+    /* Match files under a given root, or null for all files */
+    rootDir?: Path | null,
+  }): Iterable<Path>;
 }
 
 export type Glob = string;

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -50,7 +50,7 @@ export type CacheData = $ReadOnly<{
   map: RawModuleMap['map'],
   mocks: RawModuleMap['mocks'],
   duplicates: RawModuleMap['duplicates'],
-  files: FileData,
+  fileSystemData: mixed,
 }>;
 
 export type CacheDelta = $ReadOnly<{
@@ -177,7 +177,7 @@ export interface FileSystem {
   };
   getModuleName(file: Path): ?string;
   getRealPath(file: Path): ?string;
-  getSerializableSnapshot(): FileData;
+  getSerializableSnapshot(): CacheData['fileSystemData'];
   getSha1(file: Path): ?string;
 
   /**

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -186,7 +186,10 @@ export interface FileSystem {
    */
   linkStats(file: Path): ?FileStats;
 
-  matchFiles(pattern: RegExp | string): Array<Path>;
+  matchFiles(
+    pattern: RegExp | string,
+    opts?: $ReadOnly<{follow?: boolean}>,
+  ): Array<Path>;
 
   /**
    * Given a search context, return a list of file paths matching the query.
@@ -200,6 +203,8 @@ export interface FileSystem {
       recursive: boolean,
       /* Filter relative paths against a pattern. */
       filter: RegExp,
+      /* Follow symlinks when enumerating paths. */
+      follow: boolean,
     }>,
   ): Array<Path>;
 }

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -53,17 +53,25 @@ export type CacheData = $ReadOnly<{
   files: FileData,
 }>;
 
+export type CacheDelta = $ReadOnly<{
+  changed: $ReadOnlyMap<CanonicalPath, FileMetaData>,
+  removed: $ReadOnlySet<CanonicalPath>,
+}>;
+
 export interface CacheManager {
   read(): Promise<?CacheData>;
-  write(
-    dataSnapshot: CacheData,
-    delta: $ReadOnly<{changed: FileData, removed: FileData}>,
-  ): Promise<void>;
+  write(dataSnapshot: CacheData, delta: CacheDelta): Promise<void>;
 }
 
 export type CacheManagerFactory = (
   buildParameters: BuildParameters,
 ) => CacheManager;
+
+// A path that is
+//  - Relative to the contextual `rootDir`
+//  - Normalised (no extraneous '.' or '..')
+//  - Real (no symlinks in path, though the path itself may be a symlink)
+export type CanonicalPath = string;
 
 export type ChangeEvent = {
   logger: ?RootPerfLogger,
@@ -87,8 +95,8 @@ export type CrawlerOptions = {
   includeSymlinks: boolean,
   perfLogger?: ?PerfLogger,
   previousState: $ReadOnly<{
-    clocks: $ReadOnlyMap<Path, WatchmanClockSpec>,
-    files: $ReadOnlyMap<Path, FileMetaData>,
+    clocks: $ReadOnlyMap<CanonicalPath, WatchmanClockSpec>,
+    files: $ReadOnlyMap<CanonicalPath, FileMetaData>,
   }>,
   rootDir: string,
   roots: $ReadOnlyArray<string>,
@@ -142,7 +150,7 @@ export type HTypeValue = $Values<HType>;
 
 export type IgnoreMatcher = (item: string) => boolean;
 
-export type FileData = Map<Path, FileMetaData>;
+export type FileData = Map<CanonicalPath, FileMetaData>;
 
 export type FileMetaData = [
   /* id */ string,

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -96,7 +96,7 @@ export type CrawlerOptions = {
   perfLogger?: ?PerfLogger,
   previousState: $ReadOnly<{
     clocks: $ReadOnlyMap<CanonicalPath, WatchmanClockSpec>,
-    files: $ReadOnlyMap<CanonicalPath, FileMetaData>,
+    fileSystem: FileSystem,
   }>,
   rootDir: string,
   roots: $ReadOnlyArray<string>,
@@ -171,6 +171,10 @@ export interface FileSystem {
   exists(file: Path): boolean;
   getAllFiles(): Array<Path>;
   getDependencies(file: Path): ?Array<string>;
+  getDifference(files: FileData): {
+    changedFiles: FileData,
+    removedFiles: Set<string>,
+  };
   getModuleName(file: Path): ?string;
   getRealPath(file: Path): ?string;
   getSerializableSnapshot(): FileData;

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -373,7 +373,7 @@ export default class HasteMap extends EventEmitter {
         };
 
         const fileDelta = await this._buildFileDelta({
-          files: initialData.files,
+          fileSystem,
           clocks: initialData.clocks,
         });
 

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -127,8 +127,9 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   getAllFiles(): Array<Path> {
+    const rootDir = this.#rootDir;
     return Array.from(this._regularFileIterator(), normalPath =>
-      this._normalToAbsolutePath(normalPath),
+      fastPath.resolve(rootDir, normalPath),
     );
   }
 
@@ -149,8 +150,9 @@ export default class TreeFS implements MutableFileSystem {
     const regexpPattern =
       pattern instanceof RegExp ? pattern : new RegExp(pattern);
     const files = [];
+    const rootDir = this.#rootDir;
     for (const filePath of this._pathIterator()) {
-      const absolutePath = this._normalToAbsolutePath(filePath);
+      const absolutePath = fastPath.resolve(rootDir, filePath);
       if (regexpPattern.test(absolutePath)) {
         files.push(absolutePath);
       }
@@ -421,14 +423,6 @@ export default class TreeFS implements MutableFileSystem {
     return path.isAbsolute(relativeOrAbsolutePath)
       ? fastPath.relative(this.#rootDir, relativeOrAbsolutePath)
       : path.normalize(relativeOrAbsolutePath);
-  }
-
-  _normalToAbsolutePath(normalPath: Path): Path {
-    if (normalPath[0] === '.') {
-      return path.normalize(this.#rootDir + path.sep + normalPath);
-    } else {
-      return this.#rootDir + path.sep + normalPath;
-    }
   }
 
   *_regularFileIterator(): Iterator<Path> {

--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -32,11 +32,13 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       rootDir: p('/project'),
       files: new Map([
         [p('foo/another.js'), ['', 123, 0, 0, '', '', 0]],
+        [p('foo/owndir'), ['', 0, 0, 0, '', '', '.']],
         [p('foo/link-to-bar.js'), ['', 0, 0, 0, '', '', p('../bar.js')]],
         [p('foo/link-to-another.js'), ['', 0, 0, 0, '', '', p('another.js')]],
         [p('../outside/external.js'), ['', 0, 0, 0, '', '', 0]],
         [p('bar.js'), ['', 234, 0, 0, '', '', 0]],
-        [p('link-to-foo'), ['', 456, 0, 0, '', '', p('./foo')]],
+        [p('link-to-foo'), ['', 456, 0, 0, '', '', p('././abnormal/../foo')]],
+        [p('abs-link-out'), ['', 456, 0, 0, '', '', p('/outside/./baz/..')]],
         [p('root'), ['', 0, 0, 0, '', '', '..']],
         [p('link-to-nowhere'), ['', 123, 0, 0, '', '', p('./nowhere')]],
         [p('link-to-self'), ['', 123, 0, 0, '', '', p('./link-to-self')]],
@@ -129,10 +131,12 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
           [p('link-to-self'), ['', 123, 0, 0, '', '', 0]],
         ]),
         removedFiles: new Set([
+          p('foo/owndir'),
           p('foo/link-to-bar.js'),
           p('foo/link-to-another.js'),
           p('../outside/external.js'),
           p('bar.js'),
+          p('abs-link-out'),
           p('root'),
         ]),
       });
@@ -162,6 +166,9 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         }),
       ).toEqual([
         p('/project/foo/another.js'),
+        p('/project/foo/owndir/another.js'),
+        p('/project/foo/owndir/link-to-bar.js'),
+        p('/project/foo/owndir/link-to-another.js'),
         p('/project/foo/link-to-bar.js'),
         p('/project/foo/link-to-another.js'),
       ]);
@@ -186,12 +193,19 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         }),
       ).toEqual([
         p('/project/foo/another.js'),
+        p('/project/foo/owndir/another.js'),
+        p('/project/foo/owndir/link-to-bar.js'),
+        p('/project/foo/owndir/link-to-another.js'),
         p('/project/foo/link-to-bar.js'),
         p('/project/foo/link-to-another.js'),
         p('/project/bar.js'),
         p('/project/link-to-foo/another.js'),
+        p('/project/link-to-foo/owndir/another.js'),
+        p('/project/link-to-foo/owndir/link-to-bar.js'),
+        p('/project/link-to-foo/owndir/link-to-another.js'),
         p('/project/link-to-foo/link-to-bar.js'),
         p('/project/link-to-foo/link-to-another.js'),
+        p('/project/abs-link-out/external.js'),
         p('/project/root/outside/external.js'),
       ]);
     });
@@ -220,7 +234,9 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         }),
       ).toEqual([
         p('/project/foo/another.js'),
+        p('/project/foo/owndir/another.js'),
         p('/project/link-to-foo/another.js'),
+        p('/project/link-to-foo/owndir/another.js'),
       ]);
     });
   });

--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -147,6 +147,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
             // Test starting with `./` since this is mandatory for parity with Webpack.
             /^\.\/.*/,
           ),
+          follow: true,
           recursive: false,
         }),
       ).toEqual([p('/project/bar.js')]);
@@ -156,6 +157,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       expect(
         tfs.matchFilesWithContext(p('/project/foo'), {
           filter: new RegExp(/.*/),
+          follow: true,
           recursive: true,
         }),
       ).toEqual([
@@ -169,6 +171,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       expect(
         tfs.matchFilesWithContext(p('/outside'), {
           filter: new RegExp(/.*/),
+          follow: true,
           recursive: true,
         }),
       ).toEqual([p('/outside/external.js')]);
@@ -178,6 +181,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       expect(
         tfs.matchFilesWithContext(p('/project'), {
           filter: new RegExp(/.*/),
+          follow: true,
           recursive: true,
         }),
       ).toEqual([
@@ -192,10 +196,26 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       ]);
     });
 
+    test('recursive, no follow', () => {
+      expect(
+        tfs.matchFilesWithContext(p('/project'), {
+          filter: new RegExp(/.*/),
+          follow: false,
+          recursive: true,
+        }),
+      ).toEqual([
+        p('/project/foo/another.js'),
+        p('/project/foo/link-to-bar.js'),
+        p('/project/foo/link-to-another.js'),
+        p('/project/bar.js'),
+      ]);
+    });
+
     test('recursive with filter', () => {
       expect(
         tfs.matchFilesWithContext(p('/project'), {
           filter: new RegExp(/\/another\.js/),
+          follow: true,
           recursive: true,
         }),
       ).toEqual([

--- a/packages/metro-file-map/src/lib/fast_path.js
+++ b/packages/metro-file-map/src/lib/fast_path.js
@@ -10,7 +10,8 @@
 
 import * as path from 'path';
 
-// rootDir and filename must be absolute paths (resolved)
+// rootDir must be normalized and absolute, filename may be any absolute path.
+// (but will optimally start with rootDir)
 export function relative(rootDir: string, filename: string): string {
   return filename.indexOf(rootDir + path.sep) === 0
     ? filename.substr(rootDir.length + 1)
@@ -18,11 +19,21 @@ export function relative(rootDir: string, filename: string): string {
 }
 
 const INDIRECTION_FRAGMENT = '..' + path.sep;
+const INDIRECTION_FRAGMENT_LENGTH = INDIRECTION_FRAGMENT.length;
 
-// rootDir must be an absolute path and relativeFilename must be simple
-// (e.g.: foo/bar or ../foo/bar, but never ./foo or foo/../bar)
-export function resolve(rootDir: string, relativeFilename: string): string {
-  return relativeFilename.indexOf(INDIRECTION_FRAGMENT) === 0
-    ? path.resolve(rootDir, relativeFilename)
-    : rootDir + path.sep + relativeFilename;
+// rootDir must be an absolute path and normalPath must be a normal relative
+// path (e.g.: foo/bar or ../foo/bar, but never ./foo or foo/../bar)
+// As of Node 18 this is several times faster than path.resolve, over
+// thousands of real calls with 1-3 levels of indirection.
+export function resolve(rootDir: string, normalPath: string): string {
+  if (normalPath.startsWith(INDIRECTION_FRAGMENT)) {
+    const dirname = rootDir === '' ? '' : path.dirname(rootDir);
+    return resolve(dirname, normalPath.slice(INDIRECTION_FRAGMENT_LENGTH));
+  } else {
+    return (
+      rootDir +
+      // If rootDir is the file system root, it will end in a path separator
+      (rootDir.endsWith(path.sep) ? normalPath : path.sep + normalPath)
+    );
+  }
 }

--- a/packages/metro-file-map/types/flow-types.d.ts
+++ b/packages/metro-file-map/types/flow-types.d.ts
@@ -174,22 +174,20 @@ export interface FileSystem {
    */
   linkStats(file: Path): FileStats | null;
 
-  matchFiles(pattern: RegExp | string): Path[];
-
-  /**
-   * Given a search context, return a list of file paths matching the query.
-   * The query matches against normalized paths which start with `./`,
-   * for example: `a/b.js` -> `./a/b.js`
-   */
-  matchFilesWithContext(
-    root: Path,
-    context: Readonly<{
-      /* Should search for files recursively. */
-      recursive: boolean;
-      /* Filter relative paths against a pattern. */
-      filter: RegExp;
-    }>,
-  ): Path[];
+  matchFiles(opts: {
+    /* Filter relative paths against a pattern. */
+    filter?: RegExp | null;
+    /* `filter` is applied against absolute paths, vs rootDir-relative. (default: false) */
+    filterCompareAbsolute?: boolean;
+    /* `filter` is applied against posix-delimited paths, even on Windows. (default: false) */
+    filterComparePosix?: boolean;
+    /* Follow symlinks when enumerating paths. (default: false) */
+    follow?: boolean;
+    /* Should search for files recursively. (default: true) */
+    recursive?: boolean;
+    /* Match files under a given root, or null for all files */
+    rootDir?: Path | null;
+  }): Iterable<Path>;
 }
 
 export type Glob = string;

--- a/packages/metro/src/lib/contextModule.js
+++ b/packages/metro/src/lib/contextModule.js
@@ -63,7 +63,7 @@ export function fileMatchesContext(
   context: RequireContext,
 ): boolean {
   // NOTE(EvanBacon): Ensure this logic is synchronized with the similar
-  // functionality in `metro-file-map/src/HasteFS.js` (`matchFilesWithContext()`)
+  // functionality in `metro-file-map/src/lib/TreeFS.js` (`matchFiles()`)
 
   const filePath = path.relative(nullthrows(context.from), testPath);
   const filter = context.filter;

--- a/packages/metro/src/lib/transformHelpers.js
+++ b/packages/metro/src/lib/transformHelpers.js
@@ -153,10 +153,12 @@ async function getTransformFn(
       // this is a massive performance boost.
 
       // Search against all files in a subtree.
-      const files = graph.matchFilesWithContext(requireContext.from, {
-        filter: requireContext.filter,
-        recursive: requireContext.recursive,
-      });
+      const files = Array.from(
+        graph.matchFilesWithContext(requireContext.from, {
+          filter: requireContext.filter,
+          recursive: requireContext.recursive,
+        }),
+      );
 
       const template = getContextModuleTemplate(
         requireContext.mode,

--- a/packages/metro/src/lib/transformHelpers.js
+++ b/packages/metro/src/lib/transformHelpers.js
@@ -152,8 +152,7 @@ async function getTransformFn(
       // TODO: Check delta changes to avoid having to look over all files each time
       // this is a massive performance boost.
 
-      // Search against all files, this is very expensive.
-      // TODO: Maybe we could let the user specify which root to check against.
+      // Search against all files in a subtree.
       const files = graph.matchFilesWithContext(requireContext.from, {
         filter: requireContext.filter,
         recursive: requireContext.recursive,

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -299,7 +299,10 @@ class DependencyGraph extends EventEmitter {
       filter: RegExp,
     }>,
   ): string[] {
-    return this._fileSystem.matchFilesWithContext(from, context);
+    return this._fileSystem.matchFilesWithContext(from, {
+      ...context,
+      follow: true,
+    });
   }
 
   resolveDependency(

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -298,9 +298,12 @@ class DependencyGraph extends EventEmitter {
       /* Filter relative paths against a pattern. */
       filter: RegExp,
     }>,
-  ): string[] {
-    return this._fileSystem.matchFilesWithContext(from, {
-      ...context,
+  ): Iterable<string> {
+    return this._fileSystem.matchFiles({
+      rootDir: from,
+      recursive: context.recursive,
+      filter: context.filter,
+      filterComparePosix: true,
       follow: true,
     });
   }


### PR DESCRIPTION
Summary:
Serialise `metro-file-map`'s `TreeFS` by cloning the tree, instead of converting to and from a flat `Map`.

 - Cache `fileSystemData` is now fully cross-platform (it contains no path separators).
 - Serialised data is now a closer match with the internal representation. The new structure is as fast to write, faster to read, and smaller.

Changelog:
```
 - **[Performance]**: Improved startup speed via a new file map cache format.
```

Differential Revision: D46598820

