### PR TITLE
fix: support serverRoot with hmr serializer chunks

### DIFF
--- a/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
+++ b/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
@@ -42,7 +42,7 @@ function generateModules(
       // Construct a bundle URL for this specific module only
       const getURL = (extension: 'bundle' | 'map') => {
         options.clientUrl.pathname = path.relative(
-          options.projectRoot,
+          options.serverRoot ?? options.projectRoot,
           path.join(
             path.dirname(module.path),
             path.basename(module.path, path.extname(module.path)) +


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

We use unstable_serverRoot heavily in Expo to support monorepos and consistently have issues where saving a file will log an error in the console:

```
Error: Unable to resolve module ./app/index from /Users/evanbacon/Documents/GitHub/expo/.: 

None of these files exist:
  * ../../app/index(.web.ts|.ts|.web.tsx|.tsx|.web.mjs|.mjs|.web.js|.js|.web.jsx|.jsx|.web.json|.json|.web.cjs|.cjs|.web.scss|.scss|.web.sass|.sass|.web.css|.css|.web.cjs|.cjs)
  * ../../app/index/index(.web.ts|.ts|.web.tsx|.tsx|.web.mjs|.mjs|.web.js|.js|.web.jsx|.jsx|.web.json|.json|.web.cjs|.cjs|.web.scss|.scss|.web.sass|.sass|.web.css|.css|.web.cjs|.cjs)
    at ModuleResolver.resolveDependency (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:114:15)
    at DependencyGraph.resolveDependency (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/node-haste/DependencyGraph.js:277:43)
    at /Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/lib/transformHelpers.js:169:21
    at Server._resolveRelativePath (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/Server.js:1045:12)
    at Server.requestProcessor [as _processSourceMapRequest] (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/Server.js:449:37)
    at Server._processRequest (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/Server.js:396:7)
```

This is because the HMR `sourceMappingURL` is being calculated relative to the projectRoot instead of the serverRoot, but all files are being resolved relative to the serverRoot.
