### PR TITLE
FileSystem: Replace getRealPath with lookup - allow for extended information

### DIFF
--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -175,7 +175,6 @@ export interface FileSystem {
     removedFiles: Set<string>,
   };
   getModuleName(file: Path): ?string;
-  getRealPath(file: Path): ?string;
   getSerializableSnapshot(): CacheData['fileSystemData'];
   getSha1(file: Path): ?string;
 
@@ -184,6 +183,12 @@ export interface FileSystem {
    * information about the symlink without following it.
    */
   linkStats(file: Path): ?FileStats;
+
+  /**
+   * Return information about the given path, whether a directory or file.
+   * Always follow symlinks, and return a real path if it exists.
+   */
+  lookup(mixedPath: Path): LookupResult;
 
   matchFiles(opts: {
     /* Filter relative paths against a pattern. */
@@ -202,6 +207,12 @@ export interface FileSystem {
 }
 
 export type Glob = string;
+
+export type LookupResult =
+  | {
+      exists: false,
+    }
+  | {exists: true, realPath: string, type: 'd' | 'f' | 'l'};
 
 export interface MockMap {
   getMockModule(name: string): ?Path;

--- a/packages/metro-resolver/types/index.d.ts
+++ b/packages/metro-resolver/types/index.d.ts
@@ -10,7 +10,7 @@
 
 export * from './types';
 
-import {ResolutionContext, Resolution} from './types';
+import {Resolution, ResolutionContext} from './types';
 
 export function resolve(
   context: ResolutionContext,

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -180,6 +180,11 @@ class DependencyGraph extends EventEmitter {
   }
 
   _createModuleResolver() {
+    const getRealPathIfFile = (path: string) => {
+      const result = this._fileSystem.lookup(path);
+      return result.exists && result.type === 'f' ? result.realPath : null;
+    };
+
     this._moduleResolver = new ModuleResolver({
       assetExts: new Set(this._config.resolver.assetExts),
       dirExists: (filePath: string) => {
@@ -213,9 +218,7 @@ class DependencyGraph extends EventEmitter {
         ];
 
         if (this._config.resolver.unstable_enableSymlinks) {
-          assets = assets
-            .map(candidate => this._fileSystem.getRealPath(candidate))
-            .filter(Boolean);
+          assets = assets.map(getRealPathIfFile).filter(Boolean);
         } else {
           assets = assets.filter(candidate =>
             this._fileSystem.exists(candidate),
@@ -232,7 +235,7 @@ class DependencyGraph extends EventEmitter {
       unstable_enablePackageExports:
         this._config.resolver.unstable_enablePackageExports,
       unstable_getRealPath: this._config.resolver.unstable_enableSymlinks
-        ? path => this._fileSystem.getRealPath(path)
+        ? getRealPathIfFile
         : null,
     });
   }


### PR DESCRIPTION
Summary:
Implement `FileSystem.lookup()`, replacing `FileSystem.getRealPath()`, both internal APIs.

This is motivated by incremental resolution - in particular, we'll need to return more information from `TreeFS` in the context of resolution for both existence (which symlinks have been traversed that would invalidate a resolution if deleted) and non-existence (the first non-existent real path, and the symlinks traversed to get there), so we switch to an extensible object for both cases vs the current `?string`.

Changelog: Internal

Reviewed By: huntie

Differential Revision: D52390401


