### PR TITLE
fix or filter with a comment windows tests and run CI tests on windows and macOS

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: ['ubuntu-latest']
+        runs-on: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         node-version: [
           '18.18.0', # minimum supported
           'lts/-1',  # pre-latest lts

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 1 # reduces the flakiness of these tests
       fail-fast: false
       matrix:
-        runs-on: ['ubuntu-latest']
+        runs-on: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         node-version: [  # https://github.com/nodejs/release#release-schedule
           '18.18.0', # minimum supported
           'lts/-1',  # pre-latest lts

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,50 @@ if (process.env.NIGHTLY_TESTS_NO_LOCKFILE) {
   testPathIgnorePatterns.push('__tests__/babel-lib-defs-test.js');
 }
 
+if (process.platform === 'win32') {
+  // TODO: fix on windows
+  testPathIgnorePatterns.push(
+    ...[
+      // path mismatches
+      'packages/metro/src/__tests__/HmrServer-test.js',
+      'packages/metro/src/DeltaBundler/__tests__/buildSubgraph-test.js',
+      'packages/metro/src/DeltaBundler/__tests__/Graph-test.js',
+      'packages/metro/src/DeltaBundler/Serializers/helpers/__tests__/js-test.js',
+      'packages/metro/src/node-haste/lib/__tests__/AssetPaths-test.js',
+      'packages/metro/src/Server/__tests__/Server-test.js',
+      'packages/metro-config/src/__tests__/loadConfig-test.js',
+      'packages/metro-symbolicate/src/__tests__/symbolicate-test.js',
+      'packages/metro-file-map/src/__tests__/index-test.js',
+      'packages/metro-file-map/src/watchers/__tests__/WatchmanWatcher-test.js',
+      'packages/metro-file-map/src/crawlers/__tests__/node-test.js',
+      'packages/metro-file-map/src/watchers/__tests__/integration-test.js',
+
+      // resolveModulePath failed
+      'packages/metro-cache/src/stores/__tests__/FileStore-test.js',
+      'packages/metro-resolver/src/__tests__/assets-test.js',
+      'packages/metro-resolver/src/__tests__/platform-extensions-test.js',
+      'packages/metro-resolver/src/__tests__/symlinks-test.js',
+
+      // const {_cwd} = this; resolution issue in `metro-memory-fs/src/index.js:1294:15`
+      'packages/metro/src/__tests__/Assets-test.js',
+      'packages/metro/src/DeltaBundler/__tests__/resolver-test.js',
+      'packages/buck-worker-tool/src/__tests__/worker-test.js',
+      'packages/metro-transform-worker/src/__tests__/index-test.js',
+      'packages/metro-cache/src/stores/__tests__/AutoCleanFileStore-test.js',
+      'packages/metro-cache/src/stores/__tests__/FileStore-test.js',
+
+      // endless loading
+      'packages/metro-resolver/src/__tests__/browser-spec-test.js',
+      'packages/metro-resolver/src/__tests__/package-exports-test.js',
+      'packages/metro-resolver/src/__tests__/index-test.js',
+
+      // unclear issue
+      'packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js',
+      'packages/metro-file-map/src/crawlers/__tests__/integration-test.js',
+    ],
+  );
+}
+
 /** @type {import('jest').Config} **/
 module.exports = {
   modulePathIgnorePatterns: ['/node_modules/', 'packages/[^/]+/build/'],

--- a/packages/metro/src/integration_tests/__tests__/server-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-test.js
@@ -32,11 +32,11 @@ describe('Metro development server serves bundles via HTTP', () => {
   const bundlesDownloaded = new Set();
   let serverClosedPromise;
 
-  async function downloadAndExec(path: string, context = {}): mixed {
+  async function downloadAndExec(pathname: string, context = {}): mixed {
     const response = await fetchAndClose(
-      'http://localhost:' + config.server.port + path,
+      'http://localhost:' + config.server.port + pathname,
     );
-    bundlesDownloaded.add(path);
+    bundlesDownloaded.add(pathname.replaceAll('\\', '/'));
 
     const body = await response.text();
 

--- a/packages/metro/src/integration_tests/__tests__/server-torn-down-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-torn-down-test.js
@@ -15,6 +15,8 @@ jest.unmock('cosmiconfig');
 
 jest.useRealTimers();
 
+jest.setTimeout(10000);
+
 describe('Server torn down test', () => {
   const active = new Map();
   const hook = asyncHooks.createHook({


### PR DESCRIPTION
## Summary
* Make tests pass on by fixing 2 tests files and ignoring 27 test files categorized into 4 categories of reasons for their failure.
* This allows us to run on CI **1308 tests on across 96 files on Windows** ignoring around 700 tests (**64% out of the 2038 tests that pass on macOS**)
* Run tests on MacOS as well, meaning that the tests will now run on Ubuntu, Windows, MacOS

Changelog: [Internal]

## Test plan
`yarn jest` on Windows.
![image](https://github.com/user-attachments/assets/40f22af0-8c20-4f70-b8b3-9c28d40a6b0b)

CI passes, testing on Windows, Linux, and MacOS:
* PR: https://github.com/facebook/metro/actions/runs/11381806744 ![image](https://github.com/user-attachments/assets/c20f81e2-b4ea-4248-8817-be55e25073e1)
* Nightly: https://github.com/facebook/metro/actions/runs/11381806756 (fails the same way the current nightly tests fail on current node. Please ignore)
