### PR TITLE
refactor(metro-resolver): more descriptive assertions in should resolve exports target directly tests

### DIFF
--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -115,6 +115,7 @@ describe('with package exports resolution enabled', () => {
           '/root/node_modules/test-pkg/package.json': '',
           '/root/node_modules/test-pkg/index.js': '',
           '/root/node_modules/test-pkg/index-main.js': '',
+          '/root/node_modules/test-pkg/index-exports.js': '',
           '/root/node_modules/test-pkg/index-exports.js.js': '',
           '/root/node_modules/test-pkg/index-exports.ios.js': '',
           '/root/node_modules/test-pkg/symlink.js': {
@@ -225,14 +226,14 @@ describe('with package exports resolution enabled', () => {
       test('without expanding `sourceExts`', () => {
         expect(Resolver.resolve(context, 'test-pkg', null)).toEqual({
           type: 'sourceFile',
-          filePath: '/root/node_modules/test-pkg/index-main.js',
+          filePath: '/root/node_modules/test-pkg/index-exports.js',
         });
       });
 
       test('without expanding platform-specific extensions', () => {
         expect(Resolver.resolve(context, 'test-pkg', 'ios')).toEqual({
           type: 'sourceFile',
-          filePath: '/root/node_modules/test-pkg/index-main.js',
+          filePath: '/root/node_modules/test-pkg/index-exports.js',
         });
       });
 

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -115,7 +115,6 @@ describe('with package exports resolution enabled', () => {
           '/root/node_modules/test-pkg/package.json': '',
           '/root/node_modules/test-pkg/index.js': '',
           '/root/node_modules/test-pkg/index-main.js': '',
-          '/root/node_modules/test-pkg/index-exports.js': '',
           '/root/node_modules/test-pkg/index-exports.js.js': '',
           '/root/node_modules/test-pkg/index-exports.ios.js': '',
           '/root/node_modules/test-pkg/symlink.js': {
@@ -217,7 +216,6 @@ describe('with package exports resolution enabled', () => {
         ...baseContext,
         ...createPackageAccessors({
           '/root/node_modules/test-pkg/package.json': {
-            main: 'index-main.js',
             exports: './index-exports.js',
           },
         }),
@@ -226,14 +224,16 @@ describe('with package exports resolution enabled', () => {
       test('without expanding `sourceExts`', () => {
         expect(Resolver.resolve(context, 'test-pkg', null)).toEqual({
           type: 'sourceFile',
-          filePath: '/root/node_modules/test-pkg/index-exports.js',
+          // [nonstrict] Falls back to index.js based on file resolution
+          filePath: '/root/node_modules/test-pkg/index.js',
         });
       });
 
       test('without expanding platform-specific extensions', () => {
         expect(Resolver.resolve(context, 'test-pkg', 'ios')).toEqual({
           type: 'sourceFile',
-          filePath: '/root/node_modules/test-pkg/index-exports.js',
+          // [nonstrict] Falls back to index.js based on file resolution
+          filePath: '/root/node_modules/test-pkg/index.js',
         });
       });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This PR adds comments to assertions in tests that check that neither `sourceExts` or `platformExts` are expanded when matching exports target directly, which was suggested inside of #1236 by @huntie. The assertions rely on using `[nonstrict]` fallback mechanism as there is no other way to test this functionality right now because `strict` mode is not implemented.

Changelog: [Internal] Refactor Package Exports `sourceExts` and `platformExts` tests that rely on fallback

## Test plan
- [x] - all tests pass
