### PR TITLE
Update Cosmiconfig to 8.2.0

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "connect": "^3.6.5",
-    "cosmiconfig": "^5.0.5",
+    "cosmiconfig": "^8.2.0",
     "jest-validate": "^29.6.3",
     "metro": "0.78.1",
     "metro-cache": "0.78.1",

--- a/packages/metro-config/src/__mocks__/cosmiconfig.js
+++ b/packages/metro-config/src/__mocks__/cosmiconfig.js
@@ -14,7 +14,15 @@ let resolvedConfig = {};
 let loadHasBeenCalled = false;
 let returnNull = false;
 
-const cosmiconfig = jest.fn(() => ({
+const cosmiconfig = {
+  cosmiconfig: jest.fn(),
+  setResolvedConfig: jest.fn(),
+  setReturnNull: jest.fn(),
+  reset: jest.fn(),
+  hasLoadBeenCalled: jest.fn(),
+};
+
+cosmiconfig.cosmiconfig = jest.fn(() => ({
   search: async () =>
     returnNull
       ? null

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -45,7 +45,7 @@ function overrideArgument<T>(arg: Array<T> | T): T {
   return arg;
 }
 
-const explorer = cosmiconfig('metro', {
+const explorer = cosmiconfig.cosmiconfig('metro', {
   searchPlaces: [
     'metro.config.js',
     'metro.config.cjs',
@@ -53,13 +53,7 @@ const explorer = cosmiconfig('metro', {
     'package.json',
   ],
   loaders: {
-    '.json': cosmiconfig.loadJson,
-    '.yaml': cosmiconfig.loadYaml,
-    '.yml': cosmiconfig.loadYaml,
-    '.js': cosmiconfig.loadJs,
-    '.cjs': cosmiconfig.loadJs,
     '.es6': cosmiconfig.loadJs,
-    noExt: cosmiconfig.loadYaml,
   },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,25 +2507,6 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-caller-callsite@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
-  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
-  dependencies:
-    callsites "^2.0.0"
-
-caller-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
-  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
-  dependencies:
-    caller-callsite "^2.0.0"
-
-callsites@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
-  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
-
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -2761,15 +2742,15 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@^5.0.5:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
-  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+cosmiconfig@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.2.0.tgz#f7d17c56a590856cd1e7cee98734dca272b0d8fd"
+  integrity sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==
   dependencies:
-    import-fresh "^2.0.0"
-    is-directory "^0.3.1"
-    js-yaml "^3.13.1"
-    parse-json "^4.0.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -3984,14 +3965,6 @@ image-size@^1.0.2:
   dependencies:
     queue "6.0.2"
 
-import-fresh@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
-  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
-  dependencies:
-    caller-path "^2.0.0"
-    resolve-from "^3.0.0"
-
 import-fresh@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -4156,11 +4129,6 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
-
-is-directory@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
-  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -5830,14 +5798,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-json@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
-  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  dependencies:
-    error-ex "^1.3.1"
-    json-parse-better-errors "^1.0.1"
-
 parse-json@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
@@ -6243,11 +6203,6 @@ resolve-cwd@^3.0.0:
   integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
   dependencies:
     resolve-from "^5.0.0"
-
-resolve-from@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
-  integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary

I encountered a dependency conflict with version `5.1.2`. A local package, SVGR, required a newer version than the one currently utilized in Metro. Notably, the Nx repository favored the version from SVGR. I've updated the dependency and observed no disruptions in the test cases, making the update process straightforward.

## Test Plan

I've done the standard `npm test` without encountering any problems. I'll further investigate in the morning to verify that the update hasn't inadvertently caused other issues.