### PR TITLE
feat: pass dev option to resolver

### DIFF
--- a/docs/Resolution.md
+++ b/docs/Resolution.md
@@ -164,6 +164,10 @@ Parameters: (*context*, *moduleName*, *platform*)
 
 The set of file extensions used to identify asset files. Defaults to [`resolver.assetExts`](./Configuration.md#assetexts).
 
+#### `dev: boolean`
+
+Returns `true` if the resolution is for a development bundle, or `false` otherwise.
+
 #### `doesFileExist: string => boolean`
 
 Returns `true` if the file with the given path exists, or `false` otherwise.
@@ -299,7 +303,7 @@ Resolver results may be cached under the following conditions:
 
 1. For given origin module paths _A_ and _B_ and target module name _M_, the resolution for _M_ may be reused if **all** of the following conditions hold:
     1. _A_ and _B_ are in the same directory.
-    2. The contents of [`customResolverOptions`](#customresolveroptions-string-mixed) are equivalent ( = serialize to JSON the same) in both calls to the resolver.
+    2. The contents of [`dev`](#dev) and [`customResolverOptions`](#customresolveroptions-string-mixed) are equivalent ( = serialize to JSON the same) in both calls to the resolver.
 2. Any cache of resolutions must be invalidated if any file in the project has changed.
 
 Custom resolvers must adhere to these assumptions, e.g. they may not return different resolutions for origin modules in the same directory under the same `customResolverOptions`.

--- a/packages/metro-resolver/src/__tests__/utils.js
+++ b/packages/metro-resolver/src/__tests__/utils.js
@@ -32,6 +32,7 @@ export function createResolutionContext(
   {enableSymlinks}: $ReadOnly<{enableSymlinks?: boolean}> = {},
 ): $Diff<ResolutionContext, {originModulePath: string}> {
   return {
+    dev: true,
     allowHaste: true,
     assetExts: new Set(['jpg', 'png']),
     customResolverOptions: {},

--- a/packages/metro-resolver/src/types.js
+++ b/packages/metro-resolver/src/types.js
@@ -112,6 +112,9 @@ export type ResolutionContext = $ReadOnly<{
   doesFileExist: DoesFileExist,
   extraNodeModules: ?{[string]: string, ...},
 
+  /** Is resolving for a development bundle. */
+  dev: boolean,
+
   /**
    * Get the parsed contents of the specified `package.json` file.
    */

--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -116,7 +116,7 @@ function dep(name: string): TransformResultDependency {
       resolve: (
         from: string,
         dependency: TransformResultDependency,
-        resolverOptions?: ResolverInputOptions = {},
+        resolverOptions?: ResolverInputOptions = {dev: true},
         options: void | {assumeFlatNodeModules: boolean},
       ) =>
         dependencyGraph.resolveDependency(
@@ -2723,6 +2723,7 @@ function dep(name: string): TransformResultDependency {
         });
         expect(
           resolver.resolve(p('/root1/dir/a.js'), dep('target'), {
+            dev: true,
             customResolverOptions: {
               foo: 'bar',
               key: 'value',
@@ -2731,6 +2732,7 @@ function dep(name: string): TransformResultDependency {
         ).toEqual({type: 'sourceFile', filePath: p('/target1.js')});
         expect(
           resolver.resolve(p('/root1/dir/b.js'), dep('target'), {
+            dev: true,
             customResolverOptions: {
               // NOTE: reverse order from what we passed above
               key: 'value',
@@ -2743,6 +2745,7 @@ function dep(name: string): TransformResultDependency {
         resolveRequest.mockClear();
         expect(
           resolver.resolve(p('/root1/dir/b.js'), dep('target'), {
+            dev: true,
             customResolverOptions: {
               // NOTE: only a subset of the options passed above
               foo: 'bar',
@@ -2754,6 +2757,7 @@ function dep(name: string): TransformResultDependency {
         resolveRequest.mockClear();
         expect(
           resolver.resolve(p('/root1/dir/b.js'), dep('target'), {
+            dev: true,
             customResolverOptions: {
               something: 'else',
             },

--- a/packages/metro/src/__tests__/HmrServer-test.js
+++ b/packages/metro/src/__tests__/HmrServer-test.js
@@ -212,7 +212,9 @@ describe('HmrServer', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     );
@@ -239,7 +241,9 @@ describe('HmrServer', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     );
@@ -266,7 +270,9 @@ describe('HmrServer', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     );
@@ -293,7 +299,9 @@ describe('HmrServer', () => {
         shallow: false,
         lazy: false,
         unstable_allowRequireContext: false,
-        resolverOptions: {},
+        resolverOptions: {
+          dev: true,
+        },
       },
     )}\` was not found.`;
 

--- a/packages/metro/src/index.flow.js
+++ b/packages/metro/src/index.flow.js
@@ -458,7 +458,7 @@ exports.buildGraph = async function (
         platform,
         type,
       },
-      {customResolverOptions},
+      {customResolverOptions, dev},
     );
   } finally {
     bundler.end();

--- a/packages/metro/src/lib/__tests__/getGraphId-test.js
+++ b/packages/metro/src/lib/__tests__/getGraphId-test.js
@@ -30,7 +30,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     ).not.toBe(
@@ -48,7 +50,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     );
@@ -70,7 +74,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     ).not.toBe(
@@ -88,7 +94,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     );
@@ -110,7 +118,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     ).toBe(
@@ -128,7 +138,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     );
@@ -154,7 +166,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     ).toBe(
@@ -176,7 +190,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     );
@@ -201,6 +217,7 @@ describe('getGraphId', () => {
           customResolverOptions: {
             foo: 'bar',
           },
+          dev: true,
         },
       }),
     ).not.toBe(
@@ -212,6 +229,7 @@ describe('getGraphId', () => {
           customResolverOptions: {
             something: 'else',
           },
+          dev: true,
         },
       }),
     );
@@ -237,6 +255,7 @@ describe('getGraphId', () => {
             a: true,
             b: false,
           },
+          dev: true,
         },
       }),
     ).toBe(
@@ -249,6 +268,7 @@ describe('getGraphId', () => {
             b: false,
             a: true,
           },
+          dev: true,
         },
       }),
     );
@@ -274,6 +294,7 @@ describe('getGraphId', () => {
           unstable_allowRequireContext: false,
           resolverOptions: {
             customResolverOptions: undefined,
+            dev: true,
           },
         },
       ),
@@ -292,7 +313,9 @@ describe('getGraphId', () => {
           shallow: false,
           lazy: false,
           unstable_allowRequireContext: false,
-          resolverOptions: {},
+          resolverOptions: {
+            dev: true,
+          },
         },
       ),
     );

--- a/packages/metro/src/lib/splitBundleOptions.js
+++ b/packages/metro/src/lib/splitBundleOptions.js
@@ -21,6 +21,7 @@ function splitBundleOptions(options: BundleOptions): SplitBundleOptions {
     entryFile: options.entryFile,
     resolverOptions: {
       customResolverOptions: options.customResolverOptions,
+      dev: options.dev,
     },
     transformOptions: {
       customTransformOptions: options.customTransformOptions,

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -335,10 +335,7 @@ class DependencyGraph extends EventEmitter {
 
     // Compound key for the resolver cache
     const resolverOptionsKey =
-      JSON.stringify(
-        resolverOptions.customResolverOptions ?? {},
-        canonicalize,
-      ) ?? '';
+      JSON.stringify(resolverOptions ?? {}, canonicalize) ?? '';
     const originKey = isSensitiveToOriginFolder ? path.dirname(from) : '';
     const targetKey = to;
     const platformKey = platform ?? NULL_PLATFORM;

--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -120,7 +120,7 @@ class ModuleResolver<TPackage: Packageish> {
         },
         false,
         null,
-        /* resolverOptions */ {},
+        /* resolverOptions */ {dev: false},
       );
       this._cachedEmptyModule = emptyModule;
     }
@@ -157,6 +157,7 @@ class ModuleResolver<TPackage: Packageish> {
           {
             allowHaste,
             assetExts,
+            dev: resolverOptions.dev,
             disableHierarchicalLookup,
             doesFileExist,
             extraNodeModules,

--- a/packages/metro/src/shared/types.flow.js
+++ b/packages/metro/src/shared/types.flow.js
@@ -65,6 +65,7 @@ export type BundleOptions = {
 
 export type ResolverInputOptions = $ReadOnly<{
   customResolverOptions?: CustomResolverOptions,
+  dev: boolean,
 }>;
 
 export type SerializerOptions = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Have first-class support for resolving based on if the process is bundling for `dev` or not. Ref https://discord.com/channels/514829729862516747/514832110595604510/1171554890456256522

This feature is essentially a built-in version of just passing `dev` as a custom resolver option.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Updated the tests, defaulting to `dev: true`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
