### PR TITLE
Widen config search paths to include metro.config.cjs

### DIFF
--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -46,8 +46,12 @@ function overrideArgument<T>(arg: Array<T> | T): T {
 }
 
 const explorer = cosmiconfig('metro', {
-  searchPlaces: ['metro.config.js', 'metro.config.json', 'package.json'],
-
+  searchPlaces: [
+    'metro.config.js',
+    'metro.config.cjs',
+    'metro.config.json',
+    'package.json',
+  ],
   loaders: {
     '.json': cosmiconfig.loadJson,
     '.yaml': cosmiconfig.loadYaml,


### PR DESCRIPTION
Summary:
Resolves https://github.com/facebook/metro/issues/1026.

Changelog: **[Feature]** Widen config search paths to include `metro.config.cjs`

Differential Revision: D47290079

