### PR TITLE
Fix bug in symlink traversal with indirect targets

### DIFF
--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -559,13 +559,13 @@ export default class TreeFS implements MutableFileSystem {
       typeof literalSymlinkTarget === 'string',
       'Expected symlink target to be populated.',
     );
-    if (path.isAbsolute(literalSymlinkTarget)) {
-      normalSymlinkTarget = path.relative(this.#rootDir, literalSymlinkTarget);
-    } else {
-      normalSymlinkTarget = path.normalize(
-        path.join(path.dirname(canonicalPathOfSymlink), literalSymlinkTarget),
-      );
-    }
+    const absoluteSymlinkTarget = path.resolve(
+      this.#rootDir,
+      canonicalPathOfSymlink,
+      '..', // Symlink target is relative to its containing directory.
+      literalSymlinkTarget, // May be absolute, in which case the above are ignored
+    );
+    normalSymlinkTarget = path.relative(this.#rootDir, absoluteSymlinkTarget);
     this.#cachedNormalSymlinkTargets.set(symlinkNode, normalSymlinkTarget);
     return normalSymlinkTarget;
   }

--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -37,7 +37,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         [p('foo/link-to-another.js'), ['', 0, 0, 0, '', '', p('another.js')]],
         [p('../outside/external.js'), ['', 0, 0, 0, '', '', 0]],
         [p('bar.js'), ['bar', 234, 0, 0, '', '', 0]],
-        [p('link-to-foo'), ['', 456, 0, 0, '', '', p('././abnormal/../foo')]],
+        [p('link-to-foo'), ['', 456, 0, 0, '', '', p('./../project/foo')]],
         [p('abs-link-out'), ['', 456, 0, 0, '', '', p('/outside/./baz/..')]],
         [p('root'), ['', 0, 0, 0, '', '', '..']],
         [p('link-to-nowhere'), ['', 123, 0, 0, '', '', p('./nowhere')]],


### PR DESCRIPTION
Summary:
Fixes a bug where symlinks beginning with indirections (`../`) may fail to traverse in some `projectRoot` / `watchFolders` configurations.

This occurs due to incomplete "normalisation" of a symlink target in `metro-file-map`, relative to the project root. Given a project root of `/project` and a symlink `/project/src/link-to-foo  -> ../../project/foo.js`, we would normalise the target to `../project/foo.js` rather than simply `foo.js` - we were not taking into account that further normalisation could be possible after joining with `projectRoot`.

"Normal" paths are defined as being *fully* normalised relative to the project root. The unnecessary indirection out and back into the project root fails because `TreeFS` is a DAG, and internally there is no entry for `rootNode.get('..').get('project')` - this would be a cycle back to `rootNode`.

Changelog:
```
 * **[Fix]:** Symlinks with indirections may not be resolvable
```

Differential Revision: D49323614


