### PR TITLE
Update xplat/js/tools/metro Babel config to use `babel-plugin-syntax-hermes-parser`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,6 +19,7 @@ const fs = require('fs');
 import type {BabelCoreOptions} from '@babel/core';
 */
 const plugins = [
+  'babel-plugin-syntax-hermes-parser',
   '@babel/plugin-transform-flow-strip-types',
   '@babel/plugin-transform-modules-commonjs',
   '@babel/plugin-syntax-class-properties',

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@typescript-eslint/parser": "^6.7.4",
     "acorn": "^8.7.1",
     "babel-jest": "^29.6.3",
+    "babel-plugin-syntax-hermes-parser": "0.19.1",
     "chalk": "^4.0.0",
     "debug": "^2.2.0",
     "eslint": "^8.23.1",


### PR DESCRIPTION
Summary:
`babel-plugin-syntax-hermes-parser` allows us to use the latest Flow syntax.

After changes to the plugin SamZ made for version 0.18.1, it only applies to Flow files (leaving TS files to be parsed by Babel): https://github.com/facebook/hermes/blob/main/tools/hermes-parser/js/CHANGELOG.md#0181

Reviewed By: robhogan

Differential Revision: D53597388


