### PR TITLE
[0.76] Fix publish script to avoid dist-tag colliding with semver

### DIFF
--- a/.circleci/scripts/publish.sh
+++ b/.circleci/scripts/publish.sh
@@ -22,7 +22,7 @@ fi
 
 NPM_TAG="latest"
 # Use a tag name like "0.123-stable" as the dist-tag for a hotfix. This *must not* be valid semver.
-[ "$TAG_ON_RELEASE_BRANCH" -eq 1 ] && NPM_TAG="${RELEASE_BRANCH/%.x/-stable}"
+[ "$TAG_ON_RELEASE_BRANCH" -eq 1 ] && NPM_TAG="${RELEASE_BRANCH%.x}-stable"
 echo "Publishing with --tag=$NPM_TAG"
 
 npm run publish --tag="$NPM_TAG"

--- a/.circleci/scripts/publish.sh
+++ b/.circleci/scripts/publish.sh
@@ -21,7 +21,8 @@ if [ $TAG_ON_RELEASE_BRANCH -eq $TAG_ON_MAIN ]; then
 fi
 
 NPM_TAG="latest"
-[ "$TAG_ON_RELEASE_BRANCH" -eq 1 ] && NPM_TAG=$RELEASE_BRANCH
+# Use a tag name like "0.123-stable" as the dist-tag for a hotfix. This *must not* be valid semver.
+[ "$TAG_ON_RELEASE_BRANCH" -eq 1 ] && NPM_TAG="${RELEASE_BRANCH/%.x/-stable}"
 echo "Publishing with --tag=$NPM_TAG"
 
 npm run publish --tag="$NPM_TAG"


### PR DESCRIPTION
## Summary

Previously hotfix releases on old stable branches used to automatically publish with `latest`, which overwrote the tag for the actual latest release. 

https://github.com/facebook/metro/pull/1086 attempted to fix that, and *mostly* works, but npm does not allow dist tags that pass `semver.isValid()`, because that would conflict with semver specifiers in `package@[tagorsemver]`. Our stable branch naming convention `0.76.x` happens to be valid semver, and is rejected as a tag name.

This uses `0.76-stable` instead via shell substitution. I've just used it to semi-manually successfully publish 0.76.9.

## Test plan

- SSH into publish job in CircleCI
- Patch .circleci/scripts/publish.sh and run
- Published 0.76.9 with tag `0.76-stable` 