### PR TITLE
Pin @babel/register dependency to 7.22.5

### DIFF
--- a/packages/metro-babel-register/package.json
+++ b/packages/metro-babel-register/package.json
@@ -13,7 +13,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.25.2",
     "@babel/plugin-transform-modules-commonjs": "^7.24.8",
     "@babel/preset-typescript": "^7.24.7",
-    "@babel/register": "^7.24.6",
+    "@babel/register": "7.22.5",
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
     "babel-plugin-syntax-hermes-parser": "0.23.1",
     "babel-plugin-transform-flow-enums": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,7 +705,18 @@
     "@babel/plugin-transform-modules-commonjs" "^7.24.7"
     "@babel/plugin-transform-typescript" "^7.24.7"
 
-"@babel/register@^7.13.16", "@babel/register@^7.24.6":
+"@babel/register@7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.22.5.tgz#e4d8d0f615ea3233a27b5c6ada6750ee59559939"
+  integrity sha512-vV6pm/4CijSQ8Y47RH5SopXzursN35RQINfGJkmOlcpAtGuf94miFvIPhCKGQN7WGIcsgG1BHEX2KVdTYwTwUQ==
+  dependencies:
+    clone-deep "^4.0.1"
+    find-cache-dir "^2.0.0"
+    make-dir "^2.1.0"
+    pirates "^4.0.5"
+    source-map-support "^0.5.16"
+
+"@babel/register@^7.13.16":
   version "7.24.6"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.24.6.tgz#59e21dcc79e1d04eed5377633b0f88029a6bef9e"
   integrity sha512-WSuFCc2wCqMeXkz/i3yfAAsxwWflEgbVkZzivgAmXl/MxrXeoYFZOOPllbC8R8WTF7u61wSRQtDVZ1879cdu6w==
@@ -4798,7 +4809,7 @@ pirates@^4.0.4:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
 
-pirates@^4.0.6:
+pirates@^4.0.5, pirates@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
   integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==


### PR DESCRIPTION
Summary:
This fixes the current state in fbsource, where the bump to this dependency breaks existing run-from-source behaviour when we bump Metro (and `metro-babel-register`) to latest (where https://github.com/facebook/metro/pull/1343 recently bumped all Babel deps).

No change to other bumped Babel packages — want to minimally unblock https://github.com/facebook/react-native/pull/46703. As this is fbsource-only, no new release of Metro is needed.

Changelog: [Internal]

Reviewed By: vzaidman

Differential Revision: D63694664
