### PR TITLE
fix metro-file-map spamming watchman warnings

### DIFF
--- a/packages/metro-file-map/src/watchers/RecrawlWarning.js
+++ b/packages/metro-file-map/src/watchers/RecrawlWarning.js
@@ -19,7 +19,7 @@
 export default class RecrawlWarning {
   static RECRAWL_WARNINGS: Array<RecrawlWarning> = [];
   static REGEXP: RegExp =
-    /Recrawled this watch (\d+) times, most recently because:\n([^:]+)/;
+    /Recrawled this watch (\d+) times?, most recently because:\n([^:]+)/;
 
   root: string;
   count: number;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Metro file map attempts to dedupe warnings but it doesn't correctly match against the message and instead throws all of them at once.

<img width="914" alt="Screenshot 2024-04-25 at 2 57 54 PM" src="https://github.com/facebook/metro/assets/9664363/e4d04674-c17e-4187-8384-8c0bbecc5ded">

This PR accounts for when there's only recrawled file to fix deduping


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog:

  Changelog: [Fix] watchman crawl warnings dedupe correctly now


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
