### PR TITLE
fix(metro-resolver): package exports restricted paths

### DIFF
--- a/packages/metro-resolver/src/PackageExportsResolve.js
+++ b/packages/metro-resolver/src/PackageExportsResolve.js
@@ -376,8 +376,8 @@ function reduceConditionalExport(
     let match: typeof subpathValue | 'no-match';
 
     // when conditions are present and default is not specified
-    // the default condition is implictly set to null, to allow
-    // for resticting access to unexported internals of a package.
+    // the default condition is implicitly set to null, to allow
+    // for restricting access to unexported internals of a package.
     if ('default' in reducedValue) {
       match = 'no-match';
     } else {

--- a/packages/metro-resolver/src/PackageExportsResolve.js
+++ b/packages/metro-resolver/src/PackageExportsResolve.js
@@ -373,7 +373,16 @@ function reduceConditionalExport(
   let reducedValue = subpathValue;
 
   while (reducedValue != null && typeof reducedValue !== 'string') {
-    let match: typeof subpathValue | 'no-match' = 'no-match';
+    let match: typeof subpathValue | 'no-match';
+
+    // when conditions are present and default is not specified
+    // the default condition is implictly set to null, to allow
+    // for resticting access to unexported internals of a package.
+    if ('default' in reducedValue) {
+      match = 'no-match';
+    } else {
+      match = null;
+    }
 
     for (const conditionName in reducedValue) {
       if (conditionNames.has(conditionName)) {

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -539,10 +539,6 @@ describe('with package exports resolution enabled', () => {
           'test-pkg/features/foo.js.js',
           '/root/node_modules/test-pkg/src/features/foo.js.js',
         ],
-        [
-          'test-pkg/features/bar/Bar.js',
-          '/root/node_modules/test-pkg/src/features/bar/Bar.js',
-        ],
       ]) {
         expect(Resolver.resolve(baseContext, importSpecifier, null)).toEqual({
           type: 'sourceFile',
@@ -558,7 +554,13 @@ describe('with package exports resolution enabled', () => {
       ).toThrowError();
     });
 
-    test('should use most specific pattern base', () => {
+    test('should use the most specific pattern base - default condition', () => {
+      expect(() =>
+        Resolver.resolve(baseContext, 'test-pkg/features/bar/Bar.js', null),
+      ).toThrowError();
+    });
+
+    test('should use most specific pattern base - custom condition', () => {
       const context = {
         ...baseContext,
         unstable_conditionNames: ['react-native'],

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -554,7 +554,7 @@ describe('with package exports resolution enabled', () => {
       ).toThrowError();
     });
 
-    test('should use the most specific pattern base - default condition', () => {
+    test('should use the most specific pattern base - implicit default condition', () => {
       expect(() =>
         Resolver.resolve(baseContext, 'test-pkg/features/bar/Bar.js', null),
       ).toThrowError();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This PR deals with restricting internal paths through the most specific subpath pattern edge case from #1236 

- [x] - added test for implicit default condition to match Node.js resolution algorithm
- [x] - aligned implementation of `reduceConditionalExport` to account for implicit default condition

Changelog: [Experimental] Fix implicit default condition to be `null` for subpath patterns (edge case)

## Test plan
- [x] - all tests pass
