### PR TITLE
Enable symlinks (`resolver.unstable_enableSymlinks`) by default

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -395,6 +395,30 @@ In a future release of Metro, this option will become `true` by default.
 
 ---
 
+#### `unstable_enableSymlinks` <div class="label experimental">Experimental</div>
+
+Type: `boolean`
+
+Enable experimental support for projects containing symbolic links (symlinks).
+
+When enabled, Metro traverses symlinks during module and asset [resolution](./Resolution.md), instead of ignoring symlinks. Note that, as with any other file Metro needs to resolve, the symlink target *must be within configured [watched folders](#watchfolders)* and not otherwise excluded.
+
+Defaults to `false`.
+
+:::info
+
+For example, if you have a Metro project within a [Yarn workspace](https://classic.yarnpkg.com/lang/en/docs/workspaces/) (a subdirectory of a Yarn workspace root), it's likely you'll want to include your workspace *root* path in your configured [`watchFolders`](#watchfolders) so that Metro can resolve other workspaces or hoisted `node_modules`. Similarly, to use [linked packages](https://classic.yarnpkg.com/lang/en/docs/cli/link/), you'll need to list those package source locations (or a containing directory) in [`watchFolders`](#watchfolders).
+
+:::
+
+:::note
+
+In a future release of Metro, this option will become `true` by default.
+
+:::
+
+---
+
 ### Transformer Options
 
 <!-- Keep old links to `asyncRequireModulePath` working -->

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -403,7 +403,7 @@ Enable experimental support for projects containing symbolic links (symlinks).
 
 When enabled, Metro traverses symlinks during module and asset [resolution](./Resolution.md), instead of ignoring symlinks. Note that, as with any other file Metro needs to resolve, the symlink target *must be within configured [watched folders](#watchfolders)* and not otherwise excluded.
 
-Defaults to `false`.
+Defaults to `true` since Metro v0.79.0.
 
 :::info
 
@@ -413,7 +413,7 @@ For example, if you have a Metro project within a [Yarn workspace](https://class
 
 :::note
 
-In a future release of Metro, this option will become `true` by default.
+In a future release of Metro, this option will be removed (symlink support will be always-on).
 
 :::
 

--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -84,7 +84,7 @@ Object {
       ],
     },
     "unstable_enablePackageExports": false,
-    "unstable_enableSymlinks": false,
+    "unstable_enableSymlinks": true,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -262,7 +262,7 @@ Object {
       ],
     },
     "unstable_enablePackageExports": false,
-    "unstable_enableSymlinks": false,
+    "unstable_enableSymlinks": true,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -440,7 +440,7 @@ Object {
       ],
     },
     "unstable_enablePackageExports": false,
-    "unstable_enableSymlinks": false,
+    "unstable_enableSymlinks": true,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -618,7 +618,7 @@ Object {
       ],
     },
     "unstable_enablePackageExports": false,
-    "unstable_enableSymlinks": false,
+    "unstable_enableSymlinks": true,
     "useWatchman": true,
   },
   "serializer": Object {

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -40,7 +40,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     blockList: exclusionList(),
     dependencyExtractor: undefined,
     disableHierarchicalLookup: false,
-    unstable_enableSymlinks: false,
+    unstable_enableSymlinks: true,
     emptyModulePath: require.resolve(
       'metro-runtime/src/modules/empty-module.js',
     ),


### PR DESCRIPTION
Summary:
Flip the default for `unstable_enableSymlinks` to true. The option was made available in React Native 0.72 and it's been trialled by the community to the extent that we can have good confidence in it (though there are still devx gaps to guide users towards a suitable configuration).

This is also an effective prerequisite for disabling Haste/global package resolution by default in OSS, which currently allows workspaces to mostly-work in the absence of symlink support.

Closes https://github.com/facebook/metro/issues/1

Changelog:
```
 - **[Feature]**: Enable resolution through symlinks (previously experimental `unstable_enableSymlinks`)
```

Differential Revision: D48777855

