### PR TITLE
bump react-refresh to latest

### DIFF
--- a/packages/metro-runtime/package.json
+++ b/packages/metro-runtime/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "react-refresh": "^0.4.0"
+    "react-refresh": "^0.14.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6083,6 +6083,11 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-refresh@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
+  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
 react-refresh@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.2.tgz#54a277a6caaac2803d88f1d6f13c1dcfbd81e334"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

React Refresh v4 doesn't work with statically rendered React websites. We've been encouraging Expo Router users to resolve v14 for a couple months now. I haven't observed any issues with the latest version.

I'm opening a PR in React Native too. https://github.com/facebook/react-native/pull/39486

## Test plan

1. In a React Native project's `package.json`:
```json
 "resolutions": {
    "react-refresh": "~0.14.0"
  },
```
2. Start the server with a clear Metro cache.
3. Changes should update while preserving React state.

