### PR TITLE
fix: template literal syntax in error handling for asset file paths

### DIFF
--- a/packages/metro/src/node-haste/lib/AssetPaths.js
+++ b/packages/metro/src/node-haste/lib/AssetPaths.js
@@ -69,7 +69,7 @@ function tryParse(
 function parse(filePath: string, platforms: $ReadOnlySet<string>): AssetPath {
   const result = tryParse(filePath, platforms);
   if (result == null) {
-    throw new Error('invalid asset file path: `${filePath}');
+    throw new Error(`invalid asset file path: ${filePath}`);
   }
   return result;
 }


### PR DESCRIPTION
This is a PR that solves [issue 1265](https://github.com/facebook/metro/issues/1265).

## Summary

This pull request corrects a syntax error in the template literal used for handling error messages regarding asset file paths within Metro. The existing implementation failed to properly format the file path in the error message. This change updates the syntax to correctly embed the file path variable into the error message.

Changelog: [Fix] Correct template literal syntax in error handling for asset file paths.

## Test plan

To verify the correction, I conducted the following steps:

1. Triggered the error handling code with an incorrect asset file path to ensure the error message **includes the intended file path**. 
2. Reviewed the output to confirm the file path is now **correctly formatted** within the error message.
