### PR TITLE
Resolver perf: Implement TreeFS.hierarchicalLookup for getClosestPackage (2/n)

### DIFF
--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -180,6 +180,42 @@ export interface FileSystem {
   getSha1(file: Path): ?string;
 
   /**
+   * Given a start path (which need not exist), a subpath and type, and
+   * optionally a 'breakOnSegment', performs the following:
+   *
+   * X = mixedStartPath
+   * do
+   *   if basename(X) === opts.breakOnSegment
+   *     return null
+   *   if X + subpath exists and has type opts.subpathType
+   *     return {
+   *       absolutePath: realpath(X + subpath)
+   *       containerRelativePath: relative(mixedStartPath, X)
+   *     }
+   *   X = dirname(X)
+   * while X !== dirname(X)
+   *
+   * If opts.invalidatedBy is given, collects all absolute, real paths that if
+   * added or removed may invalidate this result.
+   *
+   * Useful for finding the closest package scope (subpath: package.json,
+   * type f, breakOnSegment: node_modules) or closest potential package root
+   * (subpath: node_modules/pkg, type: d) in Node.js resolution.
+   */
+  hierarchicalLookup(
+    mixedStartPath: string,
+    subpath: string,
+    opts: {
+      breakOnSegment: ?string,
+      invalidatedBy: ?Set<string>,
+      subpathType: 'f' | 'd',
+    },
+  ): ?{
+    absolutePath: string,
+    containerRelativePath: string,
+  };
+
+  /**
    * Analogous to posix lstat. If the file at `file` is a symlink, return
    * information about the symlink without following it.
    */

--- a/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
@@ -141,4 +141,16 @@ describe.each([['win32'], ['posix']])('RootPathUtils on %s', platform => {
       },
     );
   });
+
+  test.each([
+    ['foo', null],
+    ['', 0],
+    ['..', 1],
+    [p('../..'), 2],
+    [p('../../..'), 3],
+    [p('../../../foo'), null],
+    [p('../../../..foo'), null],
+  ])('getAncestorOfRootIdx (%s => %s)', (input, expected) => {
+    expect(pathUtils.getAncestorOfRootIdx(input)).toEqual(expected);
+  });
 });

--- a/packages/metro-file-map/types/flow-types.d.ts
+++ b/packages/metro-file-map/types/flow-types.d.ts
@@ -167,6 +167,42 @@ export interface FileSystem {
   getSha1(file: Path): string | null;
 
   /**
+   * Given a start path (which need not exist), a subpath and type, and
+   * optionally a 'breakOnSegment', performs the following:
+   *
+   * X = mixedStartPath
+   * do
+   *   if basename(X) === opts.breakOnSegment
+   *     return null
+   *   if X + subpath exists and has type opts.subpathType
+   *     return {
+   *       absolutePath: realpath(X + subpath)
+   *       containerRelativePath: relative(mixedStartPath, X)
+   *     }
+   *   X = dirname(X)
+   * while X !== dirname(X)
+   *
+   * If opts.invalidatedBy is given, collects all absolute, real paths that if
+   * added or removed may invalidate this result.
+   *
+   * Useful for finding the closest package scope (subpath: package.json,
+   * type f, breakOnSegment: node_modules) or closest potential package root
+   * (subpath: node_modules/pkg, type: d) in Node.js resolution.
+   */
+  hierarchicalLookup(
+    mixedStartPath: string,
+    subpath: string,
+    opts: {
+      breakOnSegment: string | null | undefined;
+      invalidatedBy: Set<string> | null | undefined;
+      subpathType: 'f' | 'd';
+    },
+  ): {
+    absolutePath: string;
+    containerRelativePath: string;
+  } | null;
+
+  /**
    * Analogous to posix lstat. If the file at `file` is a symlink, return
    * information about the symlink without following it.
    */


### PR DESCRIPTION
Summary:
Implement a new method on `TreeFS` that is able to "natively" perform hierarchical lookup, such as frequently used during node_modules resolution, config path resolution, etc., and use it initially to find the closest package scope of a given candidate path (`context.getClosestPackage()`).

This operation currently dominates resolution time, with an algorithm that uses repeated `path.dirname()` and `fileSystem.lookup()`. The current algorithm is O(n^2) on path segments (~length), because the outer loop is O(n) and each lookup is O(n) - additionally, it's slow in constant time because each `path.dirname()` and `path.join()` involves unnecessarily parsing and normalising their own outputs - `path.join()` calls alone account for >30% of resolution time.

The new implementation:
 - Performs a lookup on the start path, collecting a list of all nodes along the way.
 - Looks back through each node, and checks for the existence of the subpath on each one.

*Benchmarks based on collecting and running all resolutions performed during a build of rn-tester:*
## Before
 - Total resolution time: 1210ms
 - Time in `getClosestPackage`: 910ms

## After
 - Total resolution time: 390ms (~3x faster)
 - Time in `getClosestPackage`: 105ms (~9x faster)

Differential Revision: D58062988
