### PR TITLE
Replace strip-ansi with native module

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -25,8 +25,7 @@
   "devDependencies": {
     "@types/connect": "^3.4.35",
     "metro-babel-register": "0.80.11",
-    "pretty-format": "^29.7.0",
-    "strip-ansi": "^6.0.0"
+    "pretty-format": "^29.7.0"
   },
   "engines": {
     "node": ">=18.18"

--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -18,7 +18,7 @@ const {loadConfig} = require('../loadConfig');
 const cosmiconfig = require('cosmiconfig');
 const path = require('path');
 const prettyFormat = require('pretty-format');
-const stripAnsi = require('strip-ansi');
+const util = require('util');
 
 describe('loadConfig', () => {
   beforeEach(() => {
@@ -182,7 +182,7 @@ describe('loadConfig', () => {
     try {
       await loadConfig({});
     } catch (error) {
-      expect(stripAnsi(error.message)).toMatchSnapshot();
+      expect(util.stripVTControlCharacters(error.message)).toMatchSnapshot();
     }
   });
 
@@ -198,7 +198,7 @@ describe('loadConfig', () => {
     try {
       await loadConfig({});
     } catch (error) {
-      expect(stripAnsi(error.message)).toMatchSnapshot();
+      expect(util.stripVTControlCharacters(error.message)).toMatchSnapshot();
     }
   });
 

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -51,7 +51,6 @@
     "nullthrows": "^1.1.1",
     "serialize-error": "^2.1.0",
     "source-map": "^0.5.6",
-    "strip-ansi": "^6.0.0",
     "throat": "^5.0.0",
     "ws": "^7.5.10",
     "yargs": "^17.6.2"

--- a/packages/metro/src/lib/reporting.js
+++ b/packages/metro/src/lib/reporting.js
@@ -17,7 +17,6 @@ import type {CustomResolverOptions} from 'metro-resolver';
 import type {CustomTransformOptions} from 'metro-transform-worker';
 
 const chalk = require('chalk');
-const stripAnsi = require('strip-ansi');
 const util = require('util');
 
 export type BundleDetails = {
@@ -207,7 +206,7 @@ function logError(
     // in various places outside of where Metro is currently running.
     // If the current terminal does not support color, we'll strip the colors
     // here.
-    util.format(chalk.supportsColor ? format : stripAnsi(format), ...args),
+    util.format(chalk.supportsColor ? format : util.stripVTControlCharacters(format), ...args),
   );
 }
 


### PR DESCRIPTION
stripVTControlCharacters from Node core utilities provide the same functionality, and is available since Node 16.11. This project currently requires minimum Node 18.18.

See https://github.com/es-tooling/ecosystem-cleanup/issues/122 for similar efforts to replace this dependency in other projects.