### PR TITLE
add platform tag for logs

### DIFF
--- a/packages/metro-runtime/src/modules/types.flow.js
+++ b/packages/metro-runtime/src/modules/types.flow.js
@@ -83,6 +83,7 @@ export type HmrClientMessage =
         | 'debug',
       +data: Array<mixed>,
       +mode: 'BRIDGE' | 'NOBRIDGE',
+      +platform: string,
     }
   | {
       +type: 'log-opt-in',

--- a/packages/metro/src/HmrServer.js
+++ b/packages/metro/src/HmrServer.js
@@ -234,6 +234,7 @@ class HmrServer<TClient: Client> {
               level: data.level,
               data: data.data,
               mode: data.mode,
+              platform: data.platform,
             });
           }
           break;

--- a/packages/metro/src/lib/TerminalReporter.js
+++ b/packages/metro/src/lib/TerminalReporter.js
@@ -272,7 +272,13 @@ class TerminalReporter {
         this._logHmrClientError(event.error);
         break;
       case 'client_log':
-        logToConsole(this.terminal, event.level, event.mode, ...event.data);
+        logToConsole(
+          this.terminal,
+          event.level,
+          event.mode,
+          event.platform,
+          ...event.data,
+        );
         break;
       case 'dep_graph_loading':
         const color = event.hasReducedPerformance ? chalk.red : chalk.blue;

--- a/packages/metro/src/lib/logToConsole.js
+++ b/packages/metro/src/lib/logToConsole.js
@@ -24,6 +24,7 @@ module.exports = (
   terminal: Terminal,
   level: string,
   mode: 'BRIDGE' | 'NOBRIDGE',
+  platform: ?string,
   ...data: Array<mixed>
 ) => {
   const logFunction = console[level] && level !== 'trace' ? level : 'log';
@@ -65,10 +66,15 @@ module.exports = (
       data[data.length - 1] = lastItem.trimEnd();
     }
 
+    const platformPrefix =
+      platform != null
+        ? chalk.inverse.bold.white` ${platform.toUpperCase()} ` + ' '
+        : '';
     const modePrefix =
       !mode || mode == 'BRIDGE' ? '' : `(${mode.toUpperCase()}) `;
     terminal.log(
-      color.bold(` ${modePrefix}${logFunction.toUpperCase()} `) +
+      platformPrefix +
+        color.bold(` ${modePrefix}${logFunction.toUpperCase()} `) +
         ''.padEnd(groupStack.length * 2, ' '),
       // `util.format` actually accepts any arguments.
       // If the first argument is a string, it tries to format it.

--- a/packages/metro/src/lib/reporting.js
+++ b/packages/metro/src/lib/reporting.js
@@ -117,6 +117,7 @@ export type ReportableEvent =
     }
   | {
       type: 'client_log',
+      platform: string,
       level:
         | 'trace'
         | 'info'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

- Depends on https://github.com/facebook/react-native/pull/42753
- Adds the ability to tag console logs with the origin platform.
- Here's a snippet of how we'd likely use it in Expo CLI. I'm not especially in love with the formatting, but it's better than no platform tag.

![Uploading Screenshot 2024-01-30 at 9.27.28 PM.png…]()

- Generally related (but not required for this feature in Metro) https://github.com/expo/expo/pull/26812

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
