### PR TITLE
Use shorter error message for file resolution issues.

### DIFF
--- a/packages/metro-core/src/errors/PackageResolutionError.js
+++ b/packages/metro-core/src/errors/PackageResolutionError.js
@@ -32,9 +32,8 @@ class PackageResolutionError extends Error {
         `\`${perr.packageJsonPath}\` was successfully found. However, ` +
         'this package itself specifies ' +
         'a `main` module field that could not be resolved (' +
-        `\`${perr.mainModulePath}\`. Indeed, none of these files exist:\n\n` +
-        `  * ${formatFileCandidates(perr.fileCandidates)}\n` +
-        `  * ${formatFileCandidates(perr.indexCandidates)}`,
+        `\`${perr.mainModulePath}\`. Indeed, no file matched the pattern:\n\n` +
+        `  * ${formatFileCandidates(perr.fileCandidates, true)}`,
     );
     Object.assign(this, opts);
   }

--- a/packages/metro-resolver/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/metro-resolver/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`throws on invalid package name 1`] = `
-"The package \`/root/node_modules/invalid/package.json\` is invalid because it specifies a \`main\` module field that could not be resolved (\`/root/node_modules/invalid/main\`. None of these files exist:
+"The package \`/root/node_modules/invalid/package.json\` is invalid because it specifies a \`main\` module field that could not be resolved (\`/root/node_modules/invalid/main\`. No file matched the pattern:
 
-  * /root/node_modules/invalid/main(.js|.jsx|.json|.ts|.tsx)
-  * /root/node_modules/invalid/main/index(.js|.jsx|.json|.ts|.tsx)"
+  * /root/node_modules/invalid/main(/index)?.(js|jsx|json|ts|tsx)"
 `;

--- a/packages/metro-resolver/src/__tests__/index-test.js
+++ b/packages/metro-resolver/src/__tests__/index-test.js
@@ -301,10 +301,9 @@ it('throws a descriptive error when a file inside a Haste package cannot be reso
   expect(() => {
     Resolver.resolve(CONTEXT, 'some-package/subdir/does-not-exist', null);
   }).toThrowErrorMatchingInlineSnapshot(`
-    "While resolving module \`some-package/subdir/does-not-exist\`, the Haste package \`some-package\` was found. However the module \`subdir/does-not-exist\` could not be found within the package. Indeed, none of these files exist:
+    "While resolving module \`some-package/subdir/does-not-exist\`, the Haste package \`some-package\` was found. However the module \`subdir/does-not-exist\` could not be found within the package. Indeed, no file matched the pattern:
 
-      * \`/haste/some-package/subdir/does-not-exist(.js|.jsx|.json|.ts|.tsx)\`
-      * \`/haste/some-package/subdir/does-not-exist/index(.js|.jsx|.json|.ts|.tsx)\`"
+      * \`/haste/some-package/subdir/does-not-exist(/index)?.(js|jsx|json|ts|tsx)\`"
   `);
 });
 

--- a/packages/metro-resolver/src/errors/FailedToResolvePathError.js
+++ b/packages/metro-resolver/src/errors/FailedToResolvePathError.js
@@ -20,9 +20,8 @@ class FailedToResolvePathError extends Error {
 
   constructor(candidates: FileAndDirCandidates) {
     super(
-      'The module could not be resolved because none of these files exist:\n\n' +
-        `  * ${formatFileCandidates(candidates.file)}\n` +
-        `  * ${formatFileCandidates(candidates.dir)}`,
+      'The module could not be resolved because no file matched the pattern:\n\n' +
+        `  * ${formatFileCandidates(candidates.file, true)}`,
     );
     this.candidates = candidates;
   }

--- a/packages/metro-resolver/src/errors/InvalidPackageError.js
+++ b/packages/metro-resolver/src/errors/InvalidPackageError.js
@@ -47,9 +47,8 @@ class InvalidPackageError extends Error {
     super(
       `The package \`${opts.packageJsonPath}\` is invalid because it ` +
         'specifies a `main` module field that could not be resolved (' +
-        `\`${opts.mainModulePath}\`. None of these files exist:\n\n` +
-        `  * ${formatFileCandidates(opts.fileCandidates)}\n` +
-        `  * ${formatFileCandidates(opts.indexCandidates)}`,
+        `\`${opts.mainModulePath}\`. No file matched the pattern:\n\n` +
+        `  * ${formatFileCandidates(opts.fileCandidates, true)}`,
     );
     Object.assign(this, opts);
   }

--- a/packages/metro-resolver/src/errors/formatFileCandidates.js
+++ b/packages/metro-resolver/src/errors/formatFileCandidates.js
@@ -15,6 +15,59 @@ import path from 'path';
 
 import type {FileCandidates} from '../types';
 
+function groupExtensions(exts: $ReadOnlyArray<string>): string[][] {
+  // Reverse the extensions and split into parts
+  const extParts = exts.map(ext => ext.split('.').reverse());
+
+  // Find the maximum depth of extension parts
+  const maxDepth = Math.max(...extParts.map(parts => parts.length));
+
+  // Initialize groups based on the max depth
+  const groups = Array.from({length: maxDepth}, () => new Set<string>());
+
+  extParts.forEach(parts => {
+    parts.forEach((part, i) => {
+      // Add parts to the corresponding group based on their depth
+      groups[i].add(part);
+    });
+  });
+
+  // Cycle groups and remove duplicates that appear forwards
+  groups.forEach((group, index) => {
+    // Remove duplicates that appear forwards
+    // NOTE: This doesn't support extensions like `.native.native.js`
+    groups.forEach((otherGroup, otherIndex) => {
+      if (index < otherIndex) {
+        otherGroup.forEach(part => group.delete(part));
+      }
+    });
+  });
+
+  // Convert sets back to arrays and reverse groups to correct order
+  return groups.map(group => Array.from(group)).reverse();
+}
+
+function createMatcherPatternForExtensions(
+  exts: $ReadOnlyArray<string>,
+): string {
+  let formatted = '';
+
+  if (exts.length) {
+    // Apply grouping function
+    const groups = groupExtensions(exts);
+
+    formatted += groups
+      .map((group, index) => {
+        return index < groups.length - 1
+          ? `(${group.map(ext => `.${ext}`).join('|')})?`
+          : `.(${group.join('|')})`;
+      })
+      .join('');
+  }
+
+  return formatted;
+}
+
 function formatFileCandidates(
   candidates: FileCandidates,
   allowIndex: boolean = false,
@@ -22,43 +75,20 @@ function formatFileCandidates(
   if (candidates.type === 'asset') {
     return candidates.name;
   }
+
   let formatted = candidates.filePathPrefix;
 
   if (allowIndex) {
     formatted += `(${path.sep}index)?`;
   }
 
-  if (candidates.candidateExts.length) {
-    const exts = candidates.candidateExts.filter(Boolean);
-    // exts are formatted as `.ios.js, .native.js, .js, .native.json, .json`
-    // we want to split them into groups delimited by the period, then format
-    // like `(.native|.ios).(js|json)`
+  const extensions = candidates.candidateExts
+    // Drop additional dots, the first character if it is a dot, and remove empty strings.
+    .map(ext => ext.replace(/\.+/g, '.').replace(/^\./g, ''))
+    .filter(Boolean);
 
-    // split into groups, filter, reverse to ensure we get the most specific
-    const groups = exts.map(ext => ext.split('.').filter(Boolean).reverse());
+  formatted += createMatcherPatternForExtensions(extensions);
 
-    const splits = groups
-      .reduce((acc: Array<string>, group) => {
-        group.forEach((ext, i) => {
-          if (!acc[i]) {
-            acc[i] = [];
-          }
-          acc[i].push(ext);
-        });
-        return acc;
-      }, [])
-      // Remove duplicates
-      .map(group => [...new Set(group)])
-      .reverse();
-
-    formatted += splits
-      .map((split, index) => {
-        return index < splits.length - 1
-          ? `(${split.map(split => `.${split}`).join('|')})?`
-          : `.(${split.join('|')})`;
-      })
-      .join('');
-  }
   return formatted;
 }
 

--- a/packages/metro-resolver/src/errors/formatFileCandidates.js
+++ b/packages/metro-resolver/src/errors/formatFileCandidates.js
@@ -38,7 +38,7 @@ function formatFileCandidates(
     const groups = exts.map(ext => ext.split('.').filter(Boolean).reverse());
 
     const splits = groups
-      .reduce((acc, group) => {
+      .reduce((acc: Array<string>, group) => {
         group.forEach((ext, i) => {
           if (!acc[i]) {
             acc[i] = [];

--- a/packages/metro-resolver/src/errors/formatFileCandidates.js
+++ b/packages/metro-resolver/src/errors/formatFileCandidates.js
@@ -11,15 +11,53 @@
 
 'use strict';
 
+import path from 'path';
+
 import type {FileCandidates} from '../types';
 
-function formatFileCandidates(candidates: FileCandidates): string {
+function formatFileCandidates(
+  candidates: FileCandidates,
+  allowIndex: boolean = false,
+): string {
   if (candidates.type === 'asset') {
     return candidates.name;
   }
   let formatted = candidates.filePathPrefix;
+
+  if (allowIndex) {
+    formatted += `(${path.sep}index)?`;
+  }
+
   if (candidates.candidateExts.length) {
-    formatted += '(' + candidates.candidateExts.filter(Boolean).join('|') + ')';
+    const exts = candidates.candidateExts.filter(Boolean);
+    // exts are formatted as `.ios.js, .native.js, .js, .native.json, .json`
+    // we want to split them into groups delimited by the period, then format
+    // like `(.native|.ios).(js|json)`
+
+    // split into groups, filter, reverse to ensure we get the most specific
+    const groups = exts.map(ext => ext.split('.').filter(Boolean).reverse());
+
+    const splits = groups
+      .reduce((acc, group) => {
+        group.forEach((ext, i) => {
+          if (!acc[i]) {
+            acc[i] = [];
+          }
+          acc[i].push(ext);
+        });
+        return acc;
+      }, [])
+      // Remove duplicates
+      .map(group => [...new Set(group)])
+      .reverse();
+
+    formatted += splits
+      .map((split, index) => {
+        return index < splits.length - 1
+          ? `(${split.map(split => `.${split}`).join('|')})?`
+          : `.(${split.join('|')})`;
+      })
+      .join('');
   }
   return formatted;
 }

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -460,7 +460,10 @@ function resolveSourceFileForAllExts(
     }
   }
   if (context.preferNativePlatform) {
-    const filePath = resolveSourceFileForExt(context, `.native${sourceExt}`);
+    const filePath = resolveSourceFileForExt(
+      context,
+      sourceExt ? `.native${sourceExt}` : sourceExt,
+    );
     if (filePath) {
       return filePath;
     }

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -231,9 +231,8 @@ class MissingFileInHastePackageError extends Error {
       `While resolving module \`${opts.moduleName}\`, ` +
         `the Haste package \`${opts.packageName}\` was found. However the ` +
         `module \`${opts.pathInModule}\` could not be found within ` +
-        'the package. Indeed, none of these files exist:\n\n' +
-        `  * \`${formatFileCandidates(opts.candidates.file)}\`\n` +
-        `  * \`${formatFileCandidates(opts.candidates.dir)}\``,
+        'the package. Indeed, no file matched the pattern:\n\n' +
+        `  * \`${formatFileCandidates(opts.candidates.file, true)}\``,
     );
     Object.assign(this, opts);
   }

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
@@ -3,9 +3,8 @@
 exports[`linux assets checks asset extensions case insensitively 1`] = `
 "Unable to resolve module ./asset.PNG from /root/index.js: 
 
-None of these files exist:
-  * asset.PNG(.native|.native.js|.js|.native.json|.json)
-  * asset.PNG/index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * asset.PNG(/index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import a from './asset.PNG';
     |                ^
@@ -15,9 +14,8 @@ None of these files exist:
 exports[`linux assets resolves asset files with resolution suffixes (matching exact) 1`] = `
 "Unable to resolve module ./c@2x.png from /root/index.js: 
 
-None of these files exist:
+No file matched the pattern:
   * c@2x.png
-  * c@2x.png/index(.native|.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './c@2x.png';
     |                ^
@@ -27,9 +25,8 @@ None of these files exist:
 exports[`linux assets resolves asset files with resolution suffixes (matching size) 1`] = `
 "Unable to resolve module ./a@1.5x.png from /root/index.js: 
 
-None of these files exist:
+No file matched the pattern:
   * a@1.5x.png
-  * a@1.5x.png/index(.native|.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './a@1.5x.png';
     |                ^
@@ -39,9 +36,8 @@ None of these files exist:
 exports[`linux assets resolves custom asset extensions when overriding assetExts 1`] = `
 "Unable to resolve module ./asset2.png from /root/index.js: 
 
-None of these files exist:
-  * asset2.png(.native|.native.js|.js|.native.json|.json)
-  * asset2.png/index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * asset2.png(/index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import a from './asset2.png';
     |                ^
@@ -84,9 +80,8 @@ exports[`linux hasteImpl config param does not take file name or extension into 
 exports[`linux packages in node_modules/ browser field in package.json resolves mappings from internal calls 1`] = `
 "Unable to resolve module ./foo.js from /root/node_modules/aPackage/index.js: 
 
-None of these files exist:
-  * node_modules/aPackage/foo.js(.native|.native.js|.js|.native.json|.json)
-  * node_modules/aPackage/foo.js/index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * node_modules/aPackage/foo.js(/index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -114,9 +109,8 @@ exports[`linux packages in node_modules/ finds nested packages in node_modules 1
 exports[`linux packages in node_modules/ react-native field in package.json resolves mappings from internal calls 1`] = `
 "Unable to resolve module ./foo.js from /root/node_modules/aPackage/index.js: 
 
-None of these files exist:
-  * node_modules/aPackage/foo.js(.native|.native.js|.js|.native.json|.json)
-  * node_modules/aPackage/foo.js/index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * node_modules/aPackage/foo.js(/index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -144,9 +138,8 @@ exports[`linux packages in node_modules/ uses the folder name and not the name i
 exports[`linux platforms resolves platform-specific files 1`] = `
 "Unable to resolve module ./foo.js from /root/index.js: 
 
-None of these files exist:
-  * foo.js(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json)
-  * foo.js/index(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json)
+No file matched the pattern:
+  * foo.js(/index)?(.ios|.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -156,9 +149,8 @@ None of these files exist:
 exports[`linux relative paths fails when trying to implicitly require an extension not listed in sourceExts 1`] = `
 "Unable to resolve module ./a.another from /root/index.js: 
 
-None of these files exist:
-  * a.another(.native|.native.js|.js|.native.json|.json)
-  * a.another/index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * a.another(/index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import root from './a.another';
     |                   ^
@@ -168,9 +160,8 @@ None of these files exist:
 exports[`linux relative paths with additional files included in the file map (watcher.additionalExts) fails when implicitly requiring a file outside sourceExts 1`] = `
 "Unable to resolve module ./a from /root/index.js: 
 
-None of these files exist:
-  * a(.native|.native.js|.js|.native.json|.json)
-  * a/index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * a(/index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^
@@ -180,9 +171,8 @@ None of these files exist:
 exports[`win32 assets checks asset extensions case insensitively 1`] = `
 "Unable to resolve module ./asset.PNG from C:\\\\root\\\\index.js: 
 
-None of these files exist:
-  * asset.PNG(.native|.native.js|.js|.native.json|.json)
-  * asset.PNG\\\\index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * asset.PNG(\\\\index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import a from './asset.PNG';
     |                ^
@@ -192,9 +182,8 @@ None of these files exist:
 exports[`win32 assets resolves asset files with resolution suffixes (matching exact) 1`] = `
 "Unable to resolve module ./c@2x.png from C:\\\\root\\\\index.js: 
 
-None of these files exist:
+No file matched the pattern:
   * c@2x.png
-  * c@2x.png\\\\index(.native|.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './c@2x.png';
     |                ^
@@ -204,9 +193,8 @@ None of these files exist:
 exports[`win32 assets resolves asset files with resolution suffixes (matching size) 1`] = `
 "Unable to resolve module ./a@1.5x.png from C:\\\\root\\\\index.js: 
 
-None of these files exist:
+No file matched the pattern:
   * a@1.5x.png
-  * a@1.5x.png\\\\index(.native|.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './a@1.5x.png';
     |                ^
@@ -216,9 +204,8 @@ None of these files exist:
 exports[`win32 assets resolves custom asset extensions when overriding assetExts 1`] = `
 "Unable to resolve module ./asset2.png from C:\\\\root\\\\index.js: 
 
-None of these files exist:
-  * asset2.png(.native|.native.js|.js|.native.json|.json)
-  * asset2.png\\\\index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * asset2.png(\\\\index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import a from './asset2.png';
     |                ^
@@ -261,9 +248,8 @@ exports[`win32 hasteImpl config param does not take file name or extension into 
 exports[`win32 packages in node_modules/ browser field in package.json resolves mappings from internal calls 1`] = `
 "Unable to resolve module ./foo.js from C:\\\\root\\\\node_modules\\\\aPackage\\\\index.js: 
 
-None of these files exist:
-  * node_modules\\\\aPackage\\\\foo.js(.native|.native.js|.js|.native.json|.json)
-  * node_modules\\\\aPackage\\\\foo.js\\\\index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * node_modules\\\\aPackage\\\\foo.js(\\\\index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -291,9 +277,8 @@ exports[`win32 packages in node_modules/ finds nested packages in node_modules 1
 exports[`win32 packages in node_modules/ react-native field in package.json resolves mappings from internal calls 1`] = `
 "Unable to resolve module ./foo.js from C:\\\\root\\\\node_modules\\\\aPackage\\\\index.js: 
 
-None of these files exist:
-  * node_modules\\\\aPackage\\\\foo.js(.native|.native.js|.js|.native.json|.json)
-  * node_modules\\\\aPackage\\\\foo.js\\\\index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * node_modules\\\\aPackage\\\\foo.js(\\\\index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -321,9 +306,8 @@ exports[`win32 packages in node_modules/ uses the folder name and not the name i
 exports[`win32 platforms resolves platform-specific files 1`] = `
 "Unable to resolve module ./foo.js from C:\\\\root\\\\index.js: 
 
-None of these files exist:
-  * foo.js(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json)
-  * foo.js\\\\index(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json)
+No file matched the pattern:
+  * foo.js(\\\\index)?(.ios|.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -333,9 +317,8 @@ None of these files exist:
 exports[`win32 relative paths fails when trying to implicitly require an extension not listed in sourceExts 1`] = `
 "Unable to resolve module ./a.another from C:\\\\root\\\\index.js: 
 
-None of these files exist:
-  * a.another(.native|.native.js|.js|.native.json|.json)
-  * a.another\\\\index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * a.another(\\\\index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import root from './a.another';
     |                   ^
@@ -345,9 +328,8 @@ None of these files exist:
 exports[`win32 relative paths with additional files included in the file map (watcher.additionalExts) fails when implicitly requiring a file outside sourceExts 1`] = `
 "Unable to resolve module ./a from C:\\\\root\\\\index.js: 
 
-None of these files exist:
-  * a(.native|.native.js|.js|.native.json|.json)
-  * a\\\\index(.native|.native.js|.js|.native.json|.json)
+No file matched the pattern:
+  * a(\\\\index)?(.native)?.(native|js|json)
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`linux assets asserts missing file with enterprise-extension 1`] = `
+"Unable to resolve module ./missing from /root/index.js: 
+
+No file matched the pattern:
+  * missing(/index)?(.native)?(.fb)?.(js|json)
+  1 | import foo from 'bar';
+> 2 | import './missing';
+    |         ^
+  3 | import bar from 'foo';"
+`;
+
+exports[`linux assets asserts missing file with multiple platform-extensions 1`] = `
+"Unable to resolve module ./missing from /root/index.js: 
+
+No file matched the pattern:
+  * missing(/index)?(.ios|.native)?.(js|json)
+  1 | import foo from 'bar';
+> 2 | import './missing';
+    |         ^
+  3 | import bar from 'foo';"
+`;
+
+exports[`linux assets asserts missing file with multiple platform-extensions and enterprise-extensions 1`] = `
+"Unable to resolve module ./missing from /root/index.js: 
+
+No file matched the pattern:
+  * missing(/index)?(.ios|.native)?(.fb)?.(js|json)
+  1 | import foo from 'bar';
+> 2 | import './missing';
+    |         ^
+  3 | import bar from 'foo';"
+`;
+
 exports[`linux assets checks asset extensions case insensitively 1`] = `
 "Unable to resolve module ./asset.PNG from /root/index.js: 
 
@@ -165,6 +198,39 @@ No file matched the pattern:
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^
+  3 | import bar from 'foo';"
+`;
+
+exports[`win32 assets asserts missing file with enterprise-extension 1`] = `
+"Unable to resolve module ./missing from C:\\\\root\\\\index.js: 
+
+No file matched the pattern:
+  * missing(\\\\index)?(.native)?(.fb)?.(js|json)
+  1 | import foo from 'bar';
+> 2 | import './missing';
+    |         ^
+  3 | import bar from 'foo';"
+`;
+
+exports[`win32 assets asserts missing file with multiple platform-extensions 1`] = `
+"Unable to resolve module ./missing from C:\\\\root\\\\index.js: 
+
+No file matched the pattern:
+  * missing(\\\\index)?(.ios|.native)?.(js|json)
+  1 | import foo from 'bar';
+> 2 | import './missing';
+    |         ^
+  3 | import bar from 'foo';"
+`;
+
+exports[`win32 assets asserts missing file with multiple platform-extensions and enterprise-extensions 1`] = `
+"Unable to resolve module ./missing from C:\\\\root\\\\index.js: 
+
+No file matched the pattern:
+  * missing(\\\\index)?(.ios|.native)?(.fb)?.(js|json)
+  1 | import foo from 'bar';
+> 2 | import './missing';
+    |         ^
   3 | import bar from 'foo';"
 `;
 

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
@@ -4,7 +4,7 @@ exports[`linux assets checks asset extensions case insensitively 1`] = `
 "Unable to resolve module ./asset.PNG from /root/index.js: 
 
 No file matched the pattern:
-  * asset.PNG(/index)?(.native)?.(native|js|json)
+  * asset.PNG(/index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import a from './asset.PNG';
     |                ^
@@ -37,7 +37,7 @@ exports[`linux assets resolves custom asset extensions when overriding assetExts
 "Unable to resolve module ./asset2.png from /root/index.js: 
 
 No file matched the pattern:
-  * asset2.png(/index)?(.native)?.(native|js|json)
+  * asset2.png(/index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import a from './asset2.png';
     |                ^
@@ -81,7 +81,7 @@ exports[`linux packages in node_modules/ browser field in package.json resolves 
 "Unable to resolve module ./foo.js from /root/node_modules/aPackage/index.js: 
 
 No file matched the pattern:
-  * node_modules/aPackage/foo.js(/index)?(.native)?.(native|js|json)
+  * node_modules/aPackage/foo.js(/index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -110,7 +110,7 @@ exports[`linux packages in node_modules/ react-native field in package.json reso
 "Unable to resolve module ./foo.js from /root/node_modules/aPackage/index.js: 
 
 No file matched the pattern:
-  * node_modules/aPackage/foo.js(/index)?(.native)?.(native|js|json)
+  * node_modules/aPackage/foo.js(/index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -139,7 +139,7 @@ exports[`linux platforms resolves platform-specific files 1`] = `
 "Unable to resolve module ./foo.js from /root/index.js: 
 
 No file matched the pattern:
-  * foo.js(/index)?(.ios|.native)?.(native|js|json)
+  * foo.js(/index)?(.ios|.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -150,7 +150,7 @@ exports[`linux relative paths fails when trying to implicitly require an extensi
 "Unable to resolve module ./a.another from /root/index.js: 
 
 No file matched the pattern:
-  * a.another(/index)?(.native)?.(native|js|json)
+  * a.another(/index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import root from './a.another';
     |                   ^
@@ -161,7 +161,7 @@ exports[`linux relative paths with additional files included in the file map (wa
 "Unable to resolve module ./a from /root/index.js: 
 
 No file matched the pattern:
-  * a(/index)?(.native)?.(native|js|json)
+  * a(/index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^
@@ -172,7 +172,7 @@ exports[`win32 assets checks asset extensions case insensitively 1`] = `
 "Unable to resolve module ./asset.PNG from C:\\\\root\\\\index.js: 
 
 No file matched the pattern:
-  * asset.PNG(\\\\index)?(.native)?.(native|js|json)
+  * asset.PNG(\\\\index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import a from './asset.PNG';
     |                ^
@@ -205,7 +205,7 @@ exports[`win32 assets resolves custom asset extensions when overriding assetExts
 "Unable to resolve module ./asset2.png from C:\\\\root\\\\index.js: 
 
 No file matched the pattern:
-  * asset2.png(\\\\index)?(.native)?.(native|js|json)
+  * asset2.png(\\\\index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import a from './asset2.png';
     |                ^
@@ -249,7 +249,7 @@ exports[`win32 packages in node_modules/ browser field in package.json resolves 
 "Unable to resolve module ./foo.js from C:\\\\root\\\\node_modules\\\\aPackage\\\\index.js: 
 
 No file matched the pattern:
-  * node_modules\\\\aPackage\\\\foo.js(\\\\index)?(.native)?.(native|js|json)
+  * node_modules\\\\aPackage\\\\foo.js(\\\\index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -278,7 +278,7 @@ exports[`win32 packages in node_modules/ react-native field in package.json reso
 "Unable to resolve module ./foo.js from C:\\\\root\\\\node_modules\\\\aPackage\\\\index.js: 
 
 No file matched the pattern:
-  * node_modules\\\\aPackage\\\\foo.js(\\\\index)?(.native)?.(native|js|json)
+  * node_modules\\\\aPackage\\\\foo.js(\\\\index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -307,7 +307,7 @@ exports[`win32 platforms resolves platform-specific files 1`] = `
 "Unable to resolve module ./foo.js from C:\\\\root\\\\index.js: 
 
 No file matched the pattern:
-  * foo.js(\\\\index)?(.ios|.native)?.(native|js|json)
+  * foo.js(\\\\index)?(.ios|.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -318,7 +318,7 @@ exports[`win32 relative paths fails when trying to implicitly require an extensi
 "Unable to resolve module ./a.another from C:\\\\root\\\\index.js: 
 
 No file matched the pattern:
-  * a.another(\\\\index)?(.native)?.(native|js|json)
+  * a.another(\\\\index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import root from './a.another';
     |                   ^
@@ -329,7 +329,7 @@ exports[`win32 relative paths with additional files included in the file map (wa
 "Unable to resolve module ./a from C:\\\\root\\\\index.js: 
 
 No file matched the pattern:
-  * a(\\\\index)?(.native)?.(native|js|json)
+  * a(\\\\index)?(.native)?.(js|json)
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^

--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -1540,6 +1540,60 @@ type MockFSDirContents = $ReadOnly<{
         ).toThrowErrorMatchingSnapshot();
       });
 
+      it('asserts missing file with enterprise-extension', async () => {
+        setMockFileSystem({
+          'index.js': mockFileImport("import './missing';"),
+        });
+
+        resolver = await createResolver({
+          resolver: {
+            sourceExts: ['.fb.js', 'js', '.fb.json', 'json'],
+          },
+        });
+
+        expect(() =>
+          resolver.resolve(p('/root/index.js'), './missing'),
+        ).toThrowErrorMatchingSnapshot();
+      });
+
+      it('asserts missing file with multiple platform-extensions and enterprise-extensions', async () => {
+        setMockFileSystem({
+          'index.js': mockFileImport("import './missing';"),
+        });
+
+        resolver = await createResolver(
+          {
+            resolver: {
+              sourceExts: ['.fb.js', 'js', '.fb.json', 'json'],
+            },
+          },
+          'ios',
+        );
+
+        expect(() =>
+          resolver.resolve(p('/root/index.js'), './missing'),
+        ).toThrowErrorMatchingSnapshot();
+      });
+
+      it('asserts missing file with multiple platform-extensions', async () => {
+        setMockFileSystem({
+          'index.js': mockFileImport("import './missing';"),
+        });
+
+        resolver = await createResolver(
+          {
+            resolver: {
+              sourceExts: ['js', 'json'],
+            },
+          },
+          'ios',
+        );
+
+        expect(() =>
+          resolver.resolve(p('/root/index.js'), './missing'),
+        ).toThrowErrorMatchingSnapshot();
+      });
+
       it('resolves custom asset extensions when overriding assetExts', async () => {
         setMockFileSystem({
           'index.js': mockFileImport("import a from './asset2.png';"),

--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -181,12 +181,10 @@ class ModuleResolver<TPackage: Packageish> {
           fromModule.path,
           moduleName,
           [
-            '\n\nNone of these files exist:',
+            '\n\nNo file matched the pattern:',
             `  * ${Resolver.formatFileCandidates(
               this._removeRoot(candidates.file),
-            )}`,
-            `  * ${Resolver.formatFileCandidates(
-              this._removeRoot(candidates.dir),
+              true,
             )}`,
           ].join('\n'),
           {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

- Part of the resolution error is very verbose and somewhat hard to make sense of.
- This PR condenses the matchable segments to reduce duplicate contents.
  - Add optional `(/index)?` segment to prevent needing a second line.
  - Modify header `none of these files exist:` to account for the single line `no file matched the pattern`. I find this line more helpful as it implies the issue may be due to the pattern and not to the lack of file existence. Generally when users are reporting this issue to Expo CLI, it's because they need to modify `srcExts`.
  - Reduce duplicate references in extensions `(.native|.native.js|.js|.native.json|.json)` -> `(.native)?.(native|js|json)`. This clearly has an issue where `.native.native` would technically match the listed pattern––open to suggestions on how to format this differently. However, `.native` seems like it shouldn't be present regardless. Worth noting that I hadn't noticed the extraneous `.native` before because the length of the error message.
- [reference to discord proposal](https://discord.com/channels/514829729862516747/514832110595604510/1128846939060961411).

<img width="1059" alt="Screenshot 2023-07-15 at 6 32 54 PM" src="https://github.com/facebook/metro/assets/9664363/753cab96-9c57-4e40-ba79-7b0814895b5a">


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

- Unit tests cover this well.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
