### PR TITLE
fix: prevent dangling `.native` platform extension

### DIFF
--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -460,7 +460,7 @@ function resolveSourceFileForAllExts(
       return filePath;
     }
   }
-  if (context.preferNativePlatform) {
+  if (context.preferNativePlatform && sourceExt !== '') {
     const filePath = resolveSourceFileForExt(context, `.native${sourceExt}`);
     if (filePath) {
       return filePath;

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
@@ -4,8 +4,8 @@ exports[`linux assets checks asset extensions case insensitively 1`] = `
 "Unable to resolve module ./asset.PNG from /root/index.js: 
 
 None of these files exist:
-  * asset.PNG(.native|.native.js|.js|.native.json|.json)
-  * asset.PNG/index(.native|.native.js|.js|.native.json|.json)
+  * asset.PNG(.native.js|.js|.native.json|.json)
+  * asset.PNG/index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './asset.PNG';
     |                ^
@@ -17,7 +17,7 @@ exports[`linux assets resolves asset files with resolution suffixes (matching ex
 
 None of these files exist:
   * c@2x.png
-  * c@2x.png/index(.native|.native.js|.js|.native.json|.json)
+  * c@2x.png/index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './c@2x.png';
     |                ^
@@ -29,7 +29,7 @@ exports[`linux assets resolves asset files with resolution suffixes (matching si
 
 None of these files exist:
   * a@1.5x.png
-  * a@1.5x.png/index(.native|.native.js|.js|.native.json|.json)
+  * a@1.5x.png/index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './a@1.5x.png';
     |                ^
@@ -40,8 +40,8 @@ exports[`linux assets resolves custom asset extensions when overriding assetExts
 "Unable to resolve module ./asset2.png from /root/index.js: 
 
 None of these files exist:
-  * asset2.png(.native|.native.js|.js|.native.json|.json)
-  * asset2.png/index(.native|.native.js|.js|.native.json|.json)
+  * asset2.png(.native.js|.js|.native.json|.json)
+  * asset2.png/index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './asset2.png';
     |                ^
@@ -85,8 +85,8 @@ exports[`linux packages in node_modules/ browser field in package.json resolves 
 "Unable to resolve module ./foo.js from /root/node_modules/aPackage/index.js: 
 
 None of these files exist:
-  * node_modules/aPackage/foo.js(.native|.native.js|.js|.native.json|.json)
-  * node_modules/aPackage/foo.js/index(.native|.native.js|.js|.native.json|.json)
+  * node_modules/aPackage/foo.js(.native.js|.js|.native.json|.json)
+  * node_modules/aPackage/foo.js/index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -115,8 +115,8 @@ exports[`linux packages in node_modules/ react-native field in package.json reso
 "Unable to resolve module ./foo.js from /root/node_modules/aPackage/index.js: 
 
 None of these files exist:
-  * node_modules/aPackage/foo.js(.native|.native.js|.js|.native.json|.json)
-  * node_modules/aPackage/foo.js/index(.native|.native.js|.js|.native.json|.json)
+  * node_modules/aPackage/foo.js(.native.js|.js|.native.json|.json)
+  * node_modules/aPackage/foo.js/index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -145,8 +145,8 @@ exports[`linux platforms resolves platform-specific files 1`] = `
 "Unable to resolve module ./foo.js from /root/index.js: 
 
 None of these files exist:
-  * foo.js(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json)
-  * foo.js/index(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json)
+  * foo.js(.ios.js|.native.js|.js|.ios.json|.native.json|.json)
+  * foo.js/index(.ios.js|.native.js|.js|.ios.json|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -157,8 +157,8 @@ exports[`linux relative paths fails when trying to implicitly require an extensi
 "Unable to resolve module ./a.another from /root/index.js: 
 
 None of these files exist:
-  * a.another(.native|.native.js|.js|.native.json|.json)
-  * a.another/index(.native|.native.js|.js|.native.json|.json)
+  * a.another(.native.js|.js|.native.json|.json)
+  * a.another/index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import root from './a.another';
     |                   ^
@@ -169,8 +169,8 @@ exports[`linux relative paths with additional files included in the file map (wa
 "Unable to resolve module ./a from /root/index.js: 
 
 None of these files exist:
-  * a(.native|.native.js|.js|.native.json|.json)
-  * a/index(.native|.native.js|.js|.native.json|.json)
+  * a(.native.js|.js|.native.json|.json)
+  * a/index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^
@@ -181,8 +181,8 @@ exports[`win32 assets checks asset extensions case insensitively 1`] = `
 "Unable to resolve module ./asset.PNG from C:\\\\root\\\\index.js: 
 
 None of these files exist:
-  * asset.PNG(.native|.native.js|.js|.native.json|.json)
-  * asset.PNG\\\\index(.native|.native.js|.js|.native.json|.json)
+  * asset.PNG(.native.js|.js|.native.json|.json)
+  * asset.PNG\\\\index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './asset.PNG';
     |                ^
@@ -194,7 +194,7 @@ exports[`win32 assets resolves asset files with resolution suffixes (matching ex
 
 None of these files exist:
   * c@2x.png
-  * c@2x.png\\\\index(.native|.native.js|.js|.native.json|.json)
+  * c@2x.png\\\\index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './c@2x.png';
     |                ^
@@ -206,7 +206,7 @@ exports[`win32 assets resolves asset files with resolution suffixes (matching si
 
 None of these files exist:
   * a@1.5x.png
-  * a@1.5x.png\\\\index(.native|.native.js|.js|.native.json|.json)
+  * a@1.5x.png\\\\index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './a@1.5x.png';
     |                ^
@@ -217,8 +217,8 @@ exports[`win32 assets resolves custom asset extensions when overriding assetExts
 "Unable to resolve module ./asset2.png from C:\\\\root\\\\index.js: 
 
 None of these files exist:
-  * asset2.png(.native|.native.js|.js|.native.json|.json)
-  * asset2.png\\\\index(.native|.native.js|.js|.native.json|.json)
+  * asset2.png(.native.js|.js|.native.json|.json)
+  * asset2.png\\\\index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './asset2.png';
     |                ^
@@ -262,8 +262,8 @@ exports[`win32 packages in node_modules/ browser field in package.json resolves 
 "Unable to resolve module ./foo.js from C:\\\\root\\\\node_modules\\\\aPackage\\\\index.js: 
 
 None of these files exist:
-  * node_modules\\\\aPackage\\\\foo.js(.native|.native.js|.js|.native.json|.json)
-  * node_modules\\\\aPackage\\\\foo.js\\\\index(.native|.native.js|.js|.native.json|.json)
+  * node_modules\\\\aPackage\\\\foo.js(.native.js|.js|.native.json|.json)
+  * node_modules\\\\aPackage\\\\foo.js\\\\index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -292,8 +292,8 @@ exports[`win32 packages in node_modules/ react-native field in package.json reso
 "Unable to resolve module ./foo.js from C:\\\\root\\\\node_modules\\\\aPackage\\\\index.js: 
 
 None of these files exist:
-  * node_modules\\\\aPackage\\\\foo.js(.native|.native.js|.js|.native.json|.json)
-  * node_modules\\\\aPackage\\\\foo.js\\\\index(.native|.native.js|.js|.native.json|.json)
+  * node_modules\\\\aPackage\\\\foo.js(.native.js|.js|.native.json|.json)
+  * node_modules\\\\aPackage\\\\foo.js\\\\index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -322,8 +322,8 @@ exports[`win32 platforms resolves platform-specific files 1`] = `
 "Unable to resolve module ./foo.js from C:\\\\root\\\\index.js: 
 
 None of these files exist:
-  * foo.js(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json)
-  * foo.js\\\\index(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json)
+  * foo.js(.ios.js|.native.js|.js|.ios.json|.native.json|.json)
+  * foo.js\\\\index(.ios.js|.native.js|.js|.ios.json|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -334,8 +334,8 @@ exports[`win32 relative paths fails when trying to implicitly require an extensi
 "Unable to resolve module ./a.another from C:\\\\root\\\\index.js: 
 
 None of these files exist:
-  * a.another(.native|.native.js|.js|.native.json|.json)
-  * a.another\\\\index(.native|.native.js|.js|.native.json|.json)
+  * a.another(.native.js|.js|.native.json|.json)
+  * a.another\\\\index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import root from './a.another';
     |                   ^
@@ -346,8 +346,8 @@ exports[`win32 relative paths with additional files included in the file map (wa
 "Unable to resolve module ./a from C:\\\\root\\\\index.js: 
 
 None of these files exist:
-  * a(.native|.native.js|.js|.native.json|.json)
-  * a\\\\index(.native|.native.js|.js|.native.json|.json)
+  * a(.native.js|.js|.native.json|.json)
+  * a\\\\index(.native.js|.js|.native.json|.json)
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

- split out of https://github.com/facebook/metro/pull/1036
- Prevent `.native` extension on its own (in favor of `.native.js`, etc.).
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

- Updated the tests.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
