### PR TITLE
Updating Google Analytics to GA4

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,7 +36,8 @@ const siteConfig = {
         staticDocsProject: 'metro',
         enableEditor: true,
         gtag: {
-          trackingID: 'UA-44373548-17',
+          trackingID: 'G-Q1FRRC47Y6',
+          anonymizeIP: true,
         },
       },
     ],


### PR DESCRIPTION
## Summary

As Google deprecated UA, we are moving towards GA4 across Meta Open Source projects

## Test plan

GA data anonymized and shows up on the Google Analytics account as GA4
