### PR TITLE
Add support for resolving import subpaths

### DIFF
--- a/packages/metro-resolver/src/PackageImportsResolve.js
+++ b/packages/metro-resolver/src/PackageImportsResolve.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {ExportsLikeMap, FileResolution, ResolutionContext} from './types';
+
+import InvalidPackageConfigurationError from './errors/InvalidPackageConfigurationError';
+import PackageImportNotResolvedError from './errors/PackageImportNotResolvedError';
+import resolveAsset from './resolveAsset';
+import isAssetFile from './utils/isAssetFile';
+import {isSubpathDefinedInExportsLike} from './utils/isSubpathDefinedInExportsLike';
+import {matchSubpathFromExportsLike} from './utils/matchSubpathFromExportsLike';
+import path from 'path';
+
+/**
+ * Resolve a package subpath based on the entry points defined in the package's
+ * "imports" field. If there is no match for the given subpath (which may be
+ * augmented by resolution of conditional exports for the passed `context`),
+ * throws a `PackagePathNotExportedError`.
+ *
+ * Implementation of PACKAGE_IMPORTS_RESOLVE described in https://nodejs.org/api/esm.html
+ *
+ * @throws {InvalidPackageConfigurationError} Raised if configuration specified
+ *   by `importsMap` is invalid.
+ */
+export function resolvePackageTargetFromImports(
+  context: ResolutionContext,
+  /**
+   * The absolute path to the package.json
+   */
+  packagePath: string,
+  importPath: string,
+  importsMap: ExportsLikeMap,
+  platform: string | null,
+): FileResolution {
+  const createConfigError = (reason: string) => {
+    return new InvalidPackageConfigurationError({
+      reason,
+      packagePath,
+    });
+  };
+
+  const firstLevelKeys = Object.keys(importsMap);
+  const keysWithoutPrefix = firstLevelKeys.filter(key => !key.startsWith('#'));
+  if (firstLevelKeys.length === 0) {
+    throw createConfigError('The "imports" field cannot be empty');
+  } else if (keysWithoutPrefix.length !== 0) {
+    throw createConfigError(
+      'The "imports" field cannot have keys which do not start with #',
+    );
+  }
+
+  const normalizedMap = new Map(Object.entries(importsMap));
+  if (!isSubpathDefinedInExportsLike(normalizedMap, importPath)) {
+    throw new PackageImportNotResolvedError({
+      importSpecifier: importPath,
+      reason: `"${importPath}" could not be matched using "imports" of ${packagePath}`,
+    });
+  }
+
+  const {target, patternMatch} = matchSubpathFromExportsLike(
+    context,
+    importPath,
+    normalizedMap,
+    platform,
+    createConfigError,
+  );
+
+  if (target == null) {
+    throw new PackageImportNotResolvedError({
+      importSpecifier: importPath,
+      reason:
+        `"${importPath}" which matches a subpath "imports" in ${packagePath}` +
+        `however no match was resolved for this request (platform = ${platform ?? 'null'}).`,
+    });
+  }
+
+  const filePath = path.join(
+    packagePath,
+    patternMatch != null ? target.replace('*', patternMatch) : target,
+  );
+
+  if (isAssetFile(filePath, context.assetExts)) {
+    const assetResult = resolveAsset(context, filePath);
+
+    if (assetResult != null) {
+      return assetResult;
+    }
+  }
+
+  const lookupResult = context.fileSystemLookup(filePath);
+  if (lookupResult.exists && lookupResult.type === 'f') {
+    return {
+      type: 'sourceFile',
+      filePath: lookupResult.realPath,
+    };
+  }
+
+  throw createConfigError(
+    `The resolved path for "${importPath}" defined in "imports" is ${filePath}, ` +
+      'however this file does not exist.',
+  );
+}

--- a/packages/metro-resolver/src/errors/PackageImportNotResolvedError.js
+++ b/packages/metro-resolver/src/errors/PackageImportNotResolvedError.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * Raised when package imports do not define or permit a target subpath in the
+ * package for the given import specifier.
+ */
+export default class PackageImportNotResolvedError extends Error {
+  /**
+   * Either the import specifier read, or the absolute path of the module being
+   * resolved (used when import specifier is externally remapped).
+   */
+  +importSpecifier: string;
+
+  /**
+   * The description of the error cause.
+   */
+  +reason: string;
+
+  constructor(
+    opts: $ReadOnly<{
+      importSpecifier: string,
+      reason: string,
+    }>,
+  ) {
+    super(
+      `The path for ${opts.importSpecifier} could not be resolved.\nReason: ` +
+        opts.reason,
+    );
+    this.importSpecifier = opts.importSpecifier;
+    this.reason = opts.reason;
+  }
+}

--- a/packages/metro-resolver/src/types.js
+++ b/packages/metro-resolver/src/types.js
@@ -52,18 +52,18 @@ export type FileCandidates =
       +candidateExts: $ReadOnlyArray<string>,
     };
 
-export type ExportMap = $ReadOnly<{
-  [subpathOrCondition: string]: string | ExportMap | null,
+export type ExportsLikeMap = $ReadOnly<{
+  [subpathOrCondition: string]: string | ExportsLikeMap | null,
 }>;
 
 /** "exports" mapping where values may be legacy Node.js <13.7 array format. */
 export type ExportMapWithFallbacks = $ReadOnly<{
-  [subpath: string]: $Values<ExportMap> | ExportValueWithFallback,
+  [subpath: string]: $Values<ExportsLikeMap> | ExportValueWithFallback,
 }>;
 
 /** "exports" subpath value when in legacy Node.js <13.7 array format. */
 export type ExportValueWithFallback =
-  | $ReadOnlyArray<ExportMap | string>
+  | $ReadOnlyArray<ExportsLikeMap | string>
   // JSON can also contain exotic nested array structure, which will not be parsed
   | $ReadOnlyArray<$ReadOnlyArray<mixed>>;
 
@@ -71,13 +71,24 @@ export type ExportsField =
   | string
   | $ReadOnlyArray<string>
   | ExportValueWithFallback
-  | ExportMap
+  | ExportsLikeMap
   | ExportMapWithFallbacks;
+
+export type FlattenedExportMap = $ReadOnlyMap<
+  string /* subpath */,
+  string | null,
+>;
+
+export type NormalizedExportsLikeMap = Map<
+  string /* subpath */,
+  null | string | ExportsLikeMap,
+>;
 
 export type PackageJson = $ReadOnly<{
   name?: string,
   main?: string,
   exports?: ExportsField,
+  imports?: ExportsLikeMap,
   ...
 }>;
 

--- a/packages/metro-resolver/src/utils/isSubpathDefinedInExportsLike.js
+++ b/packages/metro-resolver/src/utils/isSubpathDefinedInExportsLike.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * Identifies whether the given subpath is defined in the given "exports"-like
+ * mapping. Does not reduce exports conditions (therefore does not identify
+ * whether the subpath is mapped to a value).
+ */
+import type {NormalizedExportsLikeMap} from '../types';
+
+import {matchSubpathPattern} from './matchSubpathPattern';
+
+export function isSubpathDefinedInExportsLike(
+  exportsLikeMap: NormalizedExportsLikeMap,
+  subpath: string,
+): boolean {
+  if (exportsLikeMap.has(subpath)) {
+    return true;
+  }
+
+  // Attempt to match after expanding any subpath pattern keys
+  for (const key of exportsLikeMap.keys()) {
+    if (
+      key.split('*').length === 2 &&
+      matchSubpathPattern(key, subpath) != null
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js
+++ b/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {NormalizedExportsLikeMap, ResolutionContext} from '../types';
+
+import {matchSubpathPattern} from './matchSubpathPattern';
+import {reduceExportsLikeMap} from './reduceExportsLikeMap';
+
+/**
+ * Get the mapped replacement for the given subpath.
+ *
+ * Implements modern package resolution behaviour based on the [Package Entry
+ * Points spec](https://nodejs.org/docs/latest-v19.x/api/packages.html#package-entry-points).
+ */
+export function matchSubpathFromExportsLike(
+  context: ResolutionContext,
+  /**
+   * The package-relative subpath (beginning with '.') to match against either
+   * an exact subpath key or subpath pattern key in "exports".
+   */
+  subpath: string,
+  exportsLikeMap: NormalizedExportsLikeMap,
+  platform: string | null,
+  createConfigError: (reason: string) => Error,
+): $ReadOnly<{
+  target: string | null,
+  patternMatch: string | null,
+}> {
+  const conditionNames = new Set([
+    'default',
+    ...context.unstable_conditionNames,
+    ...(platform != null
+      ? context.unstable_conditionsByPlatform[platform] ?? []
+      : []),
+  ]);
+
+  const exportsLikeMapAfterConditions = reduceExportsLikeMap(
+    exportsLikeMap,
+    conditionNames,
+    createConfigError,
+  );
+
+  let target = exportsLikeMapAfterConditions.get(subpath);
+  let patternMatch = null;
+
+  // Attempt to match after expanding any subpath pattern keys
+  if (target == null) {
+    // Gather keys which are subpath patterns in descending order of specificity
+    const expansionKeys = [...exportsLikeMapAfterConditions.keys()]
+      .filter(key => key.includes('*'))
+      .sort(key => key.split('*')[0].length)
+      .reverse();
+
+    for (const key of expansionKeys) {
+      const value = exportsLikeMapAfterConditions.get(key);
+
+      // Skip invalid values (must include a single '*' or be `null`)
+      if (typeof value === 'string' && value.split('*').length !== 2) {
+        break;
+      }
+
+      patternMatch = matchSubpathPattern(key, subpath);
+
+      if (patternMatch != null) {
+        target = value;
+        break;
+      }
+    }
+  }
+
+  return {target: target ?? null, patternMatch};
+}

--- a/packages/metro-resolver/src/utils/matchSubpathPattern.js
+++ b/packages/metro-resolver/src/utils/matchSubpathPattern.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * If a subpath pattern expands to the passed subpath, return the subpath match
+ * (value to substitute for '*'). Otherwise, return `null`.
+ *
+ * See https://nodejs.org/docs/latest-v19.x/api/packages.html#subpath-patterns.
+ */
+export function matchSubpathPattern(
+  subpathPattern: string,
+  subpath: string,
+): string | null {
+  const [patternBase, patternTrailer] = subpathPattern.split('*');
+
+  if (subpath.startsWith(patternBase) && subpath.endsWith(patternTrailer)) {
+    return subpath.substring(
+      patternBase.length,
+      subpath.length - patternTrailer.length,
+    );
+  }
+
+  return null;
+}

--- a/packages/metro-resolver/src/utils/reduceExportsLikeMap.js
+++ b/packages/metro-resolver/src/utils/reduceExportsLikeMap.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * Reduce an "exports"-like mapping to a flat subpath mapping after resolving
+ * conditional exports.
+ */
+import type {
+  ExportsLikeMap,
+  FlattenedExportMap,
+  NormalizedExportsLikeMap,
+} from '../types';
+
+export function reduceExportsLikeMap(
+  exportsLikeMap: NormalizedExportsLikeMap,
+  conditionNames: $ReadOnlySet<string>,
+  createConfigError: (reason: string) => Error,
+): FlattenedExportMap {
+  const result = new Map<string, string | null>();
+
+  for (const [subpath, value] of exportsLikeMap) {
+    const subpathValue = reduceConditionalExport(value, conditionNames);
+
+    // If a subpath has no resolution for the passed `conditionNames`, do not
+    // include it in the result. (This includes only explicit `null` values,
+    // which may conditionally hide higher-specificity subpath patterns.)
+    if (subpathValue !== 'no-match') {
+      result.set(subpath, subpathValue);
+    }
+  }
+
+  for (const value of result.values()) {
+    if (value != null && !value.startsWith('./')) {
+      throw createConfigError(
+        'One or more mappings for subpaths defined in "exports" are invalid. ' +
+          'All values must begin with "./".',
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Reduce an "exports"-like subpath value after asserting the passed
+ * `conditionNames` in any nested conditions.
+ *
+ * Returns `'no-match'` in the case that none of the asserted `conditionNames`
+ * are matched.
+ *
+ * See https://nodejs.org/docs/latest-v19.x/api/packages.html#conditional-exports.
+ */
+function reduceConditionalExport(
+  subpathValue: $Values<ExportsLikeMap>,
+  conditionNames: $ReadOnlySet<string>,
+): string | null | 'no-match' {
+  let reducedValue = subpathValue;
+
+  while (reducedValue != null && typeof reducedValue !== 'string') {
+    let match: typeof subpathValue | 'no-match';
+
+    // when conditions are present and default is not specified
+    // the default condition is implicitly set to null, to allow
+    // for restricting access to unexported internals of a package.
+    if ('default' in reducedValue) {
+      match = 'no-match';
+    } else {
+      match = null;
+    }
+
+    for (const conditionName in reducedValue) {
+      if (conditionNames.has(conditionName)) {
+        match = reducedValue[conditionName];
+        break;
+      }
+    }
+
+    reducedValue = match;
+  }
+
+  return reducedValue;
+}


### PR DESCRIPTION
## Summary

PR to add support in metro-resolver for resolving [import subpaths](https://nodejs.org/api/packages.html#subpath-imports); the feature discussed in Issue #978  in that reads the`"imports"` key in `package.json`


## Test plan

`npm run test`

## After Landing

- Update [the resolver algorithm doc](https://metrobundler.dev/docs/resolution#resolve) 
- Add support for resolving external packages