### PR TITLE
fetch origin main in publish gh action

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -15,6 +15,7 @@ else
 fi
 
 # Does main contain this tag? (regular release workflow)
+git fetch origin main
 TAG_ON_MAIN=$(git branch -a --contains "$RAW_TAG_NAME" | grep -cFx '  remotes/origin/main' || true)
 echo "Tag is on main branch: $TAG_ON_MAIN"
 


### PR DESCRIPTION
A publish just failed: https://github.com/facebook/metro/actions/runs/10699968796 because a tag pushed on the main branch was not validated as being on the main branch.
We assume it's because `main` was not fetched.
Adding 
`git fetch origin main`
Which is equivalent to what we do with the hotfix branch a few lines below:
`git fetch origin ${RELEASE_BRANCH}`