### PR TITLE
Add React JSX runtime to default exceptions for inline requires

### DIFF
--- a/packages/metro/src/lib/transformHelpers.js
+++ b/packages/metro/src/lib/transformHelpers.js
@@ -35,7 +35,13 @@ type TransformOptionsWithRawInlines = {
   +inlineRequires: InlineRequiresRaw,
 };
 
-const baseIgnoredInlineRequires = ['React', 'react', 'react-native'];
+const baseIgnoredInlineRequires = [
+  'React',
+  'react',
+  'react/jsx-dev-runtime',
+  'react/jsx-runtime',
+  'react-native',
+];
 
 async function calcTransformerOptions(
   entryFiles: $ReadOnlyArray<string>,


### PR DESCRIPTION
## Summary

JSX runtime calls are all over the place in every components. When using inline requires, it doesn't make sense to go through the method call + array access + property access just to call the JSX factory.

## Test plan

Before (with inline requires on):

```js
  Object.defineProperty(exports, '__esModule', {
    value: true,
  });
  var _reactNative = _$$_REQUIRE(_dependencyMap[0], "react-native"),
    View = _reactNative.View,
    Text = _reactNative.Text;
  function App() {
    return /*#__PURE__*/_$$_REQUIRE(_dependencyMap[1], "react/jsx-runtime").jsx(View, {
      style: {
        flex: 1,
        backgroundColor: 'green'
      },
      children: /*#__PURE__*/_$$_REQUIRE(_dependencyMap[1], "react/jsx-runtime").jsxs(Text, {
        style: {
          flex: 1
        },
        children: ["whatever ", _$$_IMPORT_ALL(_dependencyMap[2], "./test").A]
      })
    });
  }
```

After (with inline requires on):

```js
  Object.defineProperty(exports, '__esModule', {
    value: true,
    lol: true
  });
  var _reactNative = _$$_REQUIRE(_dependencyMap[0], "react-native"),
    View = _reactNative.View,
    Text = _reactNative.Text;
  var _jsxs = _$$_REQUIRE(_dependencyMap[1], "react/jsx-runtime").jsxs;
  var _jsx = _$$_REQUIRE(_dependencyMap[1], "react/jsx-runtime").jsx;
  function App() {
    return /*#__PURE__*/_jsx(View, {
      style: {
        flex: 1,
        backgroundColor: 'green'
      },
      children: /*#__PURE__*/_jsxs(Text, {
        style: {
          flex: 1
        },
        children: ["whatever ", _$$_IMPORT_ALL(_dependencyMap[2], "./test").A]
      })
    });
  }
```

I added both `react/jsx-runtime` and `react/jsx-dev-runtime` even though currently RN only uses the former.
