### PR TITLE
Add gh actions for building and testing the repo

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -1,0 +1,18 @@
+name: Install Dependencies
+inputs:
+  node-version:
+    required: false
+    default: '20.x'
+
+runs:
+  using: "composite"
+  steps:
+  - uses: actions/setup-node@v4
+    with:
+      node-version: ${{ inputs.node-version }}
+      cache: yarn
+      cache-dependency-path: yarn.lock
+      check-latest: true
+  - name: Install Dependencies
+    run: yarn install --frozen-lockfile --non-interactive --ignore-scripts
+    shell: bash

--- a/.github/scripts/install_codecov.sh
+++ b/.github/scripts/install_codecov.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Install Codecov Uploader
+# See https://docs.codecov.com/docs/codecov-uploader#using-the-uploader-with-codecovio-cloud
+
+CODECOV_URL="https://uploader.codecov.io"
+
+curl "${CODECOV_URL}/verification.gpg" | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl -Os "${CODECOV_URL}/latest/linux/codecov"
+curl -Os "${CODECOV_URL}/latest/linux/codecov.SHA256SUM"
+curl -Os "${CODECOV_URL}/latest/linux/codecov.SHA256SUM.sig"
+
+gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+shasum -a 256 -c codecov.SHA256SUM
+
+chmod +x codecov

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,51 @@
+name: facebook/metro/build-and-test
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# head_ref is per PR, so this ensures that updating the latest PR commit
+# will cancel the previous run of the workflow and trigger a new one
+concurrency:
+  group: "build-and-test-${{ github.head_ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  run-js-checks:
+    runs-on: ubuntu-latest
+    name: "Type check, lint, smoke test"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/yarn-install
+      - run: yarn typecheck
+      - run: yarn typecheck-ts
+      - run: yarn lint
+      - run: yarn test-smoke
+
+  test-with-coverage:
+    runs-on: ubuntu-latest
+    name: "Tests with coverage"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/yarn-install
+      - run: yarn test-coverage
+      - run: "./.github/scripts/install_codecov.sh"
+      - run: "./codecov -t ${{ secrets.CODECOV_TOKEN }} -f ./coverage/coverage-final.json"
+
+  test:
+    strategy:
+      matrix:
+        runs-on: ['ubuntu-latest']
+        node-version: ['18.0', '18.x', '20.x']
+    name: "Tests [Node.js ${{ matrix.node-version }}, ${{ matrix.runs-on }}]"
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/yarn-install
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Run Jest Tests
+        run: yarn jest --ci --maxWorkers 4 --reporters=default --reporters=jest-junit --rootdir='./'


### PR DESCRIPTION
Introduced config that triggers GH actions that build, lint, and test the repo.

These are triggered when a pull request is created or it's latest commit is updated.

If a new job is triggered, the previous is abandoned.

* Please notice that tests are currently disabled for windows because they fail. This will be fixed in a subsequent diff.

Test:
* See the Github actions on this PR: 
<img width="1185" alt="Screenshot 2024-08-02 at 17 14 07" src="https://github.com/user-attachments/assets/9cf39141-3276-48a5-9046-bebe64ab78af">

* Example of a run cancelled by pushing a new commit before the current is processed by Github actions: https://github.com/facebook/metro/actions/runs/10216106999