### PR TITLE
Update pipelines to allow running "yarn" on node 18

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -4,6 +4,10 @@ inputs:
     type: string
     required: false
     default: '20.x'
+  ignore-engines:
+    type: string
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -15,5 +19,5 @@ runs:
       cache-dependency-path: yarn.lock
       check-latest: true
   - name: Install Dependencies
-    run: yarn install --frozen-lockfile --non-interactive --ignore-scripts
+    run: yarn install --frozen-lockfile --non-interactive --ignore-scripts ${{ inputs.ignore-engines == 'true' && '--ignore-engines' || ''}}
     shell: bash

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -48,10 +48,17 @@ jobs:
       matrix:
         runs-on: ['ubuntu-latest']
         node-version: ['18.0', '18.x', '20.x']
+        include:
+          - runs-on: ubuntu-latest
+            node-version: '18.0'
+            # @typescript-eslint/eslint-plugin requires node ^18.18
+            # but we allow yarn install to run regardless to test the package
+            ignore-engines: 'true'
     uses: ./.github/workflows/test.yml
     with:
       node-version: ${{ matrix.node-version }}
       runs-on: ${{ matrix.runs-on }}
+      ignore-engines: ${{ matrix.ignore-engines }}
 
   deploy:
     # runs only on tag pushes

--- a/.github/workflows/nightly-node-compatibility-validation.yml
+++ b/.github/workflows/nightly-node-compatibility-validation.yml
@@ -25,6 +25,12 @@ jobs:
           'lts/*',   # latest lts
           'current'  # newest
         ]
+        include:
+          - runs-on: ubuntu-latest
+            node-version: '18.0'
+            # @typescript-eslint/eslint-plugin requires node ^18.18
+            # but we allow yarn install to run regardless to test the package
+            ignore-engines: 'true'
     uses: ./.github/workflows/test.yml
     with:
       node-version: ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ on:
         type: string
         required: false
         default: '20.x'
-
+      ignore-engines:
+        type: string
+        required: false
+        default: 'false'
 jobs:
   test:
     name: "Tests [Node.js ${{ inputs.node-version }}, ${{ inputs.runs-on }}]"
@@ -20,5 +23,6 @@ jobs:
       - uses: ./.github/actions/yarn-install
         with:
           node-version: ${{ inputs.node-version }}
+          ignore-engines: ${{ inputs.ignore-engines }}
       - name: Run Jest Tests
         run: yarn jest --ci --maxWorkers 4 --reporters=default --reporters=jest-junit --rootdir='./'


### PR DESCRIPTION
Summary:
While we support node 18, `typescript-eslint/eslint-plugin` can only be installed on node version `18.18` and above.

This diff forces `yarn install` regardless of packages' `engines` field so we can run tests on the minimum supported version for `metro`.

Differential Revision: D61336394
