### PR TITLE
preserve require.context call when unstable_disableModuleWrapping is enabled

### DIFF
--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -370,6 +370,7 @@ async function transformJS(
         allowOptionalDependencies: config.allowOptionalDependencies,
         dependencyMapName: config.unstable_dependencyMapReservedName,
         unstable_allowRequireContext: config.unstable_allowRequireContext,
+        unstable_disableModuleWrapping: config.unstable_disableModuleWrapping,
       };
       ({ast, dependencies, dependencyMapName} = collectDependencies(ast, opts));
     } catch (error) {

--- a/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
@@ -40,6 +40,7 @@ const opts: Options = {
   allowOptionalDependencies: false,
   dependencyMapName: null,
   unstable_allowRequireContext: false,
+  unstable_disableModuleWrapping: false,
 };
 
 describe(`require.context`, () => {

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -93,6 +93,8 @@ export type Options = $ReadOnly<{
   dependencyTransformer?: DependencyTransformer,
   /** Enable `require.context` statements which can be used to import multiple files in a directory. */
   unstable_allowRequireContext: boolean,
+
+  unstable_disableModuleWrapping?: ?boolean,
 }>;
 
 export type CollectedDependencies = $ReadOnly<{
@@ -192,6 +194,13 @@ function collectDependencies(
         !path.scope.getBinding('require')
       ) {
         processRequireContextCall(path, state);
+        // If module wrapping is disabled then we shouldn't mutate the AST,
+        // this enables calling collectDependencies multiple times on the same
+        // AST.
+        if (!options.unstable_disableModuleWrapping) {
+          // require() the generated module representing this context
+          path.get('callee').replaceWith(types.identifier('require'));
+        }
         visited.add(path.node);
         return;
       }
@@ -387,8 +396,6 @@ function processRequireContextCall(
     path,
   );
 
-  // require() the generated module representing this context
-  path.get('callee').replaceWith(types.identifier('require'));
   transformer.transformSyncRequire(path, dep, state);
 }
 


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

One possible way to implement tree shaking would require calling collectDependencies with `unstable_disableModuleWrapping` for a first pass, and invoking it a second time with module wrapping. The issue with this is that the require.context mutation is mutated to a format that wouldn't work on subsequent runs.

This PR will prevent the additional mutation of `require.context` -> `require`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Tests continue working