### PR TITLE
Package exports: resolve to real paths, fix module duplication in output

### DIFF
--- a/packages/metro-resolver/src/PackageExportsResolve.js
+++ b/packages/metro-resolver/src/PackageExportsResolve.js
@@ -103,8 +103,19 @@ export function resolvePackageTargetFromExports(
       }
     }
 
-    if (context.doesFileExist(filePath)) {
-      return {type: 'sourceFile', filePath};
+    if (context.unstable_getRealPath != null) {
+      const maybeRealPath = context.unstable_getRealPath(filePath);
+      if (maybeRealPath != null) {
+        return {
+          type: 'sourceFile',
+          filePath: maybeRealPath,
+        };
+      }
+    } else if (context.doesFileExist(filePath)) {
+      return {
+        type: 'sourceFile',
+        filePath,
+      };
     }
 
     throw createConfigError(

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -109,14 +109,20 @@ describe('with package exports resolution disabled', () => {
 describe('with package exports resolution enabled', () => {
   describe('main entry point', () => {
     const baseContext = {
-      ...createResolutionContext({
-        '/root/src/main.js': '',
-        '/root/node_modules/test-pkg/package.json': '',
-        '/root/node_modules/test-pkg/index.js': '',
-        '/root/node_modules/test-pkg/index-main.js': '',
-        '/root/node_modules/test-pkg/index-exports.js.js': '',
-        '/root/node_modules/test-pkg/index-exports.ios.js': '',
-      }),
+      ...createResolutionContext(
+        {
+          '/root/src/main.js': '',
+          '/root/node_modules/test-pkg/package.json': '',
+          '/root/node_modules/test-pkg/index.js': '',
+          '/root/node_modules/test-pkg/index-main.js': '',
+          '/root/node_modules/test-pkg/index-exports.js.js': '',
+          '/root/node_modules/test-pkg/index-exports.ios.js': '',
+          '/root/node_modules/test-pkg/symlink.js': {
+            realPath: '/root/node_modules/test-pkg/symlink-target.js',
+          },
+        },
+        {enableSymlinks: true},
+      ),
       originModulePath: '/root/src/main.js',
       unstable_enablePackageExports: true,
     };
@@ -227,6 +233,23 @@ describe('with package exports resolution enabled', () => {
         expect(Resolver.resolve(context, 'test-pkg', 'ios')).toEqual({
           type: 'sourceFile',
           filePath: '/root/node_modules/test-pkg/index-main.js',
+        });
+      });
+
+      test('following symlinks and resolving real paths', () => {
+        const context = {
+          ...baseContext,
+          ...createPackageAccessors({
+            '/root/node_modules/test-pkg/package.json': {
+              main: 'index-main.js',
+              exports: './symlink.js',
+            },
+          }),
+        };
+
+        expect(Resolver.resolve(context, 'test-pkg', null)).toEqual({
+          type: 'sourceFile',
+          filePath: '/root/node_modules/test-pkg/symlink-target.js',
         });
       });
     });


### PR DESCRIPTION
Summary:
Fix: https://github.com/facebook/metro/issues/1197

`unstable_enablePackageExports` and `unstable_enableSymlinks` in combination may result in non-real module paths in the graph, because `PackageExportsResolve` only uses `context.doesFileExist` and does not necessarily return real paths.

Often, especially with pnpm, this results in a module appearing multiple times under different paths in the output bundle, as if duplicated on the file system, which causes incorrect behaviour for stateful modules and increases bundle size.

The fix mirrors the implementation of `resolveSourceFileForExt` in the non-exports resolver.

Changelog:
```
 - **[Experimental]:** Fix module duplication due to non-real resolved paths when combining `unstable_enablePackageExports` and `unstable_enableSymlinks`.
```

Differential Revision: D52964393


