### PR TITLE
Restructure `Graph` - separate traversal from state mutation

### DIFF
--- a/packages/metro/src/DeltaBundler/Graph.js
+++ b/packages/metro/src/DeltaBundler/Graph.js
@@ -79,10 +79,11 @@ export type Result<T> = {
  **/
 type Delta<T> = $ReadOnly<{
   // `added` and `deleted` are mutually exclusive.
-  // Internally, a module can be in both `modified` and (either) `added` or
-  // `deleted`. We fix this up before returning the delta to the client.
+  // Internally, a module can be in both `touched` and (either) `added` or
+  // `deleted`. Before returning the result, we'll calculate
+  // modified = touched - added - deleted.
   added: Set<string>,
-  modified: Set<string>,
+  touched: Set<string>,
   deleted: Set<string>,
 
   // A place to temporarily track inverse dependencies for a module while it is
@@ -174,23 +175,11 @@ export class Graph<T = MixedOutput> {
   ): Promise<Result<T>> {
     const internalOptions = getInternalOptions(options);
 
-    // Record the paths that are part of the dependency graph before we start
-    // traversing - we'll use this to ensure we don't report modules modified
-    // that only exist as part of the graph mid-traversal, and to eliminate
-    // modules that end up in the same state that they started from the delta.
-    const originalModules = new Map<string, Module<T>>();
-    for (const path of paths) {
-      const originalModule = this.dependencies.get(path);
-      if (originalModule) {
-        originalModules.set(path, originalModule);
-      }
-    }
-
-    const allModifiedPaths = new Set(paths);
-
     const modifiedPathsInBaseGraph = paths.filter(path =>
       this.dependencies.has(path),
     );
+
+    const allModifiedPaths = new Set(paths);
 
     const moduleData = await buildSubgraph(
       new Set(modifiedPathsInBaseGraph),
@@ -219,7 +208,7 @@ export class Graph<T = MixedOutput> {
 
     const delta = {
       added: new Set<string>(),
-      modified: new Set<string>(),
+      touched: new Set<string>(),
       deleted: new Set<string>(),
       earlyInverseDependencies: new Map<string, CountingSet<string>>(),
       moduleData,
@@ -239,43 +228,13 @@ export class Graph<T = MixedOutput> {
     }
 
     const modified = new Map<string, Module<T>>();
-
-    // A path in delta.modified has been processed during this traversal,
-    // but may not actually differ, may be new, or may have been deleted after
-    // processing. The actually-modified modules are the intersection of
-    // delta.modified with the pre-existing paths, minus modules deleted.
-    for (const [path, originalModule] of originalModules) {
-      invariant(
-        !delta.added.has(path),
-        'delta.added has %s, but this path was already in the graph.',
-        path,
-      );
-      if (delta.modified.has(path)) {
-        // It's expected that a module may be both modified and subsequently
-        // deleted - we'll only return it as deleted.
-        if (!delta.deleted.has(path)) {
-          // If a module existed before and has not been deleted, it must be
-          // in the dependencies map.
-          const newModule = nullthrows(this.dependencies.get(path));
-          if (
-            // Module.dependencies is mutable, so it's not obviously the case
-            // that referential equality implies no modification. However, we
-            // only mutate dependencies in two cases:
-            // 1. Within _recursivelyCommitModule. In that case, we always
-            //    mutate a new module and set a new reference in
-            //    this.dependencies.
-            // 2. During _releaseModule, when recursively removing
-            //    dependencies. In that case, we immediately discard the module
-            //    object.
-            // TODO: Refactor for more explicit immutability
-            newModule !== originalModule ||
-            transfromOutputMayDiffer(newModule, originalModule) ||
-            // $FlowFixMe[incompatible-call]
-            !allDependenciesEqual(newModule, originalModule)
-          ) {
-            modified.set(path, newModule);
-          }
-        }
+    for (const path of modifiedPathsInBaseGraph) {
+      if (
+        delta.touched.has(path) &&
+        !delta.deleted.has(path) &&
+        !delta.added.has(path)
+      ) {
+        modified.set(path, nullthrows(this.dependencies.get(path)));
       }
     }
 
@@ -317,7 +276,7 @@ export class Graph<T = MixedOutput> {
 
     const delta = {
       added: new Set<string>(),
-      modified: new Set<string>(),
+      touched: new Set<string>(),
       deleted: new Set<string>(),
       earlyInverseDependencies: new Map<string, CountingSet<string>>(),
       moduleData,
@@ -404,19 +363,28 @@ export class Graph<T = MixedOutput> {
       }
     }
 
-    if (
-      previousModule &&
-      !transfromOutputMayDiffer(previousModule, nextModule) &&
+    if (!previousModule) {
+      // If the module is not currently in the graph, it is either new or was
+      // released earlier in the commit.
+      if (delta.deleted.has(path)) {
+        // Mark the addition by clearing a prior deletion.
+        delta.deleted.delete(path);
+      } else {
+        // Mark the addition in the added set.
+        delta.added.add(path);
+      }
+    } else if (
+      !transformOutputMayDiffer(previousModule, nextModule) &&
       !dependenciesRemoved &&
       !dependenciesAdded
     ) {
       // We have not operated on nextModule, so restore previousModule
-      // to aid diffing.
+      // to aid diffing. Don't add this path to delta.touched.
       this.dependencies.set(previousModule.path, previousModule);
       return previousModule;
     }
 
-    delta.modified.add(path);
+    delta.touched.add(path);
 
     // Replace dependencies with the correctly-ordered version. As long as all
     // the above promises have resolved, this will be the same map but without
@@ -476,13 +444,6 @@ export class Graph<T = MixedOutput> {
           // should only mark its parent as an inverse dependency.
           earlyInverseDependencies.add(parentModule.path);
         } else {
-          if (delta.deleted.has(path)) {
-            // Mark the addition by clearing a prior deletion.
-            delta.deleted.delete(path);
-          } else {
-            // Mark the addition in the added set.
-            delta.added.add(path);
-          }
           delta.earlyInverseDependencies.set(path, new CountingSet());
 
           module = this._recursivelyCommitModule(path, delta, options);
@@ -853,23 +814,6 @@ function dependenciesEqual(
   );
 }
 
-function allDependenciesEqual<T>(
-  a: Module<T>,
-  b: Module<T>,
-  options: $ReadOnly<{lazy: boolean, ...}>,
-): boolean {
-  if (a.dependencies.size !== b.dependencies.size) {
-    return false;
-  }
-  for (const [key, depA] of a.dependencies) {
-    const depB = b.dependencies.get(key);
-    if (!depB || !dependenciesEqual(depA, depB, options)) {
-      return false;
-    }
-  }
-  return true;
-}
-
 function contextParamsEqual(
   a: ?RequireContextParams,
   b: ?RequireContextParams,
@@ -886,7 +830,7 @@ function contextParamsEqual(
   );
 }
 
-function transfromOutputMayDiffer<T>(a: Module<T>, b: Module<T>): boolean {
+function transformOutputMayDiffer<T>(a: Module<T>, b: Module<T>): boolean {
   return (
     a.unstable_transformResultKey == null ||
     a.unstable_transformResultKey !== b.unstable_transformResultKey

--- a/packages/metro/src/DeltaBundler/__tests__/Graph-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/Graph-test.js
@@ -35,7 +35,6 @@
 import type {RequireContext} from '../../lib/contextModule';
 import type {Result} from '../Graph';
 import type {
-  Dependency,
   MixedOutput,
   Module,
   Options,
@@ -3067,62 +3066,6 @@ describe('require.context', () => {
     expect(getMatchingContextModules(graph, '/ctx/matched-file')).toEqual(
       new Set(),
     );
-  });
-});
-
-describe('reorderGraph', () => {
-  it('should reorder any unordered graph in DFS order', async () => {
-    const dep = (path: string): Dependency => ({
-      absolutePath: path,
-      data: {
-        data: {
-          asyncType: null,
-          locs: [],
-          key: path.substr(1),
-        },
-        name: path.substr(1),
-      },
-    });
-
-    const mod = (moduleData: {
-      dependencies: Map<string, Dependency>,
-      path: string,
-    }): Module<MixedOutput> => ({
-      ...moduleData,
-      output: [],
-      getSource: () => Buffer.from('// source'),
-      // NOTE: inverseDependencies is traversal state/output, not input, so we
-      // don't pre-populate it.
-      inverseDependencies: new CountingSet(),
-    });
-
-    const graph = new TestGraph({
-      entryPoints: new Set(['/a', '/b']),
-      transformOptions: options.transformOptions,
-    });
-    // prettier-ignore
-    const deps = [
-      ['/2', mod({path: '/2', dependencies: new Map()})],
-      ['/0', mod({path: '/0', dependencies: new Map([['/1', dep('/1')], ['/2', dep('/2')]])})],
-      ['/1', mod({path: '/1', dependencies: new Map([['/2', dep('/2')]])})],
-      ['/3', mod({path: '/3', dependencies: new Map([])})],
-      ['/b', mod({path: '/b', dependencies: new Map([['/3', dep('/3')]])})],
-      ['/a', mod({path: '/a', dependencies: new Map([['/0', dep('/0')]])})],
-    ];
-    for (const [key, dep] of deps) {
-      graph.dependencies.set(key, dep);
-    }
-
-    graph.reorderGraph({shallow: false});
-
-    expect([...graph.dependencies.keys()]).toEqual([
-      '/a',
-      '/0',
-      '/1',
-      '/2',
-      '/b',
-      '/3',
-    ]);
   });
 });
 

--- a/packages/metro/src/DeltaBundler/__tests__/buildSubgraph-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/buildSubgraph-test.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {RequireContextParams} from '../../ModuleGraph/worker/collectDependencies';
+import type {Dependency, TransformResultDependency} from '../types.flow';
+
+import {buildSubgraph} from '../buildSubgraph';
+import nullthrows from 'nullthrows';
+
+const makeTransformDep = (
+  name: string,
+  asyncType: null | 'weak' | 'async' = null,
+  contextParams?: RequireContextParams,
+): TransformResultDependency => ({
+  name,
+  data: {key: 'key-' + name, asyncType, locs: [], contextParams},
+});
+
+describe('GraphTraversal', () => {
+  const transformDeps: Map<
+    string,
+    $ReadOnlyArray<TransformResultDependency>,
+  > = new Map([
+    ['/bundle', [makeTransformDep('foo')]],
+    ['/foo', [makeTransformDep('bar'), makeTransformDep('baz')]],
+    ['/bar', []],
+    ['/baz', [makeTransformDep('qux', 'weak')]],
+    [
+      '/entryWithContext',
+      [
+        makeTransformDep('virtual', null, {
+          filter: {
+            pattern: 'contextMatch.*',
+            flags: 'i',
+          },
+          mode: 'sync',
+          recursive: true,
+        }),
+      ],
+    ],
+    [
+      '/virtual?ctx=af3bf59b8564d441084c02bdf04c4d662d74d3bd',
+      [makeTransformDep('contextMatch')],
+    ],
+    ['/contextMatch', []],
+  ]);
+
+  let params;
+
+  beforeEach(() => {
+    params = {
+      resolve: jest.fn((from, dependency) => ({
+        filePath: `/${dependency.name}`,
+        type: 'sourceFile',
+      })),
+      transform: jest.fn(async (path, requireContext) => ({
+        dependencies: nullthrows(transformDeps.get(path), path),
+        output: [],
+        getSource: () => Buffer.from('// source'),
+      })),
+      shouldTraverse: jest.fn(
+        (dependency: Dependency) => dependency.data.data.asyncType !== 'weak',
+      ),
+    };
+  });
+
+  test('traverses all nodes out from /bundle, except a weak dependency', async () => {
+    const moduleData = await buildSubgraph(
+      new Set(['/bundle']),
+      new Map(),
+      params,
+    );
+    expect([...moduleData.keys()]).toEqual(['/bundle', '/foo', '/bar', '/baz']);
+    expect(moduleData.get('/bundle')).toEqual({
+      dependencies: new Map([
+        [
+          'key-foo',
+          {
+            absolutePath: '/foo',
+            data: makeTransformDep('foo'),
+          },
+        ],
+      ]),
+      getSource: expect.any(Function),
+      output: [],
+      resolvedContexts: new Map(),
+    });
+  });
+
+  test('resolves context and traverses context matches', async () => {
+    const moduleData = await buildSubgraph(
+      new Set(['/entryWithContext']),
+      new Map(),
+      params,
+    );
+    expect(params.transform).toHaveBeenCalledWith(
+      '/entryWithContext',
+      undefined,
+    );
+    const expectedResolvedContext = {
+      filter: /contextMatch.*/i,
+      from: '/virtual',
+      mode: 'sync',
+      recursive: true,
+    };
+    expect(params.transform).toHaveBeenCalledWith(
+      '/virtual?ctx=af3bf59b8564d441084c02bdf04c4d662d74d3bd',
+      expectedResolvedContext,
+    );
+    expect(params.transform).toHaveBeenCalledWith('/contextMatch', undefined);
+    expect(params.transform).toHaveBeenCalledWith(
+      '/entryWithContext',
+      undefined,
+    );
+    expect(moduleData).toEqual(
+      new Map([
+        [
+          '/entryWithContext',
+          {
+            dependencies: new Map([
+              [
+                'key-virtual',
+                {
+                  absolutePath:
+                    '/virtual?ctx=af3bf59b8564d441084c02bdf04c4d662d74d3bd',
+                  data: nullthrows(transformDeps.get('/entryWithContext'))[0],
+                },
+              ],
+            ]),
+            resolvedContexts: new Map([
+              ['key-virtual', expectedResolvedContext],
+            ]),
+            output: [],
+            getSource: expect.any(Function),
+          },
+        ],
+        [
+          '/contextMatch',
+          {
+            dependencies: new Map(),
+            resolvedContexts: new Map(),
+            output: [],
+            getSource: expect.any(Function),
+          },
+        ],
+        [
+          '/virtual?ctx=af3bf59b8564d441084c02bdf04c4d662d74d3bd',
+          {
+            dependencies: new Map([
+              [
+                'key-contextMatch',
+                {
+                  absolutePath: '/contextMatch',
+                  data: nullthrows(
+                    transformDeps.get(
+                      '/virtual?ctx=af3bf59b8564d441084c02bdf04c4d662d74d3bd',
+                    ),
+                  )[0],
+                },
+              ],
+            ]),
+            resolvedContexts: new Map(),
+            output: [],
+            getSource: expect.any(Function),
+          },
+        ],
+      ]),
+    );
+  });
+});

--- a/packages/metro/src/DeltaBundler/buildSubgraph.js
+++ b/packages/metro/src/DeltaBundler/buildSubgraph.js
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {deriveAbsolutePathFromContext} from '../lib/contextModule';
+import path from 'path';
+
+import type {RequireContext} from '../lib/contextModule';
+import type {
+  Dependency,
+  ModuleData,
+  ResolveFn,
+  TransformFn,
+  TransformResultDependency,
+} from './types.flow';
+
+type Parameters<T> = $ReadOnly<{
+  resolve: ResolveFn,
+  transform: TransformFn<T>,
+  shouldTraverse: Dependency => boolean,
+}>;
+
+function resolveDependencies(
+  parentPath: string,
+  dependencies: $ReadOnlyArray<TransformResultDependency>,
+  resolve: ResolveFn,
+): {
+  dependencies: Map<string, Dependency>,
+  resolvedContexts: Map<string, RequireContext>,
+} {
+  const maybeResolvedDeps = new Map<string, void | Dependency>();
+  const resolvedContexts = new Map<string, RequireContext>();
+  for (const dep of dependencies) {
+    let resolvedDep;
+    const key = dep.data.key;
+
+    // `require.context`
+    const {contextParams} = dep.data;
+    if (contextParams) {
+      // Ensure the filepath has uniqueness applied to ensure multiple `require.context`
+      // statements can be used to target the same file with different properties.
+      const from = path.join(parentPath, '..', dep.name);
+      const absolutePath = deriveAbsolutePathFromContext(from, contextParams);
+
+      const resolvedContext: RequireContext = {
+        from,
+        mode: contextParams.mode,
+        recursive: contextParams.recursive,
+        filter: new RegExp(
+          contextParams.filter.pattern,
+          contextParams.filter.flags,
+        ),
+      };
+
+      resolvedContexts.set(key, resolvedContext);
+
+      resolvedDep = {
+        absolutePath,
+        data: dep,
+      };
+    } else {
+      try {
+        resolvedDep = {
+          absolutePath: resolve(parentPath, dep).filePath,
+          data: dep,
+        };
+      } catch (error) {
+        // Ignore unavailable optional dependencies. They are guarded
+        // with a try-catch block and will be handled during runtime.
+        if (dep.data.isOptional !== true) {
+          throw error;
+        }
+      }
+    }
+
+    if (maybeResolvedDeps.has(key)) {
+      throw new Error(
+        `resolveDependencies: Found duplicate dependency key '${key}' in ${parentPath}`,
+      );
+    }
+    maybeResolvedDeps.set(key, resolvedDep);
+  }
+
+  const resolvedDeps = new Map<string, Dependency>();
+  // Return just the dependencies we successfully resolved.
+  // FIXME: This has a bad bug affecting all dependencies *after* an unresolved
+  // optional dependency. We'll need to propagate the nulls all the way to the
+  // serializer and the require() runtime to keep the dependency map from being
+  // desynced from the contents of the module.
+  for (const [key, resolvedDep] of maybeResolvedDeps) {
+    if (resolvedDep) {
+      resolvedDeps.set(key, resolvedDep);
+    }
+  }
+  return {dependencies: resolvedDeps, resolvedContexts};
+}
+
+export async function buildSubgraph<T>(
+  entryPaths: $ReadOnlySet<string>,
+  resolvedContexts: $ReadOnlyMap<string, ?RequireContext>,
+  {resolve, transform, shouldTraverse}: Parameters<T>,
+): Promise<Map<string, ModuleData<T>>> {
+  const moduleData: Map<string, ModuleData<T>> = new Map();
+  const visitedPaths: Set<string> = new Set();
+
+  async function visit(
+    absolutePath: string,
+    requireContext: ?RequireContext,
+  ): Promise<void> {
+    if (visitedPaths.has(absolutePath)) {
+      return;
+    }
+    visitedPaths.add(absolutePath);
+    const transformResult = await transform(absolutePath, requireContext);
+
+    // Get the absolute path of all sub-dependencies (some of them could have been
+    // moved but maintain the same relative path).
+    const resolutionResult = resolveDependencies(
+      absolutePath,
+      transformResult.dependencies,
+      resolve,
+    );
+
+    moduleData.set(absolutePath, {
+      ...transformResult,
+      ...resolutionResult,
+    });
+
+    await Promise.all(
+      [...resolutionResult.dependencies]
+        .filter(([key, dependency]) => shouldTraverse(dependency))
+        .map(([key, dependency]) =>
+          visit(
+            dependency.absolutePath,
+            resolutionResult.resolvedContexts.get(dependency.data.data.key),
+          ),
+        ),
+    );
+  }
+
+  await Promise.all(
+    [...entryPaths].map(absolutePath =>
+      visit(absolutePath, resolvedContexts.get(absolutePath)),
+    ),
+  );
+
+  return moduleData;
+}

--- a/packages/metro/src/DeltaBundler/types.flow.js
+++ b/packages/metro/src/DeltaBundler/types.flow.js
@@ -70,6 +70,14 @@ export type Module<T = MixedOutput> = $ReadOnly<{
   unstable_transformResultKey?: ?string,
 }>;
 
+export type ModuleData<T = MixedOutput> = $ReadOnly<{
+  dependencies: $ReadOnlyMap<string, Dependency>,
+  resolvedContexts: $ReadOnlyMap<string, RequireContext>,
+  output: $ReadOnlyArray<T>,
+  getSource: () => Buffer,
+  unstable_transformResultKey?: ?string,
+}>;
+
 export type Dependencies<T = MixedOutput> = Map<string, Module<T>>;
 export type ReadOnlyDependencies<T = MixedOutput> = $ReadOnlyMap<
   string,
@@ -115,6 +123,12 @@ export type TransformFn<T = MixedOutput> = (
   string,
   ?RequireContext,
 ) => Promise<TransformResultWithSource<T>>;
+
+export type ResolveFn = (
+  from: string,
+  dependency: TransformResultDependency,
+) => BundlerResolution;
+
 export type AllowOptionalDependenciesWithOptions = {
   +exclude: Array<string>,
 };
@@ -128,10 +142,7 @@ export type BundlerResolution = $ReadOnly<{
 }>;
 
 export type Options<T = MixedOutput> = {
-  +resolve: (
-    from: string,
-    dependency: TransformResultDependency,
-  ) => BundlerResolution,
+  +resolve: ResolveFn,
   +transform: TransformFn<T>,
   +transformOptions: TransformInputOptions,
   +onProgress: ?(numProcessed: number, total: number) => mixed,

--- a/packages/metro/src/DeltaBundler/types.flow.js
+++ b/packages/metro/src/DeltaBundler/types.flow.js
@@ -25,41 +25,41 @@ export type MixedOutput = {
 
 export type AsyncDependencyType = 'async' | 'prefetch' | 'weak';
 
-export type TransformResultDependency = {
+export type TransformResultDependency = $ReadOnly<{
   /**
    * The literal name provided to a require or import call. For example 'foo' in
    * case of `require('foo')`.
    */
-  +name: string,
+  name: string,
 
   /**
    * Extra data returned by the dependency extractor.
    */
-  +data: {
+  data: $ReadOnly<{
     /**
      * A locally unique key for this dependency within the current module.
      */
-    +key: string,
+    key: string,
     /**
      * If not null, this dependency is due to a dynamic `import()` or `__prefetchImport()` call.
      */
-    +asyncType: AsyncDependencyType | null,
+    asyncType: AsyncDependencyType | null,
     /**
      * The dependency is enclosed in a try/catch block.
      */
-    +isOptional?: boolean,
+    isOptional?: boolean,
 
-    +locs: $ReadOnlyArray<BabelSourceLocation>,
+    locs: $ReadOnlyArray<BabelSourceLocation>,
 
     /** Context for requiring a collection of modules. */
-    +contextParams?: RequireContextParams,
-  },
-};
+    contextParams?: RequireContextParams,
+  }>,
+}>;
 
-export type Dependency = {
-  +absolutePath: string,
-  +data: TransformResultDependency,
-};
+export type Dependency = $ReadOnly<{
+  absolutePath: string,
+  data: TransformResultDependency,
+}>;
 
 export type Module<T = MixedOutput> = $ReadOnly<{
   dependencies: Map<string, Dependency>,

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -38,7 +38,7 @@ export type Dependency = $ReadOnly<{
 // TODO: Convert to a Flow enum
 export type ContextMode = 'sync' | 'eager' | 'lazy' | 'lazy-once';
 
-type ContextFilter = {pattern: string, flags: string};
+type ContextFilter = $ReadOnly<{pattern: string, flags: string}>;
 
 export type RequireContextParams = $ReadOnly<{
   /* Should search for files recursively. Optional, default `true` when `require.context` is used */


### PR DESCRIPTION
This is a significant restructuring of the internal operation of `Graph`. Currently, we asynchronously traverse, and resolve, from a set of entry/modified paths, updating the graph's state as we go.

This change performs the same work in two distinct phases:
 1. Draft: Asynchronously traverse the necessary modules, collecting transform and resolution results with *no* mutation - using a separate, ephemeral `GraphTraversal` instance to make that explicit.
 2. Commit: Mutate graph state in a second, synchronous, depth-first traversal of the modified modules.

The motivation for this is twofold:
 - Resolve a category of known bugs where a userland issue, such as a syntax error or unresolvable dependency, would interrupt traversal and potentially leave internal state *partially* updated *without sending an update to the client*. This will now fail in the draft phase, allowing `DeltaCalculator` to repeat the attempt when the userland issue is fixed.
 - Makes the operation of `Graph` easier to reason about, and opens up several opportunities for simplification. For example, the commit phase being synchronous means that ordering is deterministic, and that the need to track `earlyInverseDependencies` is obviated.

Some of the issues fixed here were introduced by Graph delta pruning in D45691844, but others are longstanding. New unit tests cover the major cases.

Changelog:
```
**[Fix]**: Fast Refresh may fail or lose modifications after correcting transform or resolution issues in user code.
```

Differential Revision: D51943094