### PR TITLE
Resolver perf: Use directory existence to cut down candidate list (3/n)

### DIFF
--- a/packages/metro-resolver/src/__tests__/index-test.js
+++ b/packages/metro-resolver/src/__tests__/index-test.js
@@ -32,6 +32,7 @@ const fileMap = {
     name: 'invalid',
     main: 'main',
   }),
+  '/root/node_modules/flat-file-in-node-modules.js': '',
   '/node_modules/root-module/main.js': '',
   '/node_modules/root-module/package.json': JSON.stringify({
     name: 'root-module',
@@ -110,8 +111,8 @@ it('does not resolve a relative path ending in a slash as a file', () => {
       file: null,
       dir: {
         type: 'sourceFile',
-        filePathPrefix: '/root/project/bar/index',
-        candidateExts: ['', '.js', '.jsx', '.json', '.ts', '.tsx'],
+        filePathPrefix: '/root/project/bar/',
+        candidateExts: [],
       },
     }),
   );
@@ -121,6 +122,13 @@ it('resolves a package in `node_modules`', () => {
   expect(Resolver.resolve(CONTEXT, 'apple', null)).toEqual({
     type: 'sourceFile',
     filePath: '/root/node_modules/apple/main.js',
+  });
+});
+
+it('resolves a standalone file in `node_modules`', () => {
+  expect(Resolver.resolve(CONTEXT, 'flat-file-in-node-modules', null)).toEqual({
+    type: 'sourceFile',
+    filePath: '/root/node_modules/flat-file-in-node-modules.js',
   });
 });
 
@@ -134,8 +142,8 @@ it('fails to resolve a relative path', () => {
     }
     expect(error.candidates).toEqual({
       dir: {
-        candidateExts: ['', '.js', '.jsx', '.json', '.ts', '.tsx'],
-        filePathPrefix: '/root/project/apple/index',
+        candidateExts: [],
+        filePathPrefix: '/root/project/apple',
         type: 'sourceFile',
       },
       file: {
@@ -326,7 +334,7 @@ it('throws a descriptive error when a file inside a Haste package cannot be reso
     "While resolving module \`some-package/subdir/does-not-exist\`, the Haste package \`some-package\` was found. However the module \`subdir/does-not-exist\` could not be found within the package. Indeed, none of these files exist:
 
       * \`/haste/some-package/subdir/does-not-exist(.js|.jsx|.json|.ts|.tsx)\`
-      * \`/haste/some-package/subdir/does-not-exist/index(.js|.jsx|.json|.ts|.tsx)\`"
+      * \`/haste/some-package/subdir/does-not-exist\`"
   `);
 });
 

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/resolver-test.js.snap
@@ -5,7 +5,7 @@ exports[`linux assets checks asset extensions case insensitively 1`] = `
 
 None of these files exist:
   * asset.PNG(.native.js|.js|.native.json|.json)
-  * asset.PNG/index(.native.js|.js|.native.json|.json)
+  * asset.PNG
   1 | import foo from 'bar';
 > 2 | import a from './asset.PNG';
     |                ^
@@ -17,7 +17,7 @@ exports[`linux assets resolves asset files with resolution suffixes (matching ex
 
 None of these files exist:
   * c@2x.png
-  * c@2x.png/index(.native.js|.js|.native.json|.json)
+  * c@2x.png
   1 | import foo from 'bar';
 > 2 | import a from './c@2x.png';
     |                ^
@@ -29,7 +29,7 @@ exports[`linux assets resolves asset files with resolution suffixes (matching si
 
 None of these files exist:
   * a@1.5x.png
-  * a@1.5x.png/index(.native.js|.js|.native.json|.json)
+  * a@1.5x.png
   1 | import foo from 'bar';
 > 2 | import a from './a@1.5x.png';
     |                ^
@@ -41,7 +41,7 @@ exports[`linux assets resolves custom asset extensions when overriding assetExts
 
 None of these files exist:
   * asset2.png(.native.js|.js|.native.json|.json)
-  * asset2.png/index(.native.js|.js|.native.json|.json)
+  * asset2.png
   1 | import foo from 'bar';
 > 2 | import a from './asset2.png';
     |                ^
@@ -116,7 +116,7 @@ exports[`linux packages in node_modules/ browser field in package.json resolves 
 
 None of these files exist:
   * node_modules/aPackage/foo.js(.native.js|.js|.native.json|.json)
-  * node_modules/aPackage/foo.js/index(.native.js|.js|.native.json|.json)
+  * node_modules/aPackage/foo.js
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -146,7 +146,7 @@ exports[`linux packages in node_modules/ react-native field in package.json reso
 
 None of these files exist:
   * node_modules/aPackage/foo.js(.native.js|.js|.native.json|.json)
-  * node_modules/aPackage/foo.js/index(.native.js|.js|.native.json|.json)
+  * node_modules/aPackage/foo.js
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -176,7 +176,7 @@ exports[`linux platforms resolves platform-specific files 1`] = `
 
 None of these files exist:
   * foo.js(.ios.js|.native.js|.js|.ios.json|.native.json|.json)
-  * foo.js/index(.ios.js|.native.js|.js|.ios.json|.native.json|.json)
+  * foo.js
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -188,7 +188,7 @@ exports[`linux relative paths fails when trying to implicitly require an extensi
 
 None of these files exist:
   * a.another(.native.js|.js|.native.json|.json)
-  * a.another/index(.native.js|.js|.native.json|.json)
+  * a.another
   1 | import foo from 'bar';
 > 2 | import root from './a.another';
     |                   ^
@@ -200,7 +200,7 @@ exports[`linux relative paths with additional files included in the file map (wa
 
 None of these files exist:
   * a(.native.js|.js|.native.json|.json)
-  * a/index(.native.js|.js|.native.json|.json)
+  * a
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^
@@ -212,7 +212,7 @@ exports[`win32 assets checks asset extensions case insensitively 1`] = `
 
 None of these files exist:
   * asset.PNG(.native.js|.js|.native.json|.json)
-  * asset.PNG\\\\index(.native.js|.js|.native.json|.json)
+  * asset.PNG
   1 | import foo from 'bar';
 > 2 | import a from './asset.PNG';
     |                ^
@@ -224,7 +224,7 @@ exports[`win32 assets resolves asset files with resolution suffixes (matching ex
 
 None of these files exist:
   * c@2x.png
-  * c@2x.png\\\\index(.native.js|.js|.native.json|.json)
+  * c@2x.png
   1 | import foo from 'bar';
 > 2 | import a from './c@2x.png';
     |                ^
@@ -236,7 +236,7 @@ exports[`win32 assets resolves asset files with resolution suffixes (matching si
 
 None of these files exist:
   * a@1.5x.png
-  * a@1.5x.png\\\\index(.native.js|.js|.native.json|.json)
+  * a@1.5x.png
   1 | import foo from 'bar';
 > 2 | import a from './a@1.5x.png';
     |                ^
@@ -248,7 +248,7 @@ exports[`win32 assets resolves custom asset extensions when overriding assetExts
 
 None of these files exist:
   * asset2.png(.native.js|.js|.native.json|.json)
-  * asset2.png\\\\index(.native.js|.js|.native.json|.json)
+  * asset2.png
   1 | import foo from 'bar';
 > 2 | import a from './asset2.png';
     |                ^
@@ -323,7 +323,7 @@ exports[`win32 packages in node_modules/ browser field in package.json resolves 
 
 None of these files exist:
   * node_modules\\\\aPackage\\\\foo.js(.native.js|.js|.native.json|.json)
-  * node_modules\\\\aPackage\\\\foo.js\\\\index(.native.js|.js|.native.json|.json)
+  * node_modules\\\\aPackage\\\\foo.js
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -353,7 +353,7 @@ exports[`win32 packages in node_modules/ react-native field in package.json reso
 
 None of these files exist:
   * node_modules\\\\aPackage\\\\foo.js(.native.js|.js|.native.json|.json)
-  * node_modules\\\\aPackage\\\\foo.js\\\\index(.native.js|.js|.native.json|.json)
+  * node_modules\\\\aPackage\\\\foo.js
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -383,7 +383,7 @@ exports[`win32 platforms resolves platform-specific files 1`] = `
 
 None of these files exist:
   * foo.js(.ios.js|.native.js|.js|.ios.json|.native.json|.json)
-  * foo.js\\\\index(.ios.js|.native.js|.js|.ios.json|.native.json|.json)
+  * foo.js
   1 | import foo from 'bar';
 > 2 | import f from './foo.js';
     |                ^
@@ -395,7 +395,7 @@ exports[`win32 relative paths fails when trying to implicitly require an extensi
 
 None of these files exist:
   * a.another(.native.js|.js|.native.json|.json)
-  * a.another\\\\index(.native.js|.js|.native.json|.json)
+  * a.another
   1 | import foo from 'bar';
 > 2 | import root from './a.another';
     |                   ^
@@ -407,7 +407,7 @@ exports[`win32 relative paths with additional files included in the file map (wa
 
 None of these files exist:
   * a(.native.js|.js|.native.json|.json)
-  * a\\\\index(.native.js|.js|.native.json|.json)
+  * a
   1 | import foo from 'bar';
 > 2 | import a from './a';
     |                ^

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/build-errors-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/build-errors-test.js.snap
@@ -5,7 +5,7 @@ Unable to resolve module ./does-not-exist from <dir>/cannot-resolve-require.js:
 
 None of these files exist:
   * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
-  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist
   13 |
   14 | // $FlowExpectedError[cannot-resolve-module]
 > 15 | const DoesNotExist = require('./does-not-exist');
@@ -20,7 +20,7 @@ Unable to resolve module ./does-not-exist from <dir>/cannot-resolve-import.js:
 
 None of these files exist:
   * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
-  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist
   13 |
   14 | // $FlowExpectedError[cannot-resolve-module]
 > 15 | import DoesNotExist from './does-not-exist';
@@ -35,7 +35,7 @@ Unable to resolve module ./does-not-exist from <dir>/inline-requires-cannot-reso
 
 None of these files exist:
   * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
-  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist
   13 |
   14 | // $FlowExpectedError[cannot-resolve-module]
 > 15 | const DoesNotExist = require('./does-not-exist');
@@ -50,7 +50,7 @@ Unable to resolve module ./does-not-exist from <dir>/inline-requires-cannot-reso
 
 None of these files exist:
   * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
-  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist
   13 |
   14 | // $FlowExpectedError[cannot-resolve-module]
 > 15 | import DoesNotExist from './does-not-exist';
@@ -65,7 +65,7 @@ Unable to resolve module ./does-not'"-exist from <dir>/cannot-resolve-multi-line
 
 None of these files exist:
   * build-errors/does-not'"-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
-  * build-errors/does-not'"-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not'"-exist
   14 | import type DoesNotExistT from './does-not/'"-exist';
   15 |
 > 16 | import {
@@ -80,7 +80,7 @@ Unable to resolve module ./does-not'"-exist from <dir>/cannot-resolve-specifier-
 
 None of these files exist:
   * build-errors/does-not'"-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
-  * build-errors/does-not'"-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not'"-exist
   15 |
   16 | // $FlowExpectedError[cannot-resolve-module]
 > 17 | import {DoesNotExist} from './does-not/'"-exist';
@@ -95,7 +95,7 @@ Unable to resolve module ./foo from <dir>/cannot-resolve-require-with-embedded-c
 
 None of these files exist:
   * build-errors/foo(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
-  * build-errors/foo/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/foo
   13 |
   14 | // $FlowExpectedError[cannot-resolve-module]
 > 15 | const DoesNotExist = require('./foo' /* ./foo */);
@@ -110,7 +110,7 @@ Unable to resolve module ./does-not-exist from <dir>/cannot-resolve-multi-line-i
 
 None of these files exist:
   * build-errors/does-not-exist(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
-  * build-errors/does-not-exist/index(.web.js|.native.js|.js|.web.jsx|.native.jsx|.jsx|.web.json|.native.json|.json|.web.ts|.native.ts|.ts|.web.tsx|.native.tsx|.tsx)
+  * build-errors/does-not-exist
   25 |   iiiiiiiiii,
   26 |   // $FlowExpectedError[cannot-resolve-module]
 > 27 | } from './does-not-exist';


### PR DESCRIPTION
Summary:
Further optimise resolution with some work avoidance by using the fact that, when resolving `require('foo')`, we can eliminate any candidates of the form `<prefix>/node_modules/foo<suffix>` unless `<prefix>/node_modules` exists and is a directory. This saves a lot of lookups from deeply-nested origin modules.

Further, when resolving `require('foo/bar')`, we can eliminate candidates of the form `<prefix>/node_modules/foo/<suffix>` unless `<prefix>/node_modules/foo` exists as a directory.

This is a bit more subtle than it might seem, and can't be extended beyond these cases, due to redirection. For `require('foo/bar/baz')`, `foo/bar` need not exist anywhere, because some `foo/package.json` could redirect it. However, when looking up a `package.json` for possible redirections, we stop at `node_modules` (we do not check `node_modules/package.json`), so  it's safe to treat anything up to and including `node_modules` (or `node_modules/foo` in the case `node_modules/foo.js` may not be a candidate) as a real file path that must be an extant directory.

This fix reduces the existence checks we need to perform in RNTester such that total resolution speed is improved ~3x, or ~12x relative to the start of this stack / the previous Metro release.

```
- **[Performance]**: Use directory existence to cut down resolution candidates
```

Reviewed By: huntie

Differential Revision: D58594993


