### PR TITLE
fix(#1167): function calls prefixed with `void` together with the optional chain (?.) are skipped

### DIFF
--- a/packages/metro-transform-plugins/src/__tests__/constant-folding-plugin-test.js
+++ b/packages/metro-transform-plugins/src/__tests__/constant-folding-plugin-test.js
@@ -361,4 +361,20 @@ describe('constant expressions', () => {
 
     compare([constantFoldingPlugin], code, expected);
   });
+
+  it('does not transform optional chained call into `undefined`', () => {
+    const code = `foo?.();`;
+
+    const expected = `foo?.();`;
+
+    compare([constantFoldingPlugin], code, expected);
+  });
+
+  it('does not transform `void` prefixed optional chained call into `undefined`', () => {
+    const code = `void foo?.();`;
+
+    const expected = `void foo?.();`;
+
+    compare([constantFoldingPlugin], code, expected);
+  });
 });

--- a/packages/metro-transform-plugins/src/constant-folding-plugin.js
+++ b/packages/metro-transform-plugins/src/constant-folding-plugin.js
@@ -47,6 +47,13 @@ function constantFoldingPlugin(context: {
     path.traverse(
       {
         CallExpression: unsafe,
+        /**
+         * This will mark `foo?.()` as unsafe, so it is not replaced with `undefined` down the line.
+         *
+         * We saw this case in the wild, where the unary expression `void foo?.()` was replaced with `undefined`
+         * resulting in the expression call being skipped.
+         */
+        OptionalCallExpression: unsafe,
         AssignmentExpression: unsafe,
       },
       state,

--- a/packages/metro-transform-plugins/src/constant-folding-plugin.js
+++ b/packages/metro-transform-plugins/src/constant-folding-plugin.js
@@ -38,7 +38,8 @@ function constantFoldingPlugin(context: {
     const unsafe = (
       path:
         | NodePath<BabelNodeAssignmentExpression>
-        | NodePath<BabelNodeCallExpression>,
+        | NodePath<BabelNodeCallExpression>
+        | NodePath<BabelNodeOptionalCallExpression>,
       state: {safe: boolean},
     ) => {
       state.safe = false;
@@ -46,6 +47,7 @@ function constantFoldingPlugin(context: {
 
     path.traverse(
       {
+        AssignmentExpression: unsafe,
         CallExpression: unsafe,
         /**
          * This will mark `foo?.()` as unsafe, so it is not replaced with `undefined` down the line.
@@ -54,7 +56,6 @@ function constantFoldingPlugin(context: {
          * resulting in the expression call being skipped.
          */
         OptionalCallExpression: unsafe,
-        AssignmentExpression: unsafe,
       },
       state,
     );


### PR DESCRIPTION
## Summary

Fixes: https://github.com/facebook/metro/issues/1167

`constant-folding-plugin` replaces this call `void foo?.();` with `undefined;`.

This is because the `evaluate()` function marks the optional call expressions as safe, making the `UnaryExpression` visitor think it is safe to replace it with the `value` returned by the `evaluate()`, in this case `undefined`.

This PR makes the `evaluate()` function mark the optional call expressions as unsafe.

Changelog:
```
* **[Fix]**: `constant-folding-plugin`: Don't fold optional function calls (`foo.?()`). (https://github.com/facebook/metro/pull/1178 by @Gamote)
```

## Test plan

I have added 2 tests to cover these changes:
- does not transform optional chained call into `undefined`
- does not transform `void` prefixed optional chained call into `undefined`
