### PR TITLE
Convert the CircleCI workflow to a GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,87 @@
+name: facebook/metro/build-and-deploy
+on:
+  push:
+    branches:
+    - main
+jobs:
+  run-js-checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18.12
+        cache: yarn
+    - name: Install Dependencies
+      run: npm install --force flow-bin
+    - run: yarn typecheck
+    - run: yarn typecheck-ts
+    - run: yarn lint
+    - run: yarn test-smoke
+  test-with-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18.12
+        cache: yarn
+    - name: Install Dependencies
+      run: npm install --force @babel/core
+    - run: yarn test-coverage
+    - name: Download Codecov Uploader
+      run: "./.circleci/scripts/install_codecov.sh"
+    - name: Upload coverage results
+      run: "./codecov -t ${{ secrets.CODECOV_TOKEN }} -f ./coverage/coverage-final.json"
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 18.12, 20.2 ]
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm install --force --save-dev jest
+    - name: Run Jest tests
+      run: yarn jest --ci --maxWorkers 4 --reporters=default --reporters=jest-junit
+  test-windows:
+    if: startsWith(github.ref, 'refs/heads/windows/')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/upload-artifact@v4.0.0
+      with:
+        path: reports/
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18.12
+        cache: yarn
+    - name: Install Dependencies
+      run: npm install --force --save-dev jest
+    - name: Run Jest tests
+      run: yarn jest --ci --maxWorkers 4 --reporters=default --reporters=jest-junit
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18.12
+        cache: yarn
+    - name: Check Tag Format
+      id: check_tag
+      run: |
+        if [[ $GITHUB_REF =~ ^refs/tags/v\d+(\.\d+){2}(-.*)?$ ]]; then
+          echo "valid=true" >> $GITHUB_OUTPUT
+        else
+          echo "valid=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+    - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+    - name: Infer dist-tag and run npm run publish
+      if: steps.check_tag.outputs.valid == 'true'
+      run: "./.circleci/scripts/publish.sh"
+    - run: rm ~/.npmrc


### PR DESCRIPTION
## Summary

This pull request converts the CircleCI workflows to GitHub actions workflows. [Github Actions Importer](https://github.com/github/gh-actions-importer) was used to convert the workflows initially, then I edited them manually to correct errors in translation.

**Issues**

1. _facebook/metro/build-and-deploy -> test-with-coverage_

```
FAIL scripts/__tests__/babel-lib-defs-test.js
```

<details>
<summary style="list-style-type: none;">Full Error</summary>
<pre>
Summary of all failing tests
FAIL scripts/__tests__/babel-lib-defs-test.js
  ● Babel Flow library definitions should be up to date

    expect(received).toEqual(expected) // deep equality

    - Expected  - 9
    + Received  + 0

    @@ -898,13 +898,11 @@
          isImmutable(opts?: Opts): boolean;
          isImport(opts?: Opts): boolean;
          isImportAttribute(opts?: Opts): boolean;
          isImportDeclaration(opts?: Opts): boolean;
          isImportDefaultSpecifier(opts?: Opts): boolean;
    -     isImportExpression(opts?: Opts): boolean;
          isImportNamespaceSpecifier(opts?: Opts): boolean;
    -     isImportOrExportDeclaration(opts?: Opts): boolean;
          isImportSpecifier(opts?: Opts): boolean;
          isIndexedAccessType(opts?: Opts): boolean;
          isInferredPredicate(opts?: Opts): boolean;
          isInterfaceDeclaration(opts?: Opts): boolean;
          isInterfaceExtends(opts?: Opts): boolean;
    @@ -1215,13 +1213,11 @@
          assertImmutable(opts?: Opts): void;
          assertImport(opts?: Opts): void;
          assertImportAttribute(opts?: Opts): void;
          assertImportDeclaration(opts?: Opts): void;
          assertImportDefaultSpecifier(opts?: Opts): void;
    -     assertImportExpression(opts?: Opts): void;
          assertImportNamespaceSpecifier(opts?: Opts): void;
    -     assertImportOrExportDeclaration(opts?: Opts): void;
          assertImportSpecifier(opts?: Opts): void;
          assertIndexedAccessType(opts?: Opts): void;
          assertInferredPredicate(opts?: Opts): void;
          assertInterfaceDeclaration(opts?: Opts): void;
          assertInterfaceExtends(opts?: Opts): void;
    @@ -1573,17 +1569,12 @@
          Immutable?: VisitNode<BabelNodeImmutable, TState>,
          Import?: VisitNode<BabelNodeImport, TState>,
          ImportAttribute?: VisitNode<BabelNodeImportAttribute, TState>,
          ImportDeclaration?: VisitNode<BabelNodeImportDeclaration, TState>,
          ImportDefaultSpecifier?: VisitNode<BabelNodeImportDefaultSpecifier, TState>,
    -     ImportExpression?: VisitNode<BabelNodeImportExpression, TState>,
          ImportNamespaceSpecifier?: VisitNode<
            BabelNodeImportNamespaceSpecifier,
    -       TState,
    -     >,
    -     ImportOrExportDeclaration?: VisitNode<
    -       BabelNodeImportOrExportDeclaration,
            TState,
          >,
          ImportSpecifier?: VisitNode<BabelNodeImportSpecifier, TState>,
          IndexedAccessType?: VisitNode<BabelNodeIndexedAccessType, TState>,
          InferredPredicate?: VisitNode<BabelNodeInferredPredicate, TState>,

      20 |   expect(contentByFilePath.size).toBe(2);
      21 |   for (const [filePath, content] of contentByFilePath) {
    > 22 |     expect(await fsPromises.readFile(filePath, 'utf8')).toEqual(content);
         |                                                         ^
      23 |   }
      24 | });
      25 |

      at Object.toEqual (scripts/__tests__/babel-lib-defs-test.js:22:57)
</pre>
</details>

## How did you test this change?

I tested these changes in a [forked repo](https://github.com/robandpdx-org/metro/actions/runs/7921950858).

https://fburl.com/workplace/f6mz6tmw