### PR TITLE
Updated link to the react native loadMetroConfig.js file

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,7 +14,7 @@ You can also give a custom file to the configuration by specifying `--config <pa
 :::note
 
 When Metro is started via the React Native CLI, some defaults are different from those mentioned below.
-See the [React Native repository](https://github.com/react-native-community/cli/blob/main/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts) for details.
+See the [React Native repository](https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/utils/loadMetroConfig.js) for details.
 
 :::
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
The link to the loadMetroConfig.js in the React Native Repository was broken because the package was relocated (see https://github.com/react-native-community/cli/blob/main/packages/cli-plugin-metro/README.md). I changed the link to send the user to the new file in the facebook/react-native repository.

## Test plan

changed the link to a working one.


--
I completed the CLA right now.