### PR TITLE
fix: apply custom serializer to source map endpoint in dev server

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -1153,6 +1153,55 @@ class Server {
         prepend = [];
       }
 
+      // If the project defines a custom serializer, then we should run it to ensure any
+      // mutations to the graph are applied in the sourcemap.
+      if (this._config.serializer.customSerializer) {
+        const bundle = await this._config.serializer.customSerializer(
+          entryFile,
+          prepend,
+          graph,
+          {
+            asyncRequireModulePath: await this._resolveRelativePath(
+              this._config.transformer.asyncRequireModulePath,
+              {
+                relativeTo: 'project',
+                resolverOptions,
+                transformOptions,
+              },
+            ),
+            processModuleFilter: this._config.serializer.processModuleFilter,
+            createModuleId: this._createModuleId,
+            getRunModuleStatement:
+              this._config.serializer.getRunModuleStatement,
+            includeAsyncPaths: graphOptions.lazy,
+            dev: transformOptions.dev,
+            projectRoot: this._config.projectRoot,
+            modulesOnly: serializerOptions.modulesOnly,
+            runBeforeMainModule:
+              this._config.serializer.getModulesRunBeforeMainModule(
+                path.relative(this._config.projectRoot, entryFile),
+              ),
+            runModule: serializerOptions.runModule,
+            sourceMapUrl: serializerOptions.sourceMapUrl,
+            sourceUrl: serializerOptions.sourceUrl,
+            inlineSourceMap: serializerOptions.inlineSourceMap,
+            serverRoot:
+              this._config.server.unstable_serverRoot ??
+              this._config.projectRoot,
+            shouldAddToIgnoreList: (module: Module<>) =>
+              this._shouldAddModuleToIgnoreList(module),
+            getSourceUrl: (module: Module<>) =>
+              this._getModuleSourceUrl(module, serializerOptions.sourcePaths),
+          },
+        );
+
+        // If the serializer returned the source map then we can use it here, otherwise
+        // fall back to the default source map generation with the possibly mutated graph.
+        if (typeof bundle !== 'string' && bundle.map) {
+          return bundle.map;
+        }
+      }
+
       return await sourceMapStringNonBlocking(
         [...prepend, ...this._getSortedModules(graph)],
         {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

- The source maps for Expo CLI are off by 1, but only in development. The cause is that source maps are generated differently between the server endpoint and the `build` function. In the Expo metro-config, we use the serializer to inject custom pre-modules for things like SSR and client-side environment variables. These changes aren't reflected in the source map endpoint.
- This PR addresses the differences by applying a custom serializer to the graph if one exists, and returning the map from the serializer if one is returned.
- The Expo CLI-side of this PR can be found here https://github.com/expo/expo/pull/29463

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Fix] Apply custom serializer to source map graph in `.map` endpoint.
