### PR TITLE
fix: correctly format logs when saving bundle

### DIFF
--- a/packages/metro/src/shared/output/bundle.flow.js
+++ b/packages/metro/src/shared/output/bundle.flow.js
@@ -49,7 +49,7 @@ async function saveBundleAndMap(
     ...
   },
   options: OutputOptions,
-  log: (message: string) => void,
+  log: (...args: Array<string>) => void,
 ): Promise<mixed> {
   const {
     bundleOutput,

--- a/packages/metro/src/shared/output/bundle.flow.js
+++ b/packages/metro/src/shared/output/bundle.flow.js
@@ -49,7 +49,7 @@ async function saveBundleAndMap(
     ...
   },
   options: OutputOptions,
-  log: (...args: Array<string>) => void,
+  log: (message: string) => void,
 ): Promise<mixed> {
   const {
     bundleOutput,
@@ -61,7 +61,7 @@ async function saveBundleAndMap(
   const writeFns = [];
 
   writeFns.push(async () => {
-    log('Writing bundle output to:', bundleOutput);
+    log(`Writing bundle output to: ${bundleOutput}`);
     await writeFile(bundleOutput, bundle.code, encoding);
     log('Done writing bundle output');
   });
@@ -75,7 +75,7 @@ async function saveBundleAndMap(
     }
 
     writeFns.push(async () => {
-      log('Writing sourcemap output to:', sourcemapOutput);
+      log(`Writing sourcemap output to: ${sourcemapOutput}`);
       await writeFile(sourcemapOutput, map, null);
       log('Done writing sourcemap output');
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

When using `community-cli-plugin`, output when saving bundle looks like this:
```
❯ npx react-native bundle --platform android --entry-file index.js --dev=false --bundle-output dist/
                Welcome to Metro v0.80.9
              Fast - Scalable - Integrated

info Writing bundle output to:, dist/
```

There's a useless comma in log, because `community-cli-plugin` uses `logger.info` from `@react-native-community/cli-tools` which separates each item with `,` separator. 

## Test plan

Saving bundle output should contain correctly formatted log:

```
info Writing bundle output to: dist/
```