### PR TITLE
Add rejectUnauthorized option to `ws` types

### DIFF
--- a/flow-typed/npm/ws_v7.x.x.js
+++ b/flow-typed/npm/ws_v7.x.x.js
@@ -125,6 +125,7 @@ declare type ws$WebSocketOptions = {
   createConnection?:
     | ((options: net$connectOptions, callback?: () => mixed) => net$Socket)
     | ((options: tls$connectOptions, callback?: () => mixed) => tls$TLSSocket),
+  rejectUnauthorized?: boolean,
 };
 
 declare type ws$CloseListener = (code: number, reason: string) => mixed;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a Flow definition that allows passing the [`rejectUnauthorized`](https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener:~:text=(120%20seconds).-,rejectUnauthorized,-%3Cboolean%3E%20If) option to a WebSocket client. (See [example usage](https://github.com/websockets/ws/blob/a049674d936746c36fe928cc1baaaafd3029a83e/examples/ssl.js#L33) in the `ws` repo.)

Differential Revision: D51014312


