### PR TITLE
replace CircleCI Badge in readme with GH actions nightly tests status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/metro/blob/HEAD/LICENSE)
 [![npm package version](https://img.shields.io/npm/v/metro?color=brightgreen)](https://www.npmjs.com/package/metro)
-[![Build status](https://circleci.com/gh/facebook/metro.svg?style=shield)](https://circleci.com/gh/facebook/metro)
+[![facebook/metro/nightly-tests](https://github.com/facebook/metro/actions/workflows/nightly-tests.yml/badge.svg)](https://github.com/facebook/metro/actions/workflows/nightly-tests.yml)
 [![Code coverage](https://codecov.io/gh/facebook/metro/branch/main/graph/badge.svg?token=oMHdoKhFZB)](https://codecov.io/gh/facebook/metro)
 [![Follow @MetroBundler on Twitter](https://img.shields.io/twitter/follow/MetroBundler?style=social)](https://twitter.com/intent/follow?screen_name=MetroBundler)
 


### PR DESCRIPTION
## Summary

Change the badge showing the health of the project from CircleCI to GH nightly tests status

Changelog: [Internal]

## Test plan
Before:

![Screenshot 2024-10-15 at 11 37 52](https://github.com/user-attachments/assets/22bc68cd-b6b9-4368-819f-458668f7e9e7)

After:

![Screenshot 2024-10-15 at 11 50 24](https://github.com/user-attachments/assets/26193e6d-841e-42ef-8a27-f612b9e43c33)

