### PR TITLE
Nightly test node compatibility

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -1,6 +1,7 @@
 name: Install Dependencies
 inputs:
   node-version:
+    type: string
     required: false
     default: '20.x'
 

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -44,18 +44,14 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on: ['ubuntu-latest']
         node-version: ['18.0', '18.x', '20.x']
-    name: "Tests [Node.js ${{ matrix.node-version }}, ${{ matrix.runs-on }}]"
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/yarn-install
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Run Jest Tests
-        run: yarn jest --ci --maxWorkers 4 --reporters=default --reporters=jest-junit --rootdir='./'
+    uses: ./.github/workflows/test.yml
+    with:
+      node-version: ${{ matrix.node-version }}
+      runs-on: ${{ matrix.runs-on }}
 
   deploy:
     # runs only on tag pushes

--- a/.github/workflows/nightly-node-compatibility-validation.yml
+++ b/.github/workflows/nightly-node-compatibility-validation.yml
@@ -1,0 +1,48 @@
+# In order to be updated when nightlies fail, please subscribe for updates on PR:
+# ---> https://github.com/facebook/metro/pull/1314 <---
+# where comments will be published on fail.
+
+# This is a bit of a workaround tackling the lack of an organic way
+# to notify certain people when a Github workflow fails:
+# https://github.com/orgs/community/discussions/18039
+
+name: facebook/metro/nightly-node-compatibility-validation
+on:
+  schedule:
+    # Everyday at at 5:00 UTC (22:00 USA West Coast, 06:00 London)
+    - cron:  '0 5 * * *'
+  push:
+
+jobs:
+  test:
+    strategy:
+      max-parallel: 1 # reduces the flakiness of these tests
+      fail-fast: false
+      matrix:
+        runs-on: ['ubuntu-latest']
+        node-version: [  # https://github.com/nodejs/release#release-schedule
+          '18.0',    # minimum supported
+          'lts/-1',  # pre-latest lts
+          'lts/*',   # latest lts
+          'current'  # newest
+        ]
+    uses: ./.github/workflows/test.yml
+    with:
+      node-version: ${{ matrix.node-version }}
+      runs-on: ${{ matrix.runs-on }}
+
+  comment-on-pr-for-failures:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: ${{ always() && needs.test.result == 'failure' }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              // see https://github.com/facebook/metro/pull/1314
+              issue_number: 1314,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'A nightly test failed in `${{ github.workflow }}` in [run ${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})!',
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      runs-on:
+        type: string
+        required: false
+        default: '20.x'
+
+jobs:
+  test:
+    name: "Tests [Node.js ${{ inputs.node-version }}, ${{ inputs.runs-on }}]"
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/yarn-install
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Run Jest Tests
+        run: yarn jest --ci --maxWorkers 4 --reporters=default --reporters=jest-junit --rootdir='./'


### PR DESCRIPTION
This PR introduces a workflow that runs every day at at `5:00 UTC` (`22:00` USA West Coast, `06:00` London) and tests the app on the following node versions:
- `18.0` (minimum supported version)
  - currently resolved to `18.0.0`
- `lts/-1` (previous lts)
  - currently resolved to `18.20.4`
- `lts/*` (current lts)
  - currently resolved to `20.16.0`
- `latest` (newest released node version)
  - currently resolved to `22.6.0`

> [!IMPORTANT]  
> **Because there's [no organic way to notify](https://github.com/orgs/community/discussions/18039) the team when a nightly fails I decided to notify all the people who are subscribed to this PR instead, by the workflow adding a comment to it with a link to the failed run:**
> <img width="915" alt="Screenshot 2024-08-08 at 16 06 35" src="https://github.com/user-attachments/assets/8070b384-c581-40f4-841e-1ca70c3710d2">

----

Successful run example:
https://github.com/facebook/metro/actions/runs/10304537317
<img width="1184" alt="Screenshot 2024-08-08 at 16 05 46" src="https://github.com/user-attachments/assets/e971d4ae-0fd7-4eba-9a6e-ae3af632f492">

Failed run:
https://github.com/facebook/metro/actions/runs/10304210697
<img width="1025" alt="Screenshot 2024-08-08 at 15 41 33" src="https://github.com/user-attachments/assets/db7e251e-a2ea-47d7-8861-1520fdf5cb4a">
With the comment added to the PR:
<img width="915" alt="Screenshot 2024-08-08 at 16 06 35" src="https://github.com/user-attachments/assets/1cb1c42a-0642-4327-a918-042a3df7a146">


