### PR TITLE
Add server.forwardClientLogs config option

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -661,6 +661,12 @@ Type: `string => string`
 
 A function that will be called every time Metro processes a URL, after normalization of non-standard query-string delimiters using [`jsc-safe-url`](https://www.npmjs.com/package/jsc-safe-url). Metro will use the return value of this function as if it were the original URL provided by the client. This applies to all incoming HTTP requests (after any custom middleware), as well as bundle URLs in `/symbolicate` request payloads and within the hot reloading protocol.
 
+#### `forwardClientLogs`
+
+Type: `boolean`
+
+Enable forwarding of `client_log` events (when client logs are [configured](https://github.com/facebook/metro/blob/614ad14a85b22958129ee94e04376b096f03ccb1/packages/metro/src/lib/createWebsocketServer.js#L20)) to the reporter. Defaults to `true`.
+
 ---
 
 ### Watcher Options

--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -100,6 +100,7 @@ Object {
   },
   "server": Object {
     "enhanceMiddleware": [Function],
+    "forwardClientLogs": true,
     "port": 8081,
     "rewriteRequestUrl": [Function],
     "unstable_serverRoot": null,
@@ -280,6 +281,7 @@ Object {
   },
   "server": Object {
     "enhanceMiddleware": [Function],
+    "forwardClientLogs": true,
     "port": 8081,
     "rewriteRequestUrl": [Function],
     "unstable_serverRoot": null,
@@ -460,6 +462,7 @@ Object {
   },
   "server": Object {
     "enhanceMiddleware": [Function],
+    "forwardClientLogs": true,
     "port": 8081,
     "rewriteRequestUrl": [Function],
     "unstable_serverRoot": null,
@@ -640,6 +643,7 @@ Object {
   },
   "server": Object {
     "enhanceMiddleware": [Function],
+    "forwardClientLogs": true,
     "port": 8081,
     "rewriteRequestUrl": [Function],
     "unstable_serverRoot": null,

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -167,6 +167,7 @@ type MetalConfigT = {
 type ServerConfigT = {
   /** @deprecated */
   enhanceMiddleware: (Middleware, MetroServer) => Middleware | Server,
+  forwardClientLogs: boolean,
   port: number,
   rewriteRequestUrl: string => string,
   unstable_serverRoot: ?string,

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -75,6 +75,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
 
   server: {
     enhanceMiddleware: (middleware, _) => middleware,
+    forwardClientLogs: true,
     port: 8081,
     rewriteRequestUrl: url => url,
     unstable_serverRoot: null,

--- a/packages/metro-config/types/configTypes.d.ts
+++ b/packages/metro-config/types/configTypes.d.ts
@@ -165,6 +165,7 @@ export interface ServerConfigT {
     metroMiddleware: Middleware,
     metroServer: MetroServer,
   ) => Middleware | Server;
+  forwardClientLogs: boolean;
   port: number;
   rewriteRequestUrl: (url: string) => string;
   unstable_serverRoot: string | null;

--- a/packages/metro/src/HmrServer.js
+++ b/packages/metro/src/HmrServer.js
@@ -228,12 +228,14 @@ class HmrServer<TClient: Client> {
             ),
           );
         case 'log':
-          this._config.reporter.update({
-            type: 'client_log',
-            level: data.level,
-            data: data.data,
-            mode: data.mode,
-          });
+          if (this._config.server.forwardClientLogs) {
+            this._config.reporter.update({
+              type: 'client_log',
+              level: data.level,
+              data: data.data,
+              mode: data.mode,
+            });
+          }
           break;
         case 'log-opt-in':
           client.optedIntoHMR = true;


### PR DESCRIPTION
Summary:
Add an option to disable reporting of forwarded client logs (via `WebsocketServiceInterface.onClientMessage`). In React Native, this enables user opt out from console logs in `metro.config.js`.

Resolves https://github.com/facebook/metro/issues/484, https://github.com/react-native-community/cli/issues/794.

Changelog: **[Feature]** Add `server.forwardClientLogs` config option

Differential Revision: D52768531


