### PR TITLE
Always exempt Babel runtime helpers from inline (lazy) requires

### DIFF
--- a/packages/metro-transform-plugins/src/inline-requires-plugin.js
+++ b/packages/metro-transform-plugins/src/inline-requires-plugin.js
@@ -258,6 +258,7 @@ function getInlineableModule(path, state) {
 
   return moduleName == null ||
     state.ignoredRequires.has(moduleName) ||
+    moduleName.startsWith('@babel/runtime/') ||
     isRequireInScope
     ? null
     : {moduleName, requireFnName: fnName};


### PR DESCRIPTION
## Summary

There is no benefit to treating Babel helpers with lazy requires. They are always going to be needed, and their initialization is extremely cheap, so it just bloats up the code and adds extra runtime indirection on every access to them.

I considered a few alternatives:

- We could add them to a default list like https://github.com/facebook/metro/pull/1126. But there's far too many to list individual modules. 
- We could add wildcard support to `nonInlinedRequires` option.
- We could add regex support to `nonInlinedRequires` option. 
- We could add a new option.

I'm not particularly enthusiastic about doing the bigger changes myself. I think hardcoding it here is fine because there's basically no legit reason for wanting these to be lazy. In fact they might even not be lazy anyway depending on where in your compilation pipeline the runtime plugin is injected. But this is nice because it fixes it for all RN users with inline requires.

## Test plan

Ran my app with the change. The app works. The diff looks like I'd expect, for example:

<img width="1144" alt="Screenshot 2023-10-31 at 00 40 00" src="https://github.com/facebook/metro/assets/810438/c04f4f5c-0f41-489b-aa50-fac9286f4c1d">
