### PR TITLE
Use `resolvePackage` instead of `resolveModulePath` in `resolveHasteName`

### DIFF
--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -455,6 +455,24 @@ describe('with package exports resolution enabled', () => {
         expect(logWarning).not.toHaveBeenCalled();
       });
     });
+
+    describe('haste package', () => {
+      test('should resolve subpath in "exports"', () => {
+        const context = {
+          ...baseContext,
+          resolveHastePackage(name: string) {
+            if (name === 'test-pkg') {
+              return '/root/node_modules/test-pkg/package.json';
+            }
+            return null;
+          },
+        };
+        expect(Resolver.resolve(context, 'test-pkg/foo.js', null)).toEqual({
+          type: 'sourceFile',
+          filePath: '/root/node_modules/test-pkg/lib/foo.js',
+        });
+      });
+    });
   });
 
   describe('subpath patterns', () => {

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -206,7 +206,7 @@ function resolveHasteName(
   const packageDirPath = path.dirname(packageJsonPath);
   const pathInModule = moduleName.substring(packageName.length + 1);
   const potentialModulePath = path.join(packageDirPath, pathInModule);
-  const result = resolveModulePath(context, potentialModulePath, platform);
+  const result = resolvePackage(context, potentialModulePath, platform);
   if (result.type === 'resolved') {
     return result;
   }


### PR DESCRIPTION
## Summary

This fixes #1128 by calling the `resolvePackage` instead of `resolveModulePath` in `resolveHasteName`.
Only `resolvePackage` has the code to resolve package "exports" and it calls `resolveModulePath` as a fallback.

## Test plan

I've added a failing test which passed as the fix got implemented.
