### PR TITLE
Update hermes-parser and related packages in fbsource to 0.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-relay": "^1.8.3",
     "flow-bin": "^0.220.1",
     "glob": "^7.1.1",
-    "hermes-eslint": "0.17.0",
+    "hermes-eslint": "0.17.1",
     "invariant": "^2.2.4",
     "istanbul-api": "3.0.0",
     "istanbul-lib-coverage": "3.0.0",
@@ -37,7 +37,7 @@
     "metro-babel-register": "*",
     "micromatch": "^4.0.4",
     "prettier": "2.8.8",
-    "prettier-plugin-hermes-parser": "0.17.0",
+    "prettier-plugin-hermes-parser": "0.17.1",
     "progress": "^2.0.0",
     "typescript": "5.0.4"
   },

--- a/packages/metro-babel-register/package.json
+++ b/packages/metro-babel-register/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-typescript": "^7.18.0",
     "@babel/register": "^7.0.0",
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
-    "babel-plugin-syntax-hermes-parser": "0.17.0",
+    "babel-plugin-syntax-hermes-parser": "0.17.1",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "escape-string-regexp": "^1.0.5"
   },

--- a/packages/metro-babel-transformer/package.json
+++ b/packages/metro-babel-transformer/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.20.0",
-    "hermes-parser": "0.17.0",
+    "hermes-parser": "0.17.1",
     "nullthrows": "^1.1.1"
   },
   "engines": {

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -28,7 +28,7 @@
     "denodeify": "^1.2.1",
     "error-stack-parser": "^2.0.6",
     "graceful-fs": "^4.2.4",
-    "hermes-parser": "0.17.0",
+    "hermes-parser": "0.17.1",
     "image-size": "^1.0.2",
     "invariant": "^2.2.4",
     "jest-worker": "^29.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,12 +2261,12 @@ babel-plugin-replace-ts-export-assignment@^0.0.2:
   resolved "https://registry.yarnpkg.com/babel-plugin-replace-ts-export-assignment/-/babel-plugin-replace-ts-export-assignment-0.0.2.tgz#927a30ba303fcf271108980a8d4f80a693e1d53f"
   integrity sha512-BiTEG2Ro+O1spuheL5nB289y37FFmz0ISE6GjpNCG2JuA/WNcuEHSYw01+vN8quGf208sID3FnZFDwVyqX18YQ==
 
-babel-plugin-syntax-hermes-parser@0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.17.0.tgz#1bc9feb6a25ed5ae97917a4afc15e7e391f55a0e"
-  integrity sha512-sYdVKubF925dghmVgfsxjNDDsYdzbqmLZZm+mO7ZxSgOgpO5ws4tpvc7UlzOTj7Yoc1kaNLNgm4Ebi491hsF1w==
+babel-plugin-syntax-hermes-parser@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.17.1.tgz#7c2eaa257d2a7ba01fcccd7410a5ce7e1a4c1c10"
+  integrity sha512-I+BUmPsjlhM2OvFDTSLId457eOslfxmi4fxt5svoczarKi8y8LEH53VG24PTI8dfmiISrz1nc/tG4sqcv1tIGA==
   dependencies:
-    hermes-parser "0.17.0"
+    hermes-parser "0.17.1"
 
 babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   version "7.0.0-beta.0"
@@ -3605,24 +3605,24 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hermes-eslint@0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.17.0.tgz#c1bbf5e2fbf04b94539d02773421a7899b438479"
-  integrity sha512-SecdcgQyl3ubjl7guk6jNt5BoWtHBPXu7VqfAsZUEM0r0s897/QS5FjHFIXBMGSeqQnfun+QGBGoCQjx8NRWxg==
+hermes-eslint@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.17.1.tgz#e5e43091082dc53a060e0b002324e68943104b71"
+  integrity sha512-g3z4L84pHKrBMRtbfifalpbNbNear0cEygAe+geCmCj1GUrqQu+RDeBZOYERHv0HOq0aDxjTZhj3m4fD/YVUwg==
   dependencies:
     esrecurse "^4.3.0"
-    hermes-estree "0.17.0"
-    hermes-parser "0.17.0"
+    hermes-estree "0.17.1"
+    hermes-parser "0.17.1"
 
 hermes-estree@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.15.0.tgz#e32f6210ab18c7b705bdcb375f7700f2db15d6ba"
   integrity sha512-lLYvAd+6BnOqWdnNbP/Q8xfl8LOGw4wVjfrNd9Gt8eoFzhNBRVD95n4l2ksfMVOoxuVyegs85g83KS9QOsxbVQ==
 
-hermes-estree@0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.17.0.tgz#4b1b0d8131826178f0af79a317ceaca3723e9012"
-  integrity sha512-bW9+bMZqnro+0+l6dUqTJW0VaNUvs4HRHh/J7VotTGnMmhBFRIcJz6ZxrRE7xIXmK7S5bJE9qrEooSiig4N70g==
+hermes-estree@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.17.1.tgz#902806a900c185720424ffcf958027821d23c051"
+  integrity sha512-EdUJms+eRE40OQxysFlPr1mPpvUbbMi7uDAKlScBw8o3tQY22BZ5yx56OYyp1bVaBm+7Cjc3NQz24sJEFXkPxg==
 
 hermes-parser@0.15.0:
   version "0.15.0"
@@ -3631,12 +3631,12 @@ hermes-parser@0.15.0:
   dependencies:
     hermes-estree "0.15.0"
 
-hermes-parser@0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.17.0.tgz#722bb8079b9081a0de4902b770d5d45dbeb380bd"
-  integrity sha512-2fmppmZheY1UU071EMKAzXfuUCiDXF3fmzKLuN1XmE3+njIFs3CAeKP88+FtNBUpS6pEMJv6lPXCaJGqGsrURQ==
+hermes-parser@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.17.1.tgz#8b5cbaff235fed28487812ad718f9c7182d0db0f"
+  integrity sha512-yErtFLMEL6490fFJPurNn23OI2ciGAtaUfKUg9VPdcde9CmItCjOVQkJt1Xzawv5kuRzeIx0RE2E2Q9TbIgdzA==
   dependencies:
-    hermes-estree "0.17.0"
+    hermes-estree "0.17.1"
 
 html-escaper@^2.0.0:
   version "2.0.0"
@@ -5224,14 +5224,14 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-hermes-parser@0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.17.0.tgz#7fd1b43a7421862abbcfdbe0f3dc7a9ee385d318"
-  integrity sha512-L4MtL2h6X6GnHPRfw5NfRMnpH93imHffyMl/5LcksEVlmsm1zQxabEjCM5MGBZOp5V7Sg2mBvbpd/NfYK4NdTQ==
+prettier-plugin-hermes-parser@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.17.1.tgz#f7c461fe875f7a365442fc69a51434b7e3ff88e4"
+  integrity sha512-ULX366DyQrrFW//a6Zgj0r/CF4a4Ijg+TCaplOtYCPCu4qThUp9XrMRSYWeB0lacD1lmWFqRDFL5R8Oxmhpw3A==
   dependencies:
-    hermes-estree "0.17.0"
-    hermes-parser "0.17.0"
-    prettier-plugin-hermes-parser "0.17.0"
+    hermes-estree "0.17.1"
+    hermes-parser "0.17.1"
+    prettier-plugin-hermes-parser "0.17.1"
 
 prettier@2.8.8:
   version "2.8.8"


### PR DESCRIPTION
Summary:
Update hermes-parser and related packages in fbsource to 0.17.1

Changes are just bug fixes: https://github.com/facebook/hermes/blob/main/tools/hermes-parser/js/CHANGELOG.md

Changelog: [internal]

Differential Revision: D50940209


