### PR TITLE
TreeFS: Refactor internal non-existence null -> {exists:false}

### DIFF
--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -190,7 +190,7 @@ export default class TreeFS implements MutableFileSystem {
   }>): Iterable<Path> {
     const normalRoot = rootDir == null ? '' : this._normalizePath(rootDir);
     const contextRootResult = this._lookupByNormalPath(normalRoot);
-    if (!contextRootResult) {
+    if (!contextRootResult.exists) {
       return;
     }
     const {canonicalPath: rootRealPath, node: contextRoot} = contextRootResult;
@@ -243,7 +243,7 @@ export default class TreeFS implements MutableFileSystem {
   getRealPath(mixedPath: Path): ?string {
     const normalPath = this._normalizePath(mixedPath);
     const result = this._lookupByNormalPath(normalPath, {followLeaf: true});
-    if (!result || result.node instanceof Map) {
+    if (!result || !result.exists || result.node instanceof Map) {
       return null;
     }
     return this.#pathUtils.normalToAbsolute(result.canonicalPath);
@@ -256,7 +256,7 @@ export default class TreeFS implements MutableFileSystem {
     const parentDirNode = this._lookupByNormalPath(path.dirname(normalPath), {
       makeDirectories: true,
     });
-    if (!parentDirNode) {
+    if (!parentDirNode.exists) {
       throw new Error(
         `TreeFS: Failed to make parent directory entry for ${mixedPath}`,
       );
@@ -289,7 +289,8 @@ export default class TreeFS implements MutableFileSystem {
         });
         if (!(lookup?.node instanceof Map)) {
           throw new Error(
-            `TreeFS: Could not add directory ${dirname} when adding files`,
+            `TreeFS: Could not add directory ${dirname}, adding ${normalPath}. ` +
+              `${dirname} already exists in the file map as a file.`,
           );
         }
         lastDir = dirname;
@@ -302,7 +303,7 @@ export default class TreeFS implements MutableFileSystem {
   remove(mixedPath: Path): ?FileMetaData {
     const normalPath = this._normalizePath(mixedPath);
     const result = this._lookupByNormalPath(normalPath, {followLeaf: false});
-    if (!result) {
+    if (!result.exists) {
       return null;
     }
     const {parentNode, canonicalPath, node} = result;
@@ -330,10 +331,20 @@ export default class TreeFS implements MutableFileSystem {
       followLeaf?: boolean,
       makeDirectories?: boolean,
     } = {followLeaf: true, makeDirectories: false},
-  ): ?(
-    | {canonicalPath: string, node: MixedNode, parentNode: DirectoryNode}
-    | {canonicalPath: string, node: DirectoryNode, parentNode: null}
-  ) {
+  ):
+    | {
+        canonicalPath: string,
+        exists: true,
+        node: MixedNode,
+        parentNode: DirectoryNode,
+      }
+    | {
+        canonicalPath: string,
+        exists: true,
+        node: DirectoryNode,
+        parentNode: null,
+      }
+    | {exists: false} {
     // We'll update the target if we hit a symlink.
     let targetNormalPath = requestedNormalPath;
     // Lazy-initialised set of seen target paths, to detect symlink cycles.
@@ -359,7 +370,9 @@ export default class TreeFS implements MutableFileSystem {
       let segmentNode = parentNode.get(segmentName);
       if (segmentNode == null) {
         if (opts.makeDirectories !== true) {
-          return null;
+          return {
+            exists: false,
+          };
         }
         segmentNode = new Map();
         parentNode.set(segmentName, segmentNode);
@@ -375,6 +388,7 @@ export default class TreeFS implements MutableFileSystem {
       ) {
         return {
           canonicalPath: targetNormalPath,
+          exists: true,
           node: segmentNode,
           parentNode,
         };
@@ -386,7 +400,7 @@ export default class TreeFS implements MutableFileSystem {
       } else {
         if (segmentNode[H.SYMLINK] === 0) {
           // Regular file in a directory path
-          return null;
+          return {exists: false};
         }
 
         // Symlink in a directory path
@@ -408,7 +422,7 @@ export default class TreeFS implements MutableFileSystem {
         }
         if (seen.has(targetNormalPath)) {
           // TODO: Warn `Symlink cycle detected: ${[...seen, node].join(' -> ')}`
-          return null;
+          return {exists: false};
         }
         seen.add(targetNormalPath);
         fromIdx = 0;
@@ -418,6 +432,7 @@ export default class TreeFS implements MutableFileSystem {
     invariant(parentNode === this.#rootNode, 'Unexpectedly escaped traversal');
     return {
       canonicalPath: targetNormalPath,
+      exists: true,
       node: this.#rootNode,
       parentNode: null,
     };
@@ -517,7 +532,7 @@ export default class TreeFS implements MutableFileSystem {
           const resolved = this._lookupByNormalPath(normalPathOfSymlink, {
             followLeaf: true,
           });
-          if (resolved == null) {
+          if (!resolved.exists) {
             // Symlink goes nowhere, nothing to report.
             continue;
           }
@@ -579,7 +594,7 @@ export default class TreeFS implements MutableFileSystem {
     const result = this._lookupByNormalPath(normalPath, {
       followLeaf: opts.followLeaf,
     });
-    if (result == null || result.node instanceof Map) {
+    if (!result.exists || result.node instanceof Map) {
       return null;
     }
     return result.node;


### PR DESCRIPTION
Summary:
Minor internal refactor of `TreeFS`'s internal `_lookupByNormalPath` to make room for additional information to be returned with non-existence, by representing non-existence as `{ exists: false }` rather than `null`.

This isn't useful in isolation but I've separated it from the subsequent stack for ease of review.

Changelog: Internal

Reviewed By: huntie

Differential Revision: D52255863


