### PR TITLE
docs: fixed link to react-native-babel-transformer

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -535,7 +535,7 @@ Type: `string`
 
 The name of a module that compiles code with Babel, returning an AST and optional metadata. Defaults to `metro-babel-transformer`.
 
-Refer to the source code of [`metro-babel-transformer`](https://github.com/facebook/metro/blob/main/packages/metro-babel-transformer/src/index.js) and [`metro-react-native-babel-transformer`](https://github.com/facebook/metro/blob/main/packages/metro-react-native-babel-transformer/src/index.js) for details on implementing a custom Babel transformer.
+Refer to the source code of [`metro-babel-transformer`](https://github.com/facebook/metro/blob/main/packages/metro-babel-transformer/src/index.js) and [`react-native-babel-transformer`](https://github.com/facebook/react-native/blob/main/packages/react-native-babel-transformer/src/index.js) for details on implementing a custom Babel transformer.
 
 :::note
 This option only has an effect under the default [`transformerPath`](#transformerpath). Custom transformers may ignore it.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -535,7 +535,7 @@ Type: `string`
 
 The name of a module that compiles code with Babel, returning an AST and optional metadata. Defaults to `metro-babel-transformer`.
 
-Refer to the source code of [`metro-babel-transformer`](https://github.com/facebook/metro/blob/main/packages/metro-babel-transformer/src/index.js) and [`react-native-babel-transformer`](https://github.com/facebook/react-native/blob/main/packages/react-native-babel-transformer/src/index.js) for details on implementing a custom Babel transformer.
+Refer to the source code of [`metro-babel-transformer`](https://github.com/facebook/metro/blob/main/packages/metro-babel-transformer/src/index.js) and [`@react-native/metro-babel-transformer`](https://github.com/facebook/react-native/blob/main/packages/react-native-babel-transformer/src/index.js) for details on implementing a custom Babel transformer.
 
 :::note
 This option only has an effect under the default [`transformerPath`](#transformerpath). Custom transformers may ignore it.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The link was pointing to the old metro-react-native-babel-transformer (changed in https://github.com/facebook/metro/pull/1024 to be located in the react-native repo)

## Test plan

Link was pointing to a 404 and is now pointing to the correct location in the react-native repo
