### PR TITLE
Move `metro-minify-terser` dependency to `metro-transform-worker`, fix pnpm (etc) resolution

### DIFF
--- a/packages/metro-transform-worker/package.json
+++ b/packages/metro-transform-worker/package.json
@@ -21,13 +21,13 @@
     "metro-babel-transformer": "0.80.4",
     "metro-cache": "0.80.4",
     "metro-cache-key": "0.80.4",
+    "metro-minify-terser": "0.80.4",
     "metro-source-map": "0.80.4",
     "metro-transform-plugins": "0.80.4",
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
     "metro-memory-fs": "0.80.4",
-    "metro-minify-terser": "0.80.4",
     "@react-native/metro-babel-transformer": "0.73.11"
   },
   "engines": {

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -40,7 +40,6 @@
     "metro-config": "0.80.4",
     "metro-core": "0.80.4",
     "metro-file-map": "0.80.4",
-    "metro-minify-terser": "0.80.4",
     "metro-resolver": "0.80.4",
     "metro-runtime": "0.80.4",
     "metro-source-map": "0.80.4",


### PR DESCRIPTION
Summary:
Related: https://github.com/facebook/metro/pull/1172

This is the minimally invasive change to fix resolution of the default `minifierPath: 'metro-minify-terser'`, especially under isolated node_modules layouts.

`minifierPath` is required/resolved only from `metro-transform-worker`:
 - https://github.com/facebook/metro/blob/v0.80.4/packages/metro-transform-worker/src/utils/getMinifier.js#L22
 - https://github.com/facebook/metro/blob/v0.80.4/packages/metro-transform-worker/src/index.js#L656

Per the [current docs for `minifierPath`](https://metrobundler.dev/docs/configuration/#minifierpath), a module specifier relative to `metro-transform-worker` is explicitly acceptable:

> Type: string (default: 'metro-minify-terser')
> Path, or package name resolvable from metro-transform-worker, to the minifier that minifies the code after transformation.

Unlike https://github.com/facebook/metro/pull/1172 (thanks tido64 for flagging), this doesn't modify the defaults and can be released in a patch release. The approach in that PR (using fully resolved paths in config) may be the better long-term fix though, so this patch shouldn't be regarded as superseding it.

Changelog:
```
 - **[Fix]:** Move `metro-minify-terser` dependency to fix resolution under isolated node_modules (pnpm, etc).
```

Differential Revision: D53000650


