### PR TITLE
dont run the nightly on every push to the repo

### DIFF
--- a/.github/workflows/nightly-node-compatibility-validation.yml
+++ b/.github/workflows/nightly-node-compatibility-validation.yml
@@ -11,7 +11,6 @@ on:
   schedule:
     # Everyday at at 5:00 UTC (22:00 USA West Coast, 06:00 London)
     - cron:  '0 5 * * *'
-  push:
 
 jobs:
   test:


### PR DESCRIPTION
Summary:
the nightly was running on every single push to the repo on any branch

this is because I forgot to remove the `push` line I used to test the workflow

Differential Revision: D61202406
