### PR TITLE
feat(metro-runtime): support using strings as module IDs

### DIFF
--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -47,7 +47,7 @@ type HotModuleReloadingData = {
   accept: (callback?: HotModuleReloadingCallback) => void,
   dispose: (callback?: HotModuleReloadingCallback) => void,
 };
-type ModuleID = number;
+type ModuleID = number | string;
 type Module = {
   id?: ModuleID,
   exports: Exports,
@@ -67,11 +67,7 @@ type ModuleDefinition = {
   publicModule: Module,
   verboseName?: string,
 };
-type ModuleList = {
-  [number]: ?ModuleDefinition,
-  __proto__: null,
-  ...
-};
+type ModuleList = Map<ModuleID, ModuleDefinition>;
 export type RequireFn = (id: ModuleID | VerboseModuleNameForDev) => Exports;
 export type DefineFn = (
   factory: FactoryFn,
@@ -103,7 +99,7 @@ if (__DEV__) {
 }
 
 function clear(): ModuleList {
-  modules = (Object.create(null): ModuleList);
+  modules = (new Map(): ModuleList);
 
   // We return modules here so that we can assign an initial value to modules
   // when defining it. Otherwise, we would have to do "let modules = null",
@@ -125,7 +121,7 @@ function define(
   moduleId: number,
   dependencyMap?: DependencyMap,
 ): void {
-  if (modules[moduleId] != null) {
+  if (modules.has(moduleId)) {
     if (__DEV__) {
       // (We take `inverseDependencies` from `arguments` to avoid an unused
       // named parameter in `define` in production.
@@ -153,7 +149,7 @@ function define(
     publicModule: {exports: {}},
   };
 
-  modules[moduleId] = mod;
+  modules.set(moduleId, mod);
 
   if (__DEV__) {
     // HMR
@@ -194,8 +190,8 @@ function metroRequire(moduleId: ModuleID | VerboseModuleNameForDev): Exports {
     if (initializingIndex !== -1) {
       const cycle = initializingModuleIds
         .slice(initializingIndex)
-        .map((id: number) =>
-          modules[id] ? modules[id].verboseName : '[unknown]',
+        .map((id: number | string) =>
+          modules.has(id) ? modules.get(id).verboseName : '[unknown]',
         );
 
       if (shouldPrintRequireCycle(cycle)) {
@@ -209,7 +205,7 @@ function metroRequire(moduleId: ModuleID | VerboseModuleNameForDev): Exports {
     }
   }
 
-  const module = modules[moduleIdReallyIsNumber];
+  const module = modules.get(moduleIdReallyIsNumber);
 
   return module && module.isInitialized
     ? module.publicModule.exports
@@ -244,18 +240,19 @@ function metroImportDefault(
   const moduleIdReallyIsNumber: number = moduleId;
 
   if (
-    modules[moduleIdReallyIsNumber] &&
-    modules[moduleIdReallyIsNumber].importedDefault !== EMPTY
+    modules.has(moduleIdReallyIsNumber) &&
+    modules.get(moduleIdReallyIsNumber).importedDefault !== EMPTY
   ) {
-    return modules[moduleIdReallyIsNumber].importedDefault;
+    return modules.get(moduleIdReallyIsNumber).importedDefault;
   }
 
   const exports: Exports = metroRequire(moduleIdReallyIsNumber);
   const importedDefault: any | Exports =
     exports && exports.__esModule ? exports.default : exports;
 
-  // $FlowFixMe The metroRequire call above will throw if modules[id] is null
-  return (modules[moduleIdReallyIsNumber].importedDefault = importedDefault);
+  // $FlowFixMe The metroRequire call above will throw if modules.get(id) is null
+  return (modules.get(moduleIdReallyIsNumber).importedDefault =
+    importedDefault);
 }
 metroRequire.importDefault = metroImportDefault;
 
@@ -271,10 +268,10 @@ function metroImportAll(
   const moduleIdReallyIsNumber: number = moduleId;
 
   if (
-    modules[moduleIdReallyIsNumber] &&
-    modules[moduleIdReallyIsNumber].importedAll !== EMPTY
+    modules.has(moduleIdReallyIsNumber) &&
+    modules.get(moduleIdReallyIsNumber).importedAll !== EMPTY
   ) {
-    return modules[moduleIdReallyIsNumber].importedAll;
+    return modules.get(moduleIdReallyIsNumber).importedAll;
   }
 
   const exports: Exports = metroRequire(moduleIdReallyIsNumber);
@@ -297,8 +294,8 @@ function metroImportAll(
     importedAll.default = exports;
   }
 
-  // $FlowFixMe The metroRequire call above will throw if modules[id] is null
-  return (modules[moduleIdReallyIsNumber].importedAll = importedAll);
+  // $FlowFixMe The metroRequire call above will throw if modules.get(id) is null
+  return (modules.get(moduleIdReallyIsNumber).importedAll = importedAll);
 }
 metroRequire.importAll = metroImportAll;
 
@@ -394,7 +391,7 @@ function registerSegment(
   }
   if (moduleIds) {
     moduleIds.forEach(moduleId => {
-      if (!modules[moduleId] && !definingSegmentByModuleID.has(moduleId)) {
+      if (!modules.has(moduleId) && !definingSegmentByModuleID.has(moduleId)) {
         definingSegmentByModuleID.set(moduleId, segmentId);
       }
     });
@@ -410,7 +407,7 @@ function loadModuleImplementation(
     const definer = moduleDefinersBySegmentID[segmentId];
     if (definer != null) {
       definer(moduleId);
-      module = modules[moduleId];
+      module = modules.get(moduleId);
       definingSegmentByModuleID.delete(moduleId);
     }
   }
@@ -419,7 +416,7 @@ function loadModuleImplementation(
   if (!module && nativeRequire) {
     const {segmentId, localId} = unpackModuleId(moduleId);
     nativeRequire(localId, segmentId);
-    module = modules[moduleId];
+    module = modules.get(moduleId);
   }
 
   if (!module) {
@@ -563,7 +560,7 @@ if (__DEV__) {
     dependencyMap: DependencyMap,
     inverseDependencies: InverseDependencyMap,
   ) {
-    const mod = modules[id];
+    const mod = modules.get(id);
     if (!mod) {
       if (factory) {
         // New modules are going to be handled by the define() method.
@@ -606,7 +603,7 @@ if (__DEV__) {
       updatedModuleIDs = topologicalSort(
         [id], // Start with the changed module and go upwards
         pendingID => {
-          const pendingModule = modules[pendingID];
+          const pendingModule = modules.get(pendingID);
           if (pendingModule == null) {
             // Nothing to do.
             return [];
@@ -677,7 +674,7 @@ if (__DEV__) {
       }
       seenModuleIDs.add(updatedID);
 
-      const updatedMod = modules[updatedID];
+      const updatedMod = modules.get(updatedID);
       if (updatedMod == null) {
         throw new Error('[Refresh] Expected to find the updated module.');
       }
@@ -734,7 +731,7 @@ if (__DEV__) {
           // Schedule all parent refresh boundaries to re-run in this loop.
           for (let j = 0; j < parentIDs.length; j++) {
             const parentID = parentIDs[j];
-            const parentMod = modules[parentID];
+            const parentMod = modules.get(parentID);
             if (parentMod == null) {
               throw new Error('[Refresh] Expected to find parent module.');
             }
@@ -810,7 +807,7 @@ if (__DEV__) {
     factory?: FactoryFn,
     dependencyMap?: DependencyMap,
   ): boolean {
-    const mod = modules[id];
+    const mod = modules.get(id);
     if (mod == null) {
       throw new Error('[Refresh] Expected to find the module.');
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Using strings will make it easier to debug larger bundles by allowing users to optionally preserve module names with something like `serializer.createModuleIdFactory`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

TBD. Unclear if this fully works due to features that don't have comments or any usage in the repo. 

I also can't get vs code to respect the flow types used in this file so I build it outside the repo and copy the changes in. 

<img width="637" alt="Screenshot 2023-11-05 at 2 44 57 PM" src="https://github.com/facebook/metro/assets/9664363/9d84d373-3efc-40e2-baac-4523d3f05a13">


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
