### PR TITLE
Improve pathUtils.absoluteToNormal correctness and performance

### DIFF
--- a/packages/metro-file-map/src/lib/MockMap.js
+++ b/packages/metro-file-map/src/lib/MockMap.js
@@ -11,19 +11,21 @@
 
 import type {MockMap as IMockMap, Path, RawMockMap} from '../flow-types';
 
-import {resolve} from './fast_path';
+import {RootPathUtils} from './RootPathUtils';
 
 export default class MockMap implements IMockMap {
   +#raw: RawMockMap;
   +#rootDir: Path;
+  +#pathUtils: RootPathUtils;
 
   constructor({rawMockMap, rootDir}: {rawMockMap: RawMockMap, rootDir: Path}) {
     this.#raw = rawMockMap;
     this.#rootDir = rootDir;
+    this.#pathUtils = new RootPathUtils(rootDir);
   }
 
   getMockModule(name: string): ?Path {
     const mockPath = this.#raw.get(name) || this.#raw.get(name + '/index');
-    return mockPath != null ? resolve(this.#rootDir, mockPath) : null;
+    return mockPath != null ? this.#pathUtils.normalToAbsolute(mockPath) : null;
   }
 }

--- a/packages/metro-file-map/src/lib/RootPathUtils.js
+++ b/packages/metro-file-map/src/lib/RootPathUtils.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+import * as path from 'path';
+
+const UP_FRAGMENT = '..' + path.sep;
+const UP_FRAGMENT_LENGTH = UP_FRAGMENT.length;
+const CURRENT_FRAGMENT = '.' + path.sep;
+
+export class RootPathUtils {
+  #rootDir: string;
+  #rootDirnamesCache: Array<string> = [];
+
+  constructor(rootDir: string) {
+    this.#rootDir = rootDir;
+  }
+
+  // absolutePath may be any well-formed absolute path.
+  absoluteToNormal(absolutePath: string): string {
+    if (absolutePath.indexOf(this.#rootDir + path.sep) === 0) {
+      const relativePath = absolutePath.substr(this.#rootDir.length + 1);
+      // Allow any sequence of indirection fragments at the start of the path,
+      // e.g ../../foo, but bail out to Node's path.relative if we find a
+      // possible indirection after any other segment, or a leading "./".
+      for (let i = 0; ; i += UP_FRAGMENT_LENGTH) {
+        const nextIndirection = relativePath.indexOf(CURRENT_FRAGMENT, i);
+        if (nextIndirection === -1) {
+          return relativePath;
+        }
+        if (
+          nextIndirection !== i + 1 || // Fallback when ./ later in the path, or leading
+          relativePath[i] !== '.' // and for anything other than a leading ../
+        ) {
+          return path.relative(this.#rootDir, absolutePath);
+        }
+      }
+    }
+    return path.relative(this.#rootDir, absolutePath);
+  }
+
+  // `normalPath` is assumed to be normal (root-relative, no redundant
+  // indirection), per the definition above.
+  normalToAbsolute(normalPath: string): string {
+    let left = this.#rootDir;
+    const rootDirnames = this.#rootDirnamesCache;
+    let i = 0;
+    let pos = 0;
+    while (
+      normalPath.startsWith(UP_FRAGMENT, pos) ||
+      (normalPath.endsWith('..') && normalPath.length === 2 + pos)
+    ) {
+      if (rootDirnames.length === i) {
+        rootDirnames.push(path.dirname(left));
+      }
+      left = rootDirnames[i++];
+      pos += UP_FRAGMENT_LENGTH;
+    }
+    const right = pos === 0 ? normalPath : normalPath.slice(pos);
+    if (right.length === 0) {
+      return left;
+    }
+    // left may already end in a path separator only if it is a filesystem root,
+    // '/' or 'X:\'.
+    if (left.endsWith(path.sep)) {
+      return left + right;
+    }
+    return left + path.sep + right;
+  }
+}

--- a/packages/metro-file-map/src/lib/RootPathUtils.js
+++ b/packages/metro-file-map/src/lib/RootPathUtils.js
@@ -10,56 +10,114 @@
 
 import * as path from 'path';
 
+/**
+ * This module provides path utility functions - similar to `node:path` -
+ * optimised for Metro's use case (many paths, few roots) under assumptions
+ * typically safe to make within Metro - namely:
+ *
+ *  - All input path separators must be system-native.
+ *  - Double/redundant separators like '/foo//bar' are not supported.
+ *  - All characters except separators are assumed to be valid in path segments.
+ *
+ *  - A "well-formed" path is any path following the rules above.
+ *  - A "normal" path is a root-relative well-formed path with no redundant
+ *    indirections. Normal paths have no leading './`, and the normal path of
+ *    the root is the empty string.
+ *
+ * Output and input paths are at least well-formed (normal where indicated by
+ * naming).
+ *
+ * As of Node 20, absoluteToNormal is ~8x faster than `path.relative` and
+ * `normalToAbsolute` is ~20x faster than `path.resolve`, benchmarked on the
+ * real inputs from building FB's product graph. Some well-formed inputs
+ * (e.g., /project/./foo/../bar), are handled but not optimised, and we fall
+ * back to `node:path` equivalents in those cases.
+ */
+
 const UP_FRAGMENT = '..' + path.sep;
 const UP_FRAGMENT_LENGTH = UP_FRAGMENT.length;
 const CURRENT_FRAGMENT = '.' + path.sep;
 
 export class RootPathUtils {
   #rootDir: string;
-  #rootDirnamesCache: Array<string> = [];
+  #rootDirnames: $ReadOnlyArray<string>;
+  #rootParts: $ReadOnlyArray<string>;
+  #rootDepth: number;
 
   constructor(rootDir: string) {
     this.#rootDir = rootDir;
+    const rootDirnames = [];
+    for (
+      let next = rootDir, previous = null;
+      previous !== next;
+      previous = next, next = path.dirname(next)
+    ) {
+      rootDirnames.push(next);
+    }
+    this.#rootDirnames = rootDirnames;
+
+    this.#rootParts = rootDir.split(path.sep);
+    this.#rootDepth = rootDirnames.length - 1;
+
+    // If rootDir is a filesystem root (C:\ or /), it will end in a separator and
+    // give a spurious empty entry at the end of rootParts.
+    if (this.#rootDepth === 0) {
+      this.#rootParts.pop();
+    }
   }
 
   // absolutePath may be any well-formed absolute path.
   absoluteToNormal(absolutePath: string): string {
-    if (absolutePath.indexOf(this.#rootDir + path.sep) === 0) {
-      const relativePath = absolutePath.substr(this.#rootDir.length + 1);
-      // Allow any sequence of indirection fragments at the start of the path,
-      // e.g ../../foo, but bail out to Node's path.relative if we find a
-      // possible indirection after any other segment, or a leading "./".
-      for (let i = 0; ; i += UP_FRAGMENT_LENGTH) {
-        const nextIndirection = relativePath.indexOf(CURRENT_FRAGMENT, i);
-        if (nextIndirection === -1) {
-          return relativePath;
-        }
-        if (
-          nextIndirection !== i + 1 || // Fallback when ./ later in the path, or leading
-          relativePath[i] !== '.' // and for anything other than a leading ../
-        ) {
-          return path.relative(this.#rootDir, absolutePath);
-        }
-      }
+    let endOfMatchingPrefix = 0;
+    let lastMatchingPartIdx = 0;
+
+    for (
+      let nextPart = this.#rootParts[0], nextLength = nextPart.length;
+      nextPart != null &&
+      // Check that absolutePath is equal to nextPart + '/' or ends with
+      // nextPart, starting from endOfMatchingPrefix.
+      absolutePath.startsWith(nextPart, endOfMatchingPrefix) &&
+      (absolutePath.length === endOfMatchingPrefix + nextLength ||
+        absolutePath[endOfMatchingPrefix + nextLength] === path.sep);
+
+    ) {
+      // Move our matching pointer forward and load the next part.
+      endOfMatchingPrefix += nextLength + 1;
+      nextPart = this.#rootParts[++lastMatchingPartIdx];
+      nextLength = nextPart?.length;
     }
-    return path.relative(this.#rootDir, absolutePath);
+
+    // If our root is /project/root and we're given /project/bar/foo.js, we
+    // have matched up to '/project', and will need to return a path
+    // beginning '../' (one prepended indirection, to go up from 'root').
+    //
+    // If we're given /project/../project2/otherroot, we have one level of
+    // indirection up to prepend in the same way as above. There's another
+    // explicit indirection already present in the input - we'll account for
+    // that in tryCollapseIndirectionsInSuffix.
+    const upIndirectionsToPrepend =
+      this.#rootParts.length - lastMatchingPartIdx;
+
+    return (
+      this.#tryCollapseIndirectionsInSuffix(
+        absolutePath,
+        endOfMatchingPrefix,
+        upIndirectionsToPrepend,
+      ) ?? path.relative(this.#rootDir, absolutePath)
+    );
   }
 
   // `normalPath` is assumed to be normal (root-relative, no redundant
   // indirection), per the definition above.
   normalToAbsolute(normalPath: string): string {
     let left = this.#rootDir;
-    const rootDirnames = this.#rootDirnamesCache;
     let i = 0;
     let pos = 0;
     while (
       normalPath.startsWith(UP_FRAGMENT, pos) ||
       (normalPath.endsWith('..') && normalPath.length === 2 + pos)
     ) {
-      if (rootDirnames.length === i) {
-        rootDirnames.push(path.dirname(left));
-      }
-      left = rootDirnames[i++];
+      left = this.#rootDirnames[i === this.#rootDepth ? this.#rootDepth : ++i];
       pos += UP_FRAGMENT_LENGTH;
     }
     const right = pos === 0 ? normalPath : normalPath.slice(pos);
@@ -68,9 +126,86 @@ export class RootPathUtils {
     }
     // left may already end in a path separator only if it is a filesystem root,
     // '/' or 'X:\'.
-    if (left.endsWith(path.sep)) {
+    if (i === this.#rootDepth) {
       return left + right;
     }
     return left + path.sep + right;
+  }
+
+  relativeToNormal(relativePath: string): string {
+    return (
+      this.#tryCollapseIndirectionsInSuffix(relativePath, 0, 0) ??
+      path.relative(this.#rootDir, path.join(this.#rootDir, relativePath))
+    );
+  }
+
+  // Internal: Tries to collapse sequences like `../root/foo` for root
+  // `/project/root` down to the normal 'foo'.
+  #tryCollapseIndirectionsInSuffix(
+    fullPath: string, // A string ending with the relative path to process
+    startOfRelativePart: number, // Index of the start of part to process
+    implicitUpIndirections: number, // 0=root-relative, 1=dirname(root)-relative...
+  ): ?string {
+    let totalUpIndirections = implicitUpIndirections;
+    // Allow any sequence of indirection fragments at the start of the
+    // unmatched suffix e.g /project/[../../foo], but bail out to Node's
+    // path.relative if we find a possible indirection after any later segment,
+    // or on any "./" that isn't a "../".
+    for (let pos = startOfRelativePart; ; pos += UP_FRAGMENT_LENGTH) {
+      const nextIndirection = fullPath.indexOf(CURRENT_FRAGMENT, pos);
+      if (nextIndirection === -1) {
+        // If we have any indirections, they may "collapse" if a subsequent
+        // segment re-enters a directory we had previously exited, e.g:
+        // /project/root/../root/foo should collapse to /project/root/foo' and
+        // return foo, not ../root/foo.
+        //
+        // We match each segment following redirections, in turn, against the
+        // part of the root path they may collapse into, and break on the first
+        // mismatch.
+        while (totalUpIndirections > 0) {
+          const segmentToMaybeCollapse =
+            this.#rootParts[this.#rootParts.length - totalUpIndirections];
+          if (
+            fullPath.startsWith(segmentToMaybeCollapse, pos) &&
+            // The following character should be either a separator or end of
+            // string
+            (fullPath.length === segmentToMaybeCollapse.length + pos ||
+              fullPath[segmentToMaybeCollapse.length + pos] === path.sep)
+          ) {
+            pos += segmentToMaybeCollapse.length + 1;
+            totalUpIndirections--;
+          } else {
+            break;
+          }
+        }
+        const right = fullPath.slice(pos);
+        if (
+          right === '' ||
+          (right === '..' && totalUpIndirections >= this.#rootParts.length - 1)
+        ) {
+          // If we have no right side (or an indirection that would take us
+          // below the root), just ensure we don't include a trailing separtor.
+          return UP_FRAGMENT.repeat(totalUpIndirections).slice(0, -1);
+        }
+        // Optimisation for the common case, saves a concatenation.
+        if (totalUpIndirections === 0) {
+          return right;
+        }
+        return UP_FRAGMENT.repeat(totalUpIndirections) + right;
+      }
+
+      // Cap the number of indirections at the total number of root segments.
+      // File systems treat '..' at the root as '.'.
+      if (totalUpIndirections < this.#rootParts.length - 1) {
+        totalUpIndirections++;
+      }
+
+      if (
+        nextIndirection !== pos + 1 || // Fallback when ./ later in the path, or leading
+        fullPath[pos] !== '.' // and for anything other than a leading ../
+      ) {
+        return null;
+      }
+    }
   }
 }

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -463,7 +463,7 @@ export default class TreeFS implements MutableFileSystem {
   _normalizePath(relativeOrAbsolutePath: Path): string {
     return path.isAbsolute(relativeOrAbsolutePath)
       ? this.#pathUtils.absoluteToNormal(relativeOrAbsolutePath)
-      : path.normalize(relativeOrAbsolutePath);
+      : this.#pathUtils.relativeToNormal(relativeOrAbsolutePath);
   }
 
   /**

--- a/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
@@ -37,6 +37,16 @@ describe.each([['win32'], ['posix']])('pathUtilsForRoot on %s', platform => {
     p('/project/root/baz/foobar'),
     p('/project/root/../root2/foobar'),
     p('/project/root/../../project2/foo'),
+    p('/project/root/../../project/foo'),
+    p('/project/root/../../project/root'),
+    p('/project/root/../../project/root/foo.js'),
+    p('/project/bar'),
+    p('/project/../outside/bar'),
+    p('/project/baz/foobar'),
+    p('/project/rootfoo/baz'),
+    p('/project'),
+    p('/'),
+    p('/outside'),
   ])(`absoluteToNormal('%s') is correct and optimised`, normalPath => {
     const rootDir = p('/project/root');
     pathUtils = new RootPathUtils(rootDir);
@@ -54,8 +64,6 @@ describe.each([['win32'], ['posix']])('pathUtilsForRoot on %s', platform => {
 
     test.each([
       p('/project/root/../root2/../root3/foo'),
-      p('/project/baz/foobar'),
-      p('/project/rootfoo/baz'),
       p('/project/root/./baz/foo/bar'),
       p('/project/root/a./../foo'),
       p('/project/root/../a./foo'),
@@ -79,5 +87,25 @@ describe.each([['win32'], ['posix']])('pathUtilsForRoot on %s', platform => {
         mockPathModule.resolve(rootDir, normalPath),
       );
     });
+
+    test.each([
+      p('..'),
+      p('../root'),
+      p('../root/path'),
+      p('../project'),
+      p('../../project/root'),
+      p('../../../normal/path'),
+      p('../../..'),
+    ])(
+      `relativeToNormal('%s') matches path.resolve + path.relative`,
+      relativePath => {
+        expect(pathUtils.relativeToNormal(relativePath)).toEqual(
+          mockPathModule.relative(
+            rootDir,
+            mockPathModule.resolve(rootDir, relativePath),
+          ),
+        );
+      },
+    );
   });
 });

--- a/packages/metro-file-map/src/lib/__tests__/fast_path-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/fast_path-test.js
@@ -68,6 +68,8 @@ describe.each([['win32'], ['posix']])('fast_path on %s', platform => {
     );
 
     test.each([
+      p('..'),
+      p('../..'),
       p('normal/path'),
       p('../normal/path'),
       p('../../normal/path'),

--- a/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
+++ b/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
@@ -11,8 +11,8 @@
 
 import type {BuildParameters} from '../flow-types';
 
-import * as fastPath from './fast_path';
 import normalizePathSeparatorsToPosix from './normalizePathSeparatorsToPosix';
+import {RootPathUtils} from './RootPathUtils';
 import {createHash} from 'crypto';
 
 function moduleCacheKey(modulePath: ?string) {
@@ -41,6 +41,7 @@ export default function rootRelativeCacheKeys(
   const rootDirHash = createHash('md5')
     .update(normalizePathSeparatorsToPosix(rootDir))
     .digest('hex');
+  const pathUtils = new RootPathUtils(rootDir);
 
   const cacheComponents = Object.keys(otherParameters)
     .sort()
@@ -48,7 +49,7 @@ export default function rootRelativeCacheKeys(
       switch (key) {
         case 'roots':
           return buildParameters[key].map(root =>
-            normalizePathSeparatorsToPosix(fastPath.relative(rootDir, root)),
+            normalizePathSeparatorsToPosix(pathUtils.absoluteToNormal(root)),
           );
         case 'cacheBreaker':
         case 'extensions':


### PR DESCRIPTION
Summary:
## Correctness
Fix a correctness issue in `pathUtils.absoluteToNormal` where the returned paths would not be fully normalised relative to the root - e.g. an input of `/project/root/../root/foo` would return `../root/foo` instead of `foo`.

## Performance
This rewrite also increases the set of paths `absoluteToNormal` is able to optimise for, beyond just those beginning with the full project root - absolute paths outside the project root are typical in monorepo setups.

Now, given a mix of absolute paths within and outside the project root, `absoluteToNormal` is >8x faster than the equivalent `path.relative` and 4x faster than before this diff.

This is called whenever `TreeFS` checks the existence of a file by absolute path (the typical case) during resolution, and accounts for more than half the time taken to return whether the file exists in the file map.

(Some of the code here is a little arcane for low-level performance - apologies!)

## Benchmarks

```
$ node bench3
Correctness check passed
Comparing absoluteToNormal with fastPath across 2116232 existence checks performed by js1 build buckfiles resolution
┌─────────┬────────────────────────────────┬─────────┬────────────────────┬──────────┬─────────┬─────────────┐
│ (index) │ Task Name                      │ ops/sec │ Average Time (ns)  │ Margin   │ Samples │ Comparison  │
├─────────┼────────────────────────────────┼─────────┼────────────────────┼──────────┼─────────┼─────────────┤
│ 0       │ 'path.relative()'              │ '0'     │ 2879838924.896717  │ '±1.92%' │ 10      │ '1x (base)' │
│ 1       │ 'fastPath.relative()'          │ '0'     │ 1595209724.8077393 │ '±1.26%' │ 10      │ '1.8x'      │
│ 2       │ 'pathUtils.absoluteToNormal()' │ '2'     │ 348316470.78990936 │ '±1.60%' │ 10      │ '8.3x'      │
└─────────┴────────────────────────────────┴─────────┴────────────────────┴──────────┴─────────┴─────────────┘
```

Changelog: 
```
**[Performance]:** Improve resolution performance for watched files outside `projectRoot`.
```

Reviewed By: motiz88

Differential Revision: D52513808


