### PR TITLE
Fix recursive require.context when the context root is an ancestor of the project root

### DIFF
--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -225,6 +225,25 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         });
       },
     );
+
+    test('matchFiles follows links up', () => {
+      const matches = [
+        ...tfs.matchFiles({
+          rootDir: p('/project/foo'),
+          follow: true,
+          recursive: true,
+        }),
+      ];
+      expect(matches).toContain(
+        p('/project/foo/link-up-2/project/foo/another.js'),
+      );
+      // Only follow a symlink cycle once.
+      expect(matches).not.toContain(
+        p(
+          '/project/foo/link-up-2/project/foo/link-up-2/project/foo/another.js',
+        ),
+      );
+    });
   });
 
   describe('getDifference', () => {
@@ -312,6 +331,23 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       ).toEqual([p('/outside/external.js')]);
     });
 
+    test('ancestor of project root includes project root', () => {
+      expect(
+        Array.from(
+          tfs.matchFiles({
+            filter: new RegExp(
+              // Test starting with `./` since this is mandatory for parity with Webpack.
+              /^\.\/.*\/bar\.js/,
+            ),
+            filterComparePosix: true,
+            follow: true,
+            recursive: true,
+            rootDir: p('/'),
+          }),
+        ),
+      ).toEqual([p('/project/bar.js')]);
+    });
+
     test('recursive', () => {
       expect(
         Array.from(
@@ -337,6 +373,22 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         p('/project/link-to-foo/link-to-bar.js'),
         p('/project/link-to-foo/link-to-another.js'),
         p('/project/abs-link-out/external.js'),
+        p('/project/root/project/foo/another.js'),
+        p('/project/root/project/foo/owndir/another.js'),
+        p('/project/root/project/foo/owndir/link-to-bar.js'),
+        p('/project/root/project/foo/owndir/link-to-another.js'),
+        p('/project/root/project/foo/link-to-bar.js'),
+        p('/project/root/project/foo/link-to-another.js'),
+        p('/project/root/project/bar.js'),
+        p('/project/root/project/link-to-foo/another.js'),
+        p('/project/root/project/link-to-foo/owndir/another.js'),
+        p('/project/root/project/link-to-foo/owndir/link-to-bar.js'),
+        p('/project/root/project/link-to-foo/owndir/link-to-another.js'),
+        p('/project/root/project/link-to-foo/link-to-bar.js'),
+        p('/project/root/project/link-to-foo/link-to-another.js'),
+        p('/project/root/project/abs-link-out/external.js'),
+        p('/project/root/project/node_modules/pkg/a.js'),
+        p('/project/root/project/node_modules/pkg/package.json'),
         p('/project/root/outside/external.js'),
         p('/project/node_modules/pkg/a.js'),
         p('/project/node_modules/pkg/package.json'),
@@ -379,6 +431,10 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         p('/project/foo/owndir/another.js'),
         p('/project/link-to-foo/another.js'),
         p('/project/link-to-foo/owndir/another.js'),
+        p('/project/root/project/foo/another.js'),
+        p('/project/root/project/foo/owndir/another.js'),
+        p('/project/root/project/link-to-foo/another.js'),
+        p('/project/root/project/link-to-foo/owndir/another.js'),
       ]);
     });
 


### PR DESCRIPTION
Summary:
## Background
(Same as previous diff)

The internal implementation of `TreeFS` uses a tree of maps representing file path segments, with a "root" node at the *project root*. For paths outside the project root, we traverse through `'..'` nodes, so that `../outside` traverses from the project root through `'..'` and `'outside'`. Basing the representation around the project root (as opposed to a volume root) minimises traversal through irrelevant paths and makes the cache portable.

## Problem
However, because this map of maps is a simple (acyclic) tree, a `'..'` node has no entry for one of its logical (=on disk) children - the node closer to the project root. When (recursively) enumerating paths under an ancestor of the project root, the descendent part of the project root will be missing if we only enumerate entries of the Map.

## Observable bugs (in experimental features)
For enumerations we miss out (ancestors of) the project root where they should be included, eg `matchFiles('..', {recursive: true})` will not include the project root subtree. This is observable through the (experimental) `require.context()` API.

## This fix
`_lookupByNormalPath` now returns information on whether the returned node is an ancestor of the project root. `matchFiles` looks up the search root (context root, for `require.context()`), and uses the new `ancestorOfRootIdx` to potentially iterate over one extra node. This is a negligible constant-time increase in complexity for `_lookupByNormalPath` and `matchFiles`.

Changelog:
```
 - **[Experimental]**: Fix subtrees of the project root missed from `require.context` when using an ancestor of the project root as context root.
```

Reviewed By: huntie

Differential Revision: D57844039


