### PR TITLE
Add function names to module factories in DEV

### DIFF
--- a/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/metro-transform-worker/src/__tests__/__snapshots__/index-test.js.snap
@@ -240,7 +240,7 @@ Object {
 `;
 
 exports[`transforms an es module with asyncToGenerator 1`] = `
-"__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+"__d(function local_file_js__module_factory__(global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], \\"@babel/runtime/helpers/interopRequireDefault\\");
   Object.defineProperty(exports, \\"__esModule\\", {
     value: true
@@ -268,7 +268,7 @@ Object {
 `;
 
 exports[`transforms async generators 1`] = `
-"__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+"__d(function local_file_js__module_factory__(global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], \\"@babel/runtime/helpers/interopRequireDefault\\");
   Object.defineProperty(exports, \\"__esModule\\", {
     value: true

--- a/packages/metro-transform-worker/src/__tests__/index-test.js
+++ b/packages/metro-transform-worker/src/__tests__/index-test.js
@@ -572,3 +572,22 @@ it('allows outputting comments when `minify: true`', async () => {
     });"
   `);
 });
+
+it('omits invalid characters from module factory name', async () => {
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    'local/!@£% weird name.js',
+    Buffer.from('arbitrary(code)', 'utf8'),
+    baseTransformOptions,
+  );
+
+  expect(result.output[0].type).toBe('js/module');
+  expect(result.output[0].data.code).toBe(
+    [
+      getExpectedHeaderDev('local______weird_name_js'),
+      '  arbitrary(code);',
+      '});',
+    ].join('\n'),
+  );
+});

--- a/packages/metro-transform-worker/src/__tests__/index-test.js
+++ b/packages/metro-transform-worker/src/__tests__/index-test.js
@@ -43,7 +43,7 @@ const transformerContents = (() =>
   require('fs').readFileSync(babelTransformerPath))();
 
 const HEADER_DEV =
-  '__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {';
+  '__d(function local_file_js__module_factory__(global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {';
 const HEADER_PROD = '__d(function (g, r, i, a, m, e, d) {';
 
 let fs: FSType;

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -346,6 +346,11 @@ async function transformJS(
   let dependencies;
   let wrappedAst;
 
+  const minify =
+    options.minify &&
+    options.unstable_transformProfile !== 'hermes-canary' &&
+    options.unstable_transformProfile !== 'hermes-stable';
+
   // If the module to transform is a script (meaning that is not part of the
   // dependency graph and it code will just be prepended to the bundle modules),
   // we need to wrap it differently than a commonJS module (also, scripts do
@@ -382,20 +387,20 @@ async function transformJS(
     if (config.unstable_disableModuleWrapping === true) {
       wrappedAst = ast;
     } else {
+      let moduleFactoryName;
+      if (options.dev && !minify) {
+        moduleFactoryName = file.filename;
+      }
       ({ast: wrappedAst} = JsFileWrapping.wrapModule(
         ast,
         importDefault,
         importAll,
         dependencyMapName,
         config.globalPrefix,
+        moduleFactoryName,
       ));
     }
   }
-
-  const minify =
-    options.minify &&
-    options.unstable_transformProfile !== 'hermes-canary' &&
-    options.unstable_transformProfile !== 'hermes-stable';
 
   const reserved = [];
   if (config.unstable_dependencyMapReservedName != null) {


### PR DESCRIPTION
This adds path-based function names to the generated module factories in development.

```js
__d(function src_some_folder_path_MyComponent_js__module_factory__() {
  // ...
})
```

They're only emitted when `minify` is `false` and `dev` is `true`.

## Motivation

Profiling module initialization is a common need. The current set of tooling React Native provides for it is arguably abysmal.

The primary tool [suggested](https://reactnative.dev/docs/profiling#profiling-android-ui-performance-with-systrace) by React Native documentation is Systrace which literally [does not exist anymore](https://stackoverflow.com/a/74005757). "Profiling with Hermes" suggests using [sampling profiler](https://reactnative.dev/docs/profile-hermes) which seems to barely work — I wasn't able to capture any information with it.

If you try to use Hermes Chrome DevTools integration and press "Record" in the Performance tab, it hangs.

I almost gave up at that point, but @brentvatne kindly suggested that there is a workaround — I need to Shift+Cmd+P to get a different "JS Profiler" Chrome DevTools tab to show up, and that one actually works.

Even that approach [is a little bit broken](https://github.com/facebook/hermes/discussions/1181) but it's the closest to what I want.

Unfortunately, even that tool does not let me see which modules I'm spending time initializing:

<img width="938" alt="Screenshot 2023-11-02 at 17 15 05" src="https://github.com/facebook/metro/assets/810438/571a5556-dabd-4294-871d-d8ad116e6016">

As you can see, module factories have blank function names.

This is not the case with web-based tooling. For example, webpack emits module factories as a dictionary like `{ "./src/some/module.js": function() {}, ... }` so the stacks are useful. Since we don't want to change the format entirely, and configuring `fn.name` dynamically at runtime does not make it show up in the trace, I opted for a minimal possible change — to actually emit the module names in development.

As a result, I can see where I'm spending time during module initialization:

<img width="926" alt="Screenshot 2023-11-02 at 17 24 47" src="https://github.com/facebook/metro/assets/810438/1fc8015f-9705-4739-87a8-43a5ec6239bb">

