### PR TITLE
Replace `rimraf` package with `fs.rmSync`

### DIFF
--- a/packages/metro-cache/package.json
+++ b/packages/metro-cache/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "exponential-backoff": "^3.1.1",
     "flow-enums-runtime": "^0.0.6",
-    "metro-core": "0.80.9",
-    "rimraf": "^3.0.2"
+    "metro-core": "0.80.9"
   },
   "devDependencies": {
     "metro-memory-fs": "0.80.9"

--- a/packages/metro-cache/src/stores/FileStore.js
+++ b/packages/metro-cache/src/stores/FileStore.js
@@ -93,7 +93,10 @@ class FileStore<T> {
 
   _removeDirs() {
     for (let i = 0; i < 256; i++) {
-      fs.rmSync(path.join(this._root, ('0' + i.toString(16)).slice(-2)), { force: true, recursive: true });
+      fs.rmSync(path.join(this._root, ('0' + i.toString(16)).slice(-2)), {
+        force: true,
+        recursive: true,
+      });
     }
   }
 }

--- a/packages/metro-cache/src/stores/FileStore.js
+++ b/packages/metro-cache/src/stores/FileStore.js
@@ -12,7 +12,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const rimraf = require('rimraf');
 
 const NULL_BYTE = 0x00;
 const NULL_BYTE_BUFFER = Buffer.from([NULL_BYTE]);
@@ -94,7 +93,7 @@ class FileStore<T> {
 
   _removeDirs() {
     for (let i = 0; i < 256; i++) {
-      rimraf.sync(path.join(this._root, ('0' + i.toString(16)).slice(-2)));
+      fs.rmSync(path.join(this._root, ('0' + i.toString(16)).slice(-2)), { force: true, recursive: true });
     }
   }
 }

--- a/packages/metro-cache/src/stores/__tests__/FileStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/FileStore-test.js
@@ -54,7 +54,7 @@ describe('FileStore', () => {
     const cache = Buffer.from([0xfa, 0xce, 0xb0, 0x0c]);
     const data = Buffer.from([0xca, 0xc4, 0xe5]);
 
-    require('rimraf').sync('/root');
+    require('fs').rmSync('/root', { recursive: true, force: true });
     await fileStore.set(cache, data);
     expect(await fileStore.get(cache)).toEqual(data);
   });

--- a/packages/metro-cache/src/stores/__tests__/FileStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/FileStore-test.js
@@ -54,7 +54,7 @@ describe('FileStore', () => {
     const cache = Buffer.from([0xfa, 0xce, 0xb0, 0x0c]);
     const data = Buffer.from([0xca, 0xc4, 0xe5]);
 
-    require('fs').rmSync('/root', { recursive: true, force: true });
+    require('fs').rmSync('/root', {recursive: true, force: true});
     await fileStore.set(cache, data);
     expect(await fileStore.get(cache)).toEqual(data);
   });

--- a/packages/metro-memory-fs/src/index.js
+++ b/packages/metro-memory-fs/src/index.js
@@ -927,6 +927,28 @@ class MemoryFs {
     });
   };
 
+  rmSync: (filePath: FilePath, options?: {recursive?: boolean}) => void = (
+    filePath: FilePath,
+    options,
+  ) => {
+    filePath = pathStr(filePath);
+    const {dirNode, node, basename} = this._resolve(filePath, {
+      keepFinalSymlink: true,
+    });
+    if (node == null) {
+      throw makeError('ENOENT', filePath, 'no such file or directory');
+    } else if (node.type === 'directory') {
+      if (options && options.recursive) {
+        // NOTE: File watchers won't be informed of recursive deletions
+        dirNode.entries.delete(basename);
+      } else {
+        this.rmdirSync(filePath);
+      }
+    } else {
+      this.unlinkSync(filePath);
+    }
+  };
+
   renameSync: (oldPath: FilePath, newPath: FilePath) => void = (
     oldPath,
     newPath,

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -50,7 +50,6 @@
     "mime-types": "^2.1.27",
     "node-fetch": "^2.2.0",
     "nullthrows": "^1.1.1",
-    "rimraf": "^3.0.2",
     "serialize-error": "^2.1.0",
     "source-map": "^0.5.6",
     "strip-ansi": "^6.0.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This is for the deprecation message:
> Rimraf versions prior to v4 are no longer supported deprecation warning.

The `rimraf` package seems to be largely unused in metro, except for `FileStore#_removeDirs`, where it can be replaced with `fs.rmSync`, [which has been added in Node 14.14/16.14/17.3](https://nodejs.org/api/fs.html#fsrmsyncpath-options). Since the minimum supported Node version (via `engines`) is set to `>=18` this seems fine to use.

A `metro-memory-fs` addition of `rmSync` has been added. A comment has been left to note that it's not the most accurate mock method. I'm not sure what the standard of additons to this package are.

Changelog: [Fix] Remove use of `rimraf` and replace it with `fs.rmSync`

## Test plan

- `rmSync` has been added to `metro-memory-fs` and tests have been added for it
- Existing tests should cover changes to `FileStore`, since functionality is unchanged
