### PR TITLE
WIP/RFC: Include import stacks in resolution errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,6 +19,7 @@ suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 suppress_type=$FlowFixMeEmpty
+suppress_type=$FlowExpectedError
 
 [lints]
 sketchy-null-number=warn

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/Graph-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/Graph-test.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`diagnostics appends a partial import stack to resolution error on incremental traversal 1`] = `
+[Error: Dependency not found: /foo -> /bar
+Import stack:
+    at /foo
+    (...)
+    at /bundle]
+`;
+
+exports[`diagnostics appends an import stack to resolution error on initial traversal 1`] = `
+[Error: Dependency not found: /foo -> /bar
+Import stack:
+    at /foo
+    at /bundle]
+`;
+
+exports[`diagnostics entry point is not named in the import stack when there are multiple entry points 1`] = `
+[Error: Dependency not found: /foo -> /bar
+Import stack:
+    at /foo
+    (...)]
+`;
+
+exports[`diagnostics import stack is available on the error object 1`] = `
+"    at /foo
+    at /bundle"
+`;
+
 exports[`should do the initial traversal correctly 1`] = `
 TestGraph {
   "dependencies": Map {

--- a/packages/metro/src/DeltaBundler/diagnostics.js
+++ b/packages/metro/src/DeltaBundler/diagnostics.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {TransformResultDependency} from './types.flow';
+
+export type DependencyStackNode = $ReadOnly<{
+  // If `dependency` is null, this is a dependency whose origin isn't known
+  // at the time we produced this stack. This happens in most incremental
+  // traversals: since we can throw before we've finished processing
+  // updates, all dependencies outside the immediate call stack are
+  // potentially out of date, so we don't try to return them.
+  dependency: null | TransformResultDependency,
+  // Absolute path of the origin module if this is a concrete dependency,
+  // or of the next known module in the chain if dependency is `null`.
+  absolutePath: null | string,
+  // The parent node in the dependency tree.
+  parent: null | DependencyStackNode,
+}>;
+
+export function addImportStackToError(
+  dependencyStack: DependencyStackNode,
+  error: Error,
+) {
+  let importStackString = '';
+  let node: ?DependencyStackNode = dependencyStack;
+  let printedEllipsis = false;
+  while (node) {
+    if (node.dependency == null || node.absolutePath == null) {
+      // Make sure we don't print multiple consecutive ellipses.
+      if (!printedEllipsis) {
+        if (importStackString !== '') {
+          importStackString += '\n';
+        }
+        importStackString += '    (...)';
+        printedEllipsis = true;
+      }
+    }
+
+    if (node.absolutePath != null) {
+      if (importStackString !== '') {
+        importStackString += '\n';
+      }
+      const loc = node.dependency?.data.locs[0];
+
+      importStackString +=
+        // TODO: @nocommit Absolute paths are too verbose - relativize them (here / outside of Graph?)
+        '    at ' +
+        node.absolutePath +
+        (loc ? `:${loc.start.line}:${loc.start.column + 1}` : '');
+      printedEllipsis = false;
+    }
+    node = node.parent;
+  }
+  try {
+    error.message += '\nImport stack:\n' + importStackString;
+
+    // $FlowIgnore
+    error.metroImportStack = importStackString;
+  } catch {
+    // Mutating the error object might fail, so swallow any inner errors.
+  }
+}

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/build-errors-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/build-errors-test.js.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`APIs/semantics reports resolution errors with CJS + non-inlined requires 1`] = `
+Unable to resolve module ./does-not-exist from <dir>/cannot-resolve-require.js: 
+
+None of these files exist:
+  * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  13 |
+  14 | // $FlowExpectedError[cannot-resolve-module]
+> 15 | const DoesNotExist = require('./does-not-exist');
+     |                               ^
+  16 |
+  17 | global.x = (DoesNotExist: DoesNotExistT);
+  18 |
+`;
+
+exports[`APIs/semantics reports resolution errors with ESM + non-inlined requires 1`] = `
+Unable to resolve module ./does-not-exist from <dir>/cannot-resolve-import.js: 
+
+None of these files exist:
+  * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  13 |
+  14 | // $FlowExpectedError[cannot-resolve-module]
+> 15 | import DoesNotExist from './does-not-exist';
+     |                           ^
+  16 |
+  17 | global.x = (DoesNotExist: DoesNotExistT);
+  18 |
+`;
+
+exports[`APIs/semantics reports resolution errors with inline requires + CJS 1`] = `
+Unable to resolve module ./does-not-exist from <dir>/inline-requires-cannot-resolve-require.js: 
+
+None of these files exist:
+  * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  13 |
+  14 | // $FlowExpectedError[cannot-resolve-module]
+> 15 | const DoesNotExist = require('./does-not-exist');
+     |                               ^
+  16 |
+  17 | global.x = (DoesNotExist: DoesNotExistT);
+  18 |
+`;
+
+exports[`APIs/semantics reports resolution errors with inline requires + ESM 1`] = `
+Unable to resolve module ./does-not-exist from <dir>/inline-requires-cannot-resolve-import.js: 
+
+None of these files exist:
+  * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  13 |
+  14 | // $FlowExpectedError[cannot-resolve-module]
+> 15 | import DoesNotExist from './does-not-exist';
+     |                           ^
+  16 |
+  17 | global.x = (DoesNotExist: DoesNotExistT);
+  18 |
+`;
+
+exports[`formatting edge cases reports resolution errors with a multi-line loc + specifier containing an escape sequence 1`] = `
+Unable to resolve module ./does-not'"-exist from <dir>/cannot-resolve-multi-line-import-with-escapes.js: 
+
+None of these files exist:
+  * build-errors/does-not'"-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not'"-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  14 | import type DoesNotExistT from './does-not/'"-exist';
+  15 |
+> 16 | import {
+     | ^
+  17 |   aaaaaaaaaa,
+  18 |   bbbbbbbbbb,
+  19 |   cccccccccc,
+`;
+
+exports[`formatting edge cases reports resolution errors with a specifier containing an escape sequence 1`] = `
+Unable to resolve module ./does-not'"-exist from <dir>/cannot-resolve-specifier-with-escapes.js: 
+
+None of these files exist:
+  * build-errors/does-not'"-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not'"-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  15 |
+  16 | // $FlowExpectedError[cannot-resolve-module]
+> 17 | import {DoesNotExist} from './does-not/'"-exist';
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  18 |
+  19 | global.x = (DoesNotExist: DoesNotExistT);
+  20 |
+`;
+
+exports[`formatting edge cases reports resolution errors with embedded comment after the specifier 1`] = `
+Unable to resolve module ./foo from <dir>/cannot-resolve-require-with-embedded-comment.js: 
+
+None of these files exist:
+  * build-errors/foo(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/foo/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  13 |
+  14 | // $FlowExpectedError[cannot-resolve-module]
+> 15 | const DoesNotExist = require('./foo' /* ./foo */);
+     |                               ^
+  16 |
+  17 | global.x = (DoesNotExist: DoesNotExistT);
+  18 |
+`;
+
+exports[`formatting edge cases reports resolution errors with multi-line locs 1`] = `
+Unable to resolve module ./does-not-exist from <dir>/cannot-resolve-multi-line-import.js: 
+
+None of these files exist:
+  * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  25 |   iiiiiiiiii,
+  26 |   // $FlowExpectedError[cannot-resolve-module]
+> 27 | } from './does-not-exist';
+     |         ^
+  28 |
+  29 | global.x = (aaaaaaaaaa: DoesNotExistT);
+  30 |
+`;

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/build-errors-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/build-errors-test.js.snap
@@ -13,6 +13,8 @@ None of these files exist:
   16 |
   17 | global.x = (DoesNotExist: DoesNotExistT);
   18 |
+Import stack:
+    at <dir>/cannot-resolve-require.js:15:22
 `;
 
 exports[`APIs/semantics reports resolution errors with ESM + non-inlined requires 1`] = `
@@ -28,6 +30,8 @@ None of these files exist:
   16 |
   17 | global.x = (DoesNotExist: DoesNotExistT);
   18 |
+Import stack:
+    at <dir>/cannot-resolve-import.js:15:1
 `;
 
 exports[`APIs/semantics reports resolution errors with inline requires + CJS 1`] = `
@@ -43,6 +47,8 @@ None of these files exist:
   16 |
   17 | global.x = (DoesNotExist: DoesNotExistT);
   18 |
+Import stack:
+    at <dir>/inline-requires-cannot-resolve-require.js:15:22
 `;
 
 exports[`APIs/semantics reports resolution errors with inline requires + ESM 1`] = `
@@ -58,6 +64,8 @@ None of these files exist:
   16 |
   17 | global.x = (DoesNotExist: DoesNotExistT);
   18 |
+Import stack:
+    at <dir>/inline-requires-cannot-resolve-import.js:15:1
 `;
 
 exports[`formatting edge cases reports resolution errors with a multi-line loc + specifier containing an escape sequence 1`] = `
@@ -73,6 +81,8 @@ None of these files exist:
   17 |   aaaaaaaaaa,
   18 |   bbbbbbbbbb,
   19 |   cccccccccc,
+Import stack:
+    at <dir>/cannot-resolve-multi-line-import-with-escapes.js:16:1
 `;
 
 exports[`formatting edge cases reports resolution errors with a specifier containing an escape sequence 1`] = `
@@ -88,6 +98,8 @@ None of these files exist:
   18 |
   19 | global.x = (DoesNotExist: DoesNotExistT);
   20 |
+Import stack:
+    at <dir>/cannot-resolve-specifier-with-escapes.js:17:1
 `;
 
 exports[`formatting edge cases reports resolution errors with embedded comment after the specifier 1`] = `
@@ -103,6 +115,8 @@ None of these files exist:
   16 |
   17 | global.x = (DoesNotExist: DoesNotExistT);
   18 |
+Import stack:
+    at <dir>/cannot-resolve-require-with-embedded-comment.js:15:22
 `;
 
 exports[`formatting edge cases reports resolution errors with multi-line locs 1`] = `
@@ -118,4 +132,28 @@ None of these files exist:
   28 |
   29 | global.x = (aaaaaaaaaa: DoesNotExistT);
   30 |
+Import stack:
+    at <dir>/cannot-resolve-multi-line-import.js:16:1
+`;
+
+exports[`reports resolution errors with a long import stack 1`] = `
+Unable to resolve module ./does-not-exist from <dir>/cannot-resolve-import.js: 
+
+None of these files exist:
+  * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  13 |
+  14 | // $FlowExpectedError[cannot-resolve-module]
+> 15 | import DoesNotExist from './does-not-exist';
+     |                           ^
+  16 |
+  17 | global.x = (DoesNotExist: DoesNotExistT);
+  18 |
+Import stack:
+    at <dir>/cannot-resolve-import.js:15:1
+    at <dir>/long-import-stack/e.js:11:1
+    at <dir>/long-import-stack/d1.js:11:1
+    at <dir>/long-import-stack/c.js:11:1
+    at <dir>/long-import-stack/b.js:11:1
+    at <dir>/long-import-stack/a.js:11:1
 `;

--- a/packages/metro/src/integration_tests/__tests__/build-errors-test.js
+++ b/packages/metro/src/integration_tests/__tests__/build-errors-test.js
@@ -128,3 +128,15 @@ describe('formatting edge cases', () => {
     await expect(buildPromise).rejects.toMatchSnapshot();
   });
 });
+
+test('reports resolution errors with a long import stack', async () => {
+  const config = await Metro.loadConfig({
+    config: require.resolve('../metro.config.js'),
+  });
+
+  const buildPromise = Metro.runBuild(config, {
+    entry: 'build-errors/long-import-stack/a.js',
+  });
+
+  await expect(buildPromise).rejects.toMatchSnapshot();
+});

--- a/packages/metro/src/integration_tests/__tests__/build-errors-test.js
+++ b/packages/metro/src/integration_tests/__tests__/build-errors-test.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+'use strict';
+
+const Metro = require('../../..');
+
+jest.unmock('cosmiconfig');
+
+jest.setTimeout(30 * 1000);
+
+const path = require('path');
+const BUILD_ERRORS_SRC_DIR =
+  path.resolve(__dirname, '..', 'basic_bundle', 'build-errors') + path.sep;
+
+expect.addSnapshotSerializer({
+  test: val => val instanceof Error,
+  print: (val: Error) =>
+    val.message
+      .replaceAll(BUILD_ERRORS_SRC_DIR, '<dir>/')
+      .replaceAll(path.win32.sep, path.posix.sep),
+});
+
+describe('APIs/semantics', () => {
+  test('reports resolution errors with inline requires + ESM', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    const buildPromise = Metro.runBuild(config, {
+      entry: 'build-errors/inline-requires-cannot-resolve-import.js',
+    });
+
+    await expect(buildPromise).rejects.toMatchSnapshot();
+  });
+
+  test('reports resolution errors with ESM + non-inlined requires', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    const buildPromise = Metro.runBuild(config, {
+      entry: 'build-errors/cannot-resolve-import.js',
+    });
+
+    await expect(buildPromise).rejects.toMatchSnapshot();
+  });
+
+  test('reports resolution errors with inline requires + CJS', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    const buildPromise = Metro.runBuild(config, {
+      entry: 'build-errors/inline-requires-cannot-resolve-require.js',
+    });
+
+    await expect(buildPromise).rejects.toMatchSnapshot();
+  });
+
+  test('reports resolution errors with CJS + non-inlined requires', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    const buildPromise = Metro.runBuild(config, {
+      entry: 'build-errors/cannot-resolve-require.js',
+    });
+
+    await expect(buildPromise).rejects.toMatchSnapshot();
+  });
+});
+
+describe('formatting edge cases', () => {
+  test('reports resolution errors with multi-line locs', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    const buildPromise = Metro.runBuild(config, {
+      entry: 'build-errors/cannot-resolve-multi-line-import.js',
+    });
+
+    await expect(buildPromise).rejects.toMatchSnapshot();
+  });
+
+  test('reports resolution errors with a specifier containing an escape sequence', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    const buildPromise = Metro.runBuild(config, {
+      entry: 'build-errors/cannot-resolve-specifier-with-escapes.js',
+    });
+
+    await expect(buildPromise).rejects.toMatchSnapshot();
+  });
+
+  test('reports resolution errors with a multi-line loc + specifier containing an escape sequence', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    const buildPromise = Metro.runBuild(config, {
+      entry: 'build-errors/cannot-resolve-multi-line-import-with-escapes.js',
+    });
+
+    await expect(buildPromise).rejects.toMatchSnapshot();
+  });
+
+  test('reports resolution errors with embedded comment after the specifier', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    const buildPromise = Metro.runBuild(config, {
+      entry: 'build-errors/cannot-resolve-require-with-embedded-comment.js',
+    });
+
+    await expect(buildPromise).rejects.toMatchSnapshot();
+  });
+});

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-import.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-import.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// $FlowExpectedError[cannot-resolve-module]
+import type DoesNotExistT from './does-not-exist';
+
+// $FlowExpectedError[cannot-resolve-module]
+import DoesNotExist from './does-not-exist';
+
+global.x = (DoesNotExist: DoesNotExistT);

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-multi-line-import-with-escapes.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-multi-line-import-with-escapes.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+/* eslint-disable no-unused-vars */
+
+// $FlowExpectedError[cannot-resolve-module]
+import type DoesNotExistT from './does-not\'"-exist';
+
+import {
+  aaaaaaaaaa,
+  bbbbbbbbbb,
+  cccccccccc,
+  dddddddddd,
+  eeeeeeeeee,
+  ffffffffff,
+  gggggggggg,
+  hhhhhhhhhh,
+  iiiiiiiiii,
+  // $FlowExpectedError[cannot-resolve-module]
+} from './does-not\'"-exist';
+
+global.x = (aaaaaaaaaa: DoesNotExistT);

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-multi-line-import.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-multi-line-import.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+/* eslint-disable no-unused-vars */
+
+// $FlowExpectedError[cannot-resolve-module]
+import type DoesNotExistT from './does-not-exist';
+
+import {
+  aaaaaaaaaa,
+  bbbbbbbbbb,
+  cccccccccc,
+  dddddddddd,
+  eeeeeeeeee,
+  ffffffffff,
+  gggggggggg,
+  hhhhhhhhhh,
+  iiiiiiiiii,
+  // $FlowExpectedError[cannot-resolve-module]
+} from './does-not-exist';
+
+global.x = (aaaaaaaaaa: DoesNotExistT);

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-require-with-embedded-comment.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-require-with-embedded-comment.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// $FlowExpectedError[cannot-resolve-module]
+import type DoesNotExistT from './foo';
+
+// $FlowExpectedError[cannot-resolve-module]
+const DoesNotExist = require('./foo' /* ./foo */);
+
+global.x = (DoesNotExist: DoesNotExistT);

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-require.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-require.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// $FlowExpectedError[cannot-resolve-module]
+import type DoesNotExistT from './does-not-exist';
+
+// $FlowExpectedError[cannot-resolve-module]
+const DoesNotExist = require('./does-not-exist');
+
+global.x = (DoesNotExist: DoesNotExistT);

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-specifier-with-escapes.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/cannot-resolve-specifier-with-escapes.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+/* eslint-disable no-unused-vars */
+
+// $FlowExpectedError[cannot-resolve-module]
+import type DoesNotExistT from './does-not\'"-exist';
+
+// $FlowExpectedError[cannot-resolve-module]
+import {DoesNotExist} from './does-not\'"-exist';
+
+global.x = (DoesNotExist: DoesNotExistT);

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/inline-requires-cannot-resolve-import.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/inline-requires-cannot-resolve-import.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// $FlowExpectedError[cannot-resolve-module]
+import type DoesNotExistT from './does-not-exist';
+
+// $FlowExpectedError[cannot-resolve-module]
+import DoesNotExist from './does-not-exist';
+
+global.x = (DoesNotExist: DoesNotExistT);

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/inline-requires-cannot-resolve-require.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/inline-requires-cannot-resolve-require.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// $FlowExpectedError[cannot-resolve-module]
+import type DoesNotExistT from './does-not-exist';
+
+// $FlowExpectedError[cannot-resolve-module]
+const DoesNotExist = require('./does-not-exist');
+
+global.x = (DoesNotExist: DoesNotExistT);

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/a.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/a.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import './b';

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/b.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/b.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import './c.js';

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/c.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/c.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import './d1';
+import './d2';

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/d1.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/d1.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import './e';

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/d2.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/d2.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import './e';

--- a/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/e.js
+++ b/packages/metro/src/integration_tests/basic_bundle/build-errors/long-import-stack/e.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import '../cannot-resolve-import.js';

--- a/packages/metro/src/integration_tests/metro.config.js
+++ b/packages/metro/src/integration_tests/metro.config.js
@@ -34,8 +34,13 @@ module.exports = {
     ),
     enableBabelRCLookup: false,
     enableBabelRuntime: false,
-    getTransformOptions: async () => ({
-      transform: {experimentalImportSupport: true, inlineRequires: false},
+    getTransformOptions: async entryFiles => ({
+      transform: {
+        experimentalImportSupport: true,
+        inlineRequires: entryFiles.some(filePath =>
+          filePath.includes('inline-requires'),
+        ),
+      },
       preloadedModules: false,
       ramGroups: [],
     }),


### PR DESCRIPTION
Summary:
Adds infrastructure for reporting *import stacks* as part of resolution errors in Metro. An import stack is the (inverse) chain of dependencies in the graph that led to a resolution error. This can help users understand and fix build errors that occur inside third-party packages (e.g. because of configuration errors).

See https://github.com/expo/expo/pull/23551 for more motivation.

## Caveats

Ideally, we'd always be able to print the full chain of dependencies from an entry point to the module containing the error.¹ However, since we update the graph incrementally in response to filesystem changes, and produce import stacks while there are still pending changes to process, we can only safely print edges that we have *just* traversed². Otherwise, it's possible that a dependency's metadata (e.g. source location) will be stale, or indeed that an edge we print doesn't exist anymore.

¹ Also, for UX reasons, we'd want to print the *shortest path* between those two modules.

² Our main traversal is depth-first, so it's also not guaranteed to take the shortest possible path to each module.

As a result, **there is an observable difference between** (the import stacks printed by) **initial and incremental builds**.

* An error in an initial build (no existing Graph instance) will contain the full import stack, from the module containing the error down to the entry point.
* An error in an incremental build (e.g. full reload / Fast Refresh of a bundle that previously built successfully) will contain a *partial* import stack - from the module containing the error down to some ancestor module *M*, where M is in the set of modules added/changed/invalidated since the previous successful build.
  * In this case we can still reliably tell the user that the dependency chain connects *somehow* to the bundle's entry point (since otherwise the module wouldn't be in the graph).

Changelog:
* **[Feature]** Include import stacks in resolution errors.

 ---

TODO:
* See how this renders in LogBox/RedBox and adjust accordingly.
* Decide whether to bake the import stack into the error message or fully rely on external error reporters for presentation.
* Probably print project-relative paths rather than absolute paths.
* Pretty-print the paths of context modules rather than expose the generated, virtual paths.

Differential Revision: D47548085

