### PR TITLE
Improve fast_path.resolve correctness and performance

### DIFF
--- a/packages/metro-file-map/src/lib/__tests__/fast_path-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/fast_path-test.js
@@ -68,6 +68,8 @@ describe.each([['win32'], ['posix']])('fast_path on %s', platform => {
     );
 
     test.each([
+      p('..'),
+      p('../..'),
       p('normal/path'),
       p('../normal/path'),
       p('../../normal/path'),


### PR DESCRIPTION
## Correctness
Fixes a bug in `fastPath.resolve` where paths ending in `/..` would not collapse preceding segments, eg `resolve('/project/root', '../..')` would return `/project/..` rather than `/`.

This came up when implementing incremental resolution support - we end up resolving canonical paths like this during lookup of first missing directory nodes. The correctness fix is changelog-internal because Metro doesn't currently call `resolve` with paths like these, and this API isn't public.

## Performance
In implementing this, I've also squeezed out a bit more performance so that `fast_path.resolve` is now about 1.6x faster than before this diff and 20x faster than `path.resolve` for repeated calls with the same root. This is significant because it actually dominates `getRealPath`, which is called hundreds of thousands of times during module resolution on a typical graph. Zoomed out benchmarks to follow in the stack.

## Benchmarks
Calling `resolve` 2m times on different, representative (FB internal) paths per sample.
```
┌─────────┬───────────┬─────────┬───────────────────┬──────────┬─────────┐
│ (index) │ Task Name │ ops/sec │ Average Time (ns) │ Margin   │ Samples │
├─────────┼───────────┼─────────┼───────────────────┼──────────┼─────────┤
│ 0       │ 'new'     │ '16'    │ 61555575.15459959 │ '±0.26%' │ 488     │
│ 1       │ 'old'     │ '10'    │ 99607323.81785941 │ '±0.32%' │ 302     │
│ 2       │ 'system'  │ '0'     │ 1472189198.380425 │ '±0.73%' │ 21      │
└─────────┴───────────┴─────────┴───────────────────┴──────────┴─────────┘
```

Changelog: 
```
**[Performance]:** Improve resolution performance by optimising normal->absolute path conversion.
```

Reviewed By: motiz88

Differential Revision: D52464135


