### PR TITLE
docs(Configuration): repair link to metro config loader

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,7 +14,7 @@ You can also give a custom file to the configuration by specifying `--config <pa
 :::note
 
 When Metro is started via the React Native CLI, some defaults are different from those mentioned below.
-See the [React Native repository](https://github.com/react-native-community/cli/blob/main/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts) for details.
+See the [React Native repository](https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/utils/loadMetroConfig.js) for details.
 
 :::
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

I was reading the documentation and noticed a broken link

## Test plan

Test-click the new link, make sure it opens the intended source file
(test-click the old one and it is github's 404...)
