### PR TITLE
image-size package version set to a static value 1.0.2

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -29,7 +29,7 @@
     "error-stack-parser": "^2.0.6",
     "graceful-fs": "^4.2.4",
     "hermes-parser": "0.18.2",
-    "image-size": "^1.0.2",
+    "image-size": "1.0.2",
     "invariant": "^2.2.4",
     "jest-worker": "^29.6.3",
     "jsc-safe-url": "^0.2.2",


### PR DESCRIPTION
The image-size package recently released version 1.1.0, which no longer supports Node versions below 18. Due to the caret (^) dependency in the metro package, it automatically upgrades from version 1.0.2 to 1.1.0. However, this poses an issue for dependent packages like react-native (below version 0.72), which allows consumers to use Node versions below 18 and hence the current code makes it incompatible because of the updated image-size package.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

React Native versions below 0.73 permit the use of Node 16 for development. However, an issue arose suddenly, indicating that the image-size package is incompatible with the current Node version and now requires version 18 or above. Upon investigation, it was discovered that `image-size` is a dependency of the metro, specified with the caret (^) notation. The problem stems from the recent release of image-size version 1.1.0, which no longer supports Node versions below 18. This change is causing installation failures in React Native projects.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos if the pull request changes UI. -->
