### PR TITLE
Replace use of object with Map in Metro module registry

### DIFF
--- a/packages/metro-runtime/src/polyfills/__tests__/require-test.js
+++ b/packages/metro-runtime/src/polyfills/__tests__/require-test.js
@@ -396,7 +396,7 @@ describe('require', () => {
       createModuleSystem(moduleSystem, true, '');
 
       createModule(moduleSystem, 0, 'index.js', (global, require) => {
-        expect(require.getModules()[0].verboseName).toEqual('index.js');
+        expect(require.getModules().get(0).verboseName).toEqual('index.js');
         done();
       });
 


### PR DESCRIPTION
Summary: We've seen small performance wins from using `Map` instances instead of objects to store modules in the Metro module registry, so we're refactoring the implementation to use it.

Differential Revision: D59115092
