### PR TITLE
Add server_listening reporter event with actually-bound port and address

### DIFF
--- a/packages/metro/src/index.flow.js
+++ b/packages/metro/src/index.flow.js
@@ -309,6 +309,14 @@ exports.runServer = async (
       });
 
       httpServer.listen(config.server.port, host, () => {
+        const {address, port, family} = httpServer.address();
+        config.reporter.update({
+          type: 'server_listening',
+          address,
+          port, // Assigned port if configured with port 0
+          family,
+        });
+
         if (onReady) {
           onReady(httpServer);
         }

--- a/packages/metro/src/lib/reporting.js
+++ b/packages/metro/src/lib/reporting.js
@@ -133,6 +133,12 @@ export type ReportableEvent =
       message: string,
     }
   | {
+      type: 'server_listening',
+      port: number,
+      address: string,
+      family: string,
+    }
+  | {
       type: 'transformer_load_started',
     }
   | {

--- a/packages/metro/types/lib/reporting.d.ts
+++ b/packages/metro/types/lib/reporting.d.ts
@@ -97,6 +97,12 @@ export type ReportableEvent =
       data: unknown[];
     }
   | {
+      type: 'server_listening';
+      port: number;
+      address: string;
+      family: string;
+    }
+  | {
       type: 'transformer_load_started';
     }
   | {


### PR DESCRIPTION
## Summary
Add a `server_listening` reporter event. This serves two purposes:

### Expose actually-bound port and address when input configuration is more ambiguous
Metro may already be configured to start on an ephemeral (OS-assigned) port, if configured with `--port 0`, however Metro doesn't report or expose which port was actually assigned - the `initialize_done` reporter event repeats the configured port.

(h/t @kmagiera who let us know about this at React Conf ⚛️)

Similarly, when Metro is configured to start on `localhost`, it doesn't expose whether it binds to IPv6 (potentially dual stack) or (exclusively) IPv4.

### Report when Metro is first ready to accept HTTP requests
Metro may be listening before the transformer is fully initialised or the file crawl is complete - but this is safe, because request handlers wait for bundler readiness. We may in future start listening earlier in the startup process so that Metro is available to at least start queueing requests as soon as possible. 

Integrators may use `server_listening` as an explicit signal that Metro is ready to accept http requests, even though it may not be fully warm.

## Changelog
```
 - **[Feature]**: Add `server_listening` reporter event, exposing bound port, address and family.
```

## Test plan

With `console.log(event)` added to `TerminalReporter` for `server_listening`:

```
yarn start serve --port 0
yarn run v1.22.19
$ node packages/metro/src/cli serve --port 0

                        ▒▒▓▓▓▓▒▒
                     ▒▓▓▓▒▒░░▒▒▓▓▓▒
                  ▒▓▓▓▓░░░▒▒▒▒░░░▓▓▓▓▒
                 ▓▓▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒▓▓
                 ▓▓░░░░░▒▓▓▓▓▓▓▒░░░░░▓▓
                 ▓▓░░▓▓▒░░░▒▒░░░▒▓▒░░▓▓
                 ▓▓░░▓▓▓▓▓▒▒▒▒▓▓▓▓▒░░▓▓
                 ▓▓░░▓▓▓▓▓▓▓▓▓▓▓▓▓▒░░▓▓
                 ▓▓▒░░▒▒▓▓▓▓▓▓▓▓▒░░░▒▓▓
                  ▒▓▓▓▒░░░▒▓▓▒░░░▒▓▓▓▒
                     ▒▓▓▓▒░░░░▒▓▓▓▒
                        ▒▒▓▓▓▓▒▒


{
  type: 'server_listening',
  address: '::1',
  port: 57182,
  family: 'IPv6'
}
                Welcome to Metro v0.80.9
              Fast - Scalable - Integrated
```

