### PR TITLE
add more info to the `getPolyfills` function

### DIFF
--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -15,7 +15,10 @@ import type {CacheStore} from 'metro-cache';
 import typeof MetroCache from 'metro-cache';
 import type {CacheManagerFactory} from 'metro-file-map';
 import type {CustomResolver} from 'metro-resolver';
-import type {JsTransformerConfig} from 'metro-transform-worker';
+import type {
+  CustomTransformOptions,
+  JsTransformerConfig,
+} from 'metro-transform-worker';
 import type {TransformResult} from 'metro/src/DeltaBundler';
 import type MetroServer from 'metro/src/Server';
 
@@ -132,7 +135,11 @@ type SerializerConfigT = {
     delta: DeltaResult<>,
   ) => mixed,
   getModulesRunBeforeMainModule: (entryFilePath: string) => Array<string>,
-  getPolyfills: ({platform: ?string, ...}) => $ReadOnlyArray<string>,
+  getPolyfills: ({
+    platform: ?string,
+    customTransformOptions: CustomTransformOptions,
+    ...
+  }) => $ReadOnlyArray<string>,
   getRunModuleStatement: (number | string) => string,
   polyfillModuleNames: $ReadOnlyArray<string>,
   processModuleFilter: (modules: Module<>) => boolean,

--- a/packages/metro/src/lib/getPrependedScripts.js
+++ b/packages/metro/src/lib/getPrependedScripts.js
@@ -39,6 +39,7 @@ async function getPrependedScripts(
   const polyfillModuleNames = config.serializer
     .getPolyfills({
       platform: options.platform,
+      customTransformOptions: options.customTransformOptions,
     })
     .concat(config.serializer.polyfillModuleNames);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

We use `getPolyfills` in Expo CLI to supply custom global setup for Node.js environments. Currently, these polyfills are applied to bundles for both client and server web environments. This PR would supply additional info that we can use to pick polyfills.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
