### PR TITLE
`metro-config`: Add `injectProjectRootAsWatchFolder` argument to `loadConfig ` and provide fallback for `watchFolders`

### DIFF
--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -166,6 +166,21 @@ describe('loadConfig', () => {
     expect(prettyFormat(result)).toEqual(prettyFormat(defaultConfig));
   });
 
+  it('does not inject projectRoot into watchFolders when called with a third `false` argument', async () => {
+    cosmiconfig.setReturnNull(true);
+
+    const result = await loadConfig(
+      {cwd: process.cwd()},
+      {watchFolders: undefined},
+      false,
+    );
+    const defaultConfig = {
+      ...(await getDefaultConfig(process.cwd())),
+      watchFolders: undefined,
+    };
+    expect(prettyFormat(result)).toEqual(prettyFormat(defaultConfig));
+  });
+
   it('validates config for server', async () => {
     expect.assertions(1);
     const config = (defaultConfig: any) => ({

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -290,13 +290,15 @@ function overrideConfigWithArguments(
 
 /**
  * Load the metro configuration from disk
- * @param  {object} argv                    Arguments coming from the CLI, can be empty
- * @param  {object} defaultConfigOverrides  A configuration that can override the default config
- * @return {object}                         Configuration returned
+ * @param  {object}  argv                           Arguments coming from the CLI, can be empty
+ * @param  {object}  defaultConfigOverrides         A configuration that can override the default config
+ * @param  {boolean} injectProjectRootAsWatchFolder Will ensure `projectRoot` is present in the `watchFolders`
+ * @return {object}                                 Configuration returned
  */
 async function loadConfig(
   argvInput?: YargArguments = {},
   defaultConfigOverrides?: InputConfigT = {},
+  injectProjectRootAsWatchFolder?: boolean = true,
 ): Promise<ConfigT> {
   const argv = {...argvInput, config: overrideArgument(argvInput.config)};
 
@@ -321,10 +323,12 @@ async function loadConfig(
 
   const overriddenConfig: {[string]: mixed} = {};
 
-  overriddenConfig.watchFolders = [
-    configWithArgs.projectRoot,
-    ...configWithArgs.watchFolders,
-  ];
+  if (injectProjectRootAsWatchFolder) {
+    overriddenConfig.watchFolders = [
+      configWithArgs.projectRoot,
+      ...(configWithArgs.watchFolders ?? []),
+    ];
+  }
 
   // Set the watchfolders to include the projectRoot, as Metro assumes that is
   // the case


### PR DESCRIPTION
## Summary

As per https://github.com/facebook/react-native/pull/41967#discussion_r1475235748 I would like to expose a way to disable the code path which overrides the `watchFolders` to be able to detect if the user provided a value for it, or not.

## Test plan

I added a test to verify the expected behaviour:

https://github.com/kraenhansen/metro/blob/e6de60117ea1e099cb417131d57de52250338ca2/packages/metro-config/src/__tests__/loadConfig-test.js#L169-L182