### PR TITLE
TreeFS: Return traversed symlinks and first missing segments in lookup results

### DIFF
--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -210,9 +210,26 @@ export type Glob = string;
 
 export type LookupResult =
   | {
+      // The node is missing from the FileSystem implementation (note this
+      // could indicate an unwatched path, or a directory containing no watched
+      // files).
       exists: false,
+      // The real, normal, absolute paths of any symlinks traversed.
+      links: $ReadOnlySet<string>,
+      // The real, normal, absolute path of the first path segment
+      // encountered that does not exist, or cannot be navigated through.
+      missing: string,
     }
-  | {exists: true, realPath: string, type: 'd' | 'f' | 'l'};
+  | {
+      exists: true,
+      // The real, normal, absolute paths of any symlinks traversed.
+      links: $ReadOnlySet<string>,
+      // The real, normal, absolute path of the file or directory.
+      realPath: string,
+      // Currently lookup always follows symlinks, so can only return
+      // directories or regular files, but this may be extended.
+      type: 'd' | 'f',
+    };
 
 export interface MockMap {
   getMockModule(name: string): ?Path;


### PR DESCRIPTION
Summary:
A module resolution should be invalidated whenever the (non-)existence of a path checked during resolution may have changed. To implement this, we'll need more information from the `FileSystem` APIs.

## Existence
A positive existence check is straightforwardly invalidated when either:
 - The resolved `realPath` is deleted (we already watch for this), or
 - Any symlink traversed on the way to the real path is deleted or modified. We will need to track symlinks traversed by their real paths.

## Non-existence
For non-existence, note that it is not sufficient to simply watch for file events whose path matches the path originally looked up, because file events are emitted for real paths, and the checked path may resolve through one or more symlinks.

We will require:
 - The first missing *real* path segment encountered (because we can watch for additions at this path, but not necessarily any of its descendants, should a symlink be created at this path), *and*
 - The symlinks traversed to get to that first missing segment (because changes to these invalidate which real path we should watch for an addition).

## This diff
This adds `links`, the set of traversed links by their canonical paths, and `missing` (for non-existence) - the first non-navigable path segment by its canonical path.

Changelog: Internal

Reviewed By: huntie

Differential Revision: D52391404


