### PR TITLE
Update node-fetch

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -48,7 +48,6 @@
     "metro-transform-plugins": "0.80.10",
     "metro-transform-worker": "0.80.10",
     "mime-types": "^2.1.27",
-    "node-fetch": "^2.2.0",
     "nullthrows": "^1.1.1",
     "serialize-error": "^2.1.0",
     "source-map": "^0.5.6",
@@ -70,6 +69,7 @@
     "metro-memory-fs": "0.80.10",
     "mock-req": "^0.2.0",
     "mock-res": "^0.6.0",
+    "node-fetch": "^2.7.0",
     "stack-trace": "^0.0.10"
   },
   "license": "MIT",

--- a/packages/metro/src/integration_tests/__tests__/server-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-test.js
@@ -20,13 +20,20 @@ jest.unmock('cosmiconfig');
 
 jest.setTimeout(60 * 1000);
 
+// Workaround for https://github.com/nodejs/node/issues/54484:
+// Fetch with connection: close to prevent Node reusing connections across tests
+const fetchAndClose = (path: string) =>
+  fetch(path, {
+    headers: {Connection: 'close'},
+  });
+
 describe('Metro development server serves bundles via HTTP', () => {
   let config;
   let httpServer;
   const bundlesDownloaded = new Set();
 
   async function downloadAndExec(path: string, context = {}): mixed {
-    const response = await fetch(
+    const response = await fetchAndClose(
       'http://localhost:' + config.server.port + path,
     );
     bundlesDownloaded.add(path);
@@ -111,14 +118,14 @@ describe('Metro development server serves bundles via HTTP', () => {
   });
 
   test('responds with 404 when the bundle cannot be resolved', async () => {
-    const response = await fetch(
+    const response = await fetchAndClose(
       'http://localhost:' + config.server.port + '/doesnotexist.bundle',
     );
     expect(response.status).toBe(404);
   });
 
   test('responds with 500 when an import inside the bundle cannot be resolved', async () => {
-    const response = await fetch(
+    const response = await fetchAndClose(
       'http://localhost:' +
         config.server.port +
         '/build-errors/inline-requires-cannot-resolve-import.bundle',
@@ -128,7 +135,7 @@ describe('Metro development server serves bundles via HTTP', () => {
 
   describe('dedicated endpoints for serving source files', () => {
     test('under /[metro-project]/', async () => {
-      const response = await fetch(
+      const response = await fetchAndClose(
         'http://localhost:' +
           config.server.port +
           '/[metro-project]/TestBundle.js',
@@ -143,7 +150,7 @@ describe('Metro development server serves bundles via HTTP', () => {
     });
 
     test('under /[metro-watchFolders]/', async () => {
-      const response = await fetch(
+      const response = await fetchAndClose(
         'http://localhost:' +
           config.server.port +
           '/[metro-watchFolders]/1/metro/src/integration_tests/basic_bundle/TestBundle.js',
@@ -158,7 +165,7 @@ describe('Metro development server serves bundles via HTTP', () => {
     });
 
     test('under /[metro-project]/', async () => {
-      const response = await fetch(
+      const response = await fetchAndClose(
         'http://localhost:' +
           config.server.port +
           '/[metro-project]/TestBundle.js',
@@ -173,7 +180,7 @@ describe('Metro development server serves bundles via HTTP', () => {
     });
 
     test('no access to files without source extensions', async () => {
-      const response = await fetch(
+      const response = await fetchAndClose(
         'http://localhost:' +
           config.server.port +
           '/[metro-project]/not_a_source_file.xyz',
@@ -188,7 +195,7 @@ describe('Metro development server serves bundles via HTTP', () => {
     });
 
     test('no access to source files excluded from the file map', async () => {
-      const response = await fetch(
+      const response = await fetchAndClose(
         'http://localhost:' +
           config.server.port +
           '/[metro-project]/excluded_from_file_map.js',
@@ -203,7 +210,7 @@ describe('Metro development server serves bundles via HTTP', () => {
     });
 
     test('requested with aggressive URL encoding /%5Bmetro-project%5D', async () => {
-      const response = await fetch(
+      const response = await fetchAndClose(
         'http://localhost:' +
           config.server.port +
           '/%5Bmetro-project%5D/Foo%2Ejs',

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,6 @@
     "@sideway/formula": "^3.0.1",
     "got": "^11.8.5",
     "http-cache-semantics": "^4.1.1",
-    "node-fetch": "^2.0.0",
     "terser": "^5.14.2",
     "trim": "^0.0.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4930,10 +4930,10 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2.2.0:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -5962,7 +5962,7 @@ to-regex-range@^5.0.1:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-api-utils@^1.0.1:
   version "1.0.3"
@@ -6145,12 +6145,12 @@ walker@^1.0.8:
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 whatwg-url@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"


### PR DESCRIPTION
Summary:
Updating `node-fetch` to the latest version caused tests in `packages/metro/src/integration_tests/__tests__/server-test.js` to fail. Running each test case inside the file failed individually, but there seems to have been a race condition between the tests causing subsequent tests to fail with the following error:
```
FetchError: request to http://localhost:10028/import-export/index.bundle?platform=ios&dev=true&minify=false failed, reason: socket hang up
```
It happens because the "connection: close" header is removed in the latest version of `node-fetch`: https://github.com/node-fetch/node-fetch/pull/1765 and can be fixed by adding this header manually to fetches.
```
fetch('path', {headers: {'Connection': 'close'}});
```

This diff introduces a workaround where we add that header, however fetch is expected to work even without it when the following bug is fixed: https://github.com/nodejs/node/issues/54484

Also, since node-fetch was only used in this one test, it was actually a good opportunity to remove it from the project's dependencies altogether.

Differential Revision: D61336391