### PR TITLE
Resolver perf: Optimise package exports `flattenLegacySubpathValues` (1/n)

### DIFF
--- a/packages/metro-resolver/src/PackageExportsResolve.js
+++ b/packages/metro-resolver/src/PackageExportsResolve.js
@@ -202,21 +202,23 @@ function flattenLegacySubpathValues(
   exportMap: ExportMap | ExportMapWithFallbacks,
   createConfigError: (reason: string) => Error,
 ): ExportMap {
-  return Object.keys(exportMap).reduce((result: ExportMap, subpath: string) => {
-    const value = exportMap[subpath];
-
-    // We do not support empty or nested arrays (non-standard)
-    if (Array.isArray(value) && (!value.length || Array.isArray(value[0]))) {
-      throw createConfigError(
-        'Could not parse non-standard array value in "exports" field.',
-      );
-    }
-
-    return {
-      ...result,
-      [subpath]: Array.isArray(value) ? value[0] : value,
-    };
-  }, {});
+  return Object.entries(exportMap).reduce(
+    (result, [subpath, value]) => {
+      // We do not support empty or nested arrays (non-standard)
+      if (Array.isArray(value)) {
+        if (!value.length || Array.isArray(value[0])) {
+          throw createConfigError(
+            'Could not parse non-standard array value in "exports" field.',
+          );
+        }
+        result[subpath] = value[0];
+      } else {
+        result[subpath] = value;
+      }
+      return result;
+    },
+    {} as {[subpathOrCondition: string]: string | ExportMap | null},
+  );
 }
 
 /**


### PR DESCRIPTION
Summary:
The performance results from this stack are based on replaying the ~3000 resolutions performed during bundling RN Tester directly through `DependencyGraph.resolveDependency`. The baseline resolution time is ~1500ms on an M1 Max. (Internal: details in test plan)

This is a self-contained optimsation to the `flattenLegacySubpathValues` step as part of exports map normalisation, which takes over 20% (360ms) of total resolver CPU time over 655 calls due largely to repeated object allocations and spreads. By mutating an intermediate object instead we get this down to ~16ms.

Note that this still preserves key order - export maps are ordered.

This reduces total resolution time from 1540ms -> 1171ms (-23%)

Differential Revision: D56701232


