### PR TITLE
CircleCI: Don't tag hotfix releases with `latest` during publish job, allow prerelease tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,30 @@ jobs:
       - checkout
       - yarn_install
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      - run: npm run publish
+    steps:
+      - checkout
+      - yarn_install
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run:
+          name: NPM publish, tagged with either "latest" or release branch name
+          command: |
+              # Reduce a semver tag name to a Metro's release branch naming convention, eg v0.1.2-alpha.3 -> 0.1.x 
+              RELEASE_BRANCH=$(echo "$CIRCLE_TAG" | awk -F. '{print substr($1, 2) "." $2 ".x"}')
+              # Does a release branch contain this tag (hotfix workflow)
+              TAG_ON_RELEASE_BRANCH=$(git branch -a --contains "$CIRCLE_TAG" | grep -cFx "  remotes/origin/$RELEASE_BRANCH" || true)
+              echo "Tag is on release branch $RELEASE_BRANCH: $TAG_ON_RELEASE_BRANCH"
+              # Does main contain this tag (regular release workflow)
+              TAG_ON_MAIN=$(git branch -a --contains "$CIRCLE_TAG" | grep -cFx '  remotes/origin/main' || true)
+              echo "Tag is on main branch: $TAG_ON_MAIN"
+              if [ $TAG_ON_RELEASE_BRANCH -eq $TAG_ON_MAIN ]; then
+                  echo "Could not determine whether this tag is 'latest' or a hotfix. Aborting."
+                  exit 1
+              fi
+              NPM_TAG="latest"
+              [ "$TAG_ON_RELEASE_BRANCH" -eq 1 ] && NPM_TAG=$RELEASE_BRANCH
+              echo "Publishing with --tag="$NPM_TAG"
+              npm run publish --tag="$NPM_TAG"
+      - run: rm ~/.npmrc
       - run: rm ~/.npmrc
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,6 @@ jobs:
       - checkout
       - yarn_install
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-    steps:
-      - checkout
-      - yarn_install
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
           name: NPM publish, tagged with either "latest" or release branch name
           command: |
@@ -133,7 +129,6 @@ jobs:
               [ "$TAG_ON_RELEASE_BRANCH" -eq 1 ] && NPM_TAG=$RELEASE_BRANCH
               echo "Publishing with --tag="$NPM_TAG"
               npm run publish --tag="$NPM_TAG"
-      - run: rm ~/.npmrc
       - run: rm ~/.npmrc
 
 workflows:
@@ -157,4 +152,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v\d+(\.\d+){2}(-.*)?/


### PR DESCRIPTION
## Summary

Currently, when we `npm publish --workspaces` on tag creation, NPM implicitly tags with "latest". This is fine in the regular release flow, but when we release a hotfix (a patch release on an old minor, from a release branch) the tag is incorrect. 

This causes issues that some folks notice within minutes: https://github.com/facebook/metro/issues/931, https://github.com/facebook/metro/issues/1057. Currently, it has to be manually corrected using `dist-tag` on each package after publishing.

This adds some logic in CircleCI to automatically tag with `latest` explicitly *only if* the tag is present on `main`, and not on any release branch (of the form `0.79.x`). OTOH, if the release looks like a hotfix (present on a release branch but *not* on `main`) we tag with the release branch name. There is no way in NPM not to have any dist-tag, so specifying *something* is the only way to prevent it assuming `latest`. 

If the release is ambiguous (edge case: we go back and tag a common ancestor of `main` and `0.123.x` with `v0.123.0-alpha`, or the tag is on neither branch) the publish aborts.

We also update the filter regex to allow semver prerelease tags eg `v0.80.0-alpha.0` - this would be handy for testing a built, published set of packages without actually releasing a new version.

## Test plan

 - Tested (after many iterations!) at my fork https://github.com/robhogan/metro, eg https://app.circleci.com/pipelines/github/robhogan/metro/74/workflows/5a375202-5863-43fd-b633-4a983b0ed4b8/jobs/264
 - I'm about to run a hotfix release to pull some bug fixes back for RN 0.72, so that'll be the first "live" test.
