### PR TITLE
Distinguish source ESM imports and propagate isESMImport to ResolutionContext

### DIFF
--- a/docs/Resolution.md
+++ b/docs/Resolution.md
@@ -243,6 +243,12 @@ Given the path to a `package.json` file, returns the parsed file contents.
 
 Given a candidate absolute module path that may exist under a package, locates and returns the closest package root (working upwards from the given path, stopping at the nearest `node_modules`), parsed `package.json` contents, and the package-relative path of the given path.
 
+#### `isESMImport?: boolean`
+
+Whether the dependency to be resolved was declared with an ESM import, ("import x from 'y'" or "await import('z')"), or a CommonJS "require". Corresponds to the criteria Node.js uses to assert an "import" resolution condition, vs "require".
+
+Always equal to dependency.data.isESMImport where dependency is provided, but may be used for resolution.
+
 #### `resolveHasteModule: string => ?string`
 
 Resolves a Haste module name to an absolute path. Returns `null` if no such module exists.

--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -56,10 +56,13 @@ export type BabelFileFunctionMapMetadata = $ReadOnly<{
   mappings: string,
 }>;
 
+export type BabelFileImportLocsMetadata = $ReadOnlySet<string>;
+
 export type MetroBabelFileMetadata = {
   ...BabelFileMetadata,
   metro?: ?{
     functionMap?: ?BabelFileFunctionMapMetadata,
+    unstable_importDeclarationLocs?: ?BabelFileImportLocsMetadata,
     ...
   },
   ...

--- a/packages/metro-resolver/src/__tests__/utils.js
+++ b/packages/metro-resolver/src/__tests__/utils.js
@@ -76,6 +76,7 @@ export function createResolutionContext(
         realPath: candidate.realPath,
       };
     },
+    isESMImport: false,
     mainFields: ['browser', 'main'],
     nodeModulesPaths: [],
     preferNativePlatform: false,

--- a/packages/metro-resolver/src/types.js
+++ b/packages/metro-resolver/src/types.js
@@ -158,6 +158,17 @@ export type ResolutionContext = $ReadOnly<{
   dependency?: TransformResultDependency,
 
   /**
+   * Whether the dependency to be resolved was declared with an ESM import,
+   * ("import x from 'y'" or "await import('z')"), or a CommonJS "require".
+   * Corresponds to the criteria Node.js uses to assert an "import"
+   * resolution condition, vs "require".
+   *
+   * Always equal to dependency.data.isESMImport where dependency is provided,
+   * but may be used for resolution.
+   */
+  isESMImport?: boolean,
+
+  /**
    * Synchonously returns information about a given absolute path, including
    * whether it exists, whether it is a file or directory, and its absolute
    * real path.

--- a/packages/metro-resolver/types/types.d.ts
+++ b/packages/metro-resolver/types/types.d.ts
@@ -134,6 +134,17 @@ export interface ResolutionContext {
   readonly dependency?: TransformResultDependency;
 
   /**
+   * Whether the dependency to be resolved was declared with an ESM import,
+   * ("import x from 'y'" or "await import('z')"), or a CommonJS "require".
+   * Corresponds to the criteria Node.js uses to assert an "import"
+   * resolution condition, vs "require".
+   *
+   * Always equal to dependency.data.isESMImport where dependency is provided,
+   * but may be used for resolution.
+   */
+  readonly isESMImport?: boolean;
+
+  /**
    * Synchonously returns information about a given absolute path, including
    * whether it exists, whether it is a file or directory, and its absolute
    * real path.

--- a/packages/metro/src/DeltaBundler/Serializers/__tests__/baseJSBundle-test.js
+++ b/packages/metro/src/DeltaBundler/Serializers/__tests__/baseJSBundle-test.js
@@ -41,7 +41,10 @@ const fooModule: Module<> = {
       './bar',
       {
         absolutePath: '/root/bar',
-        data: {data: {asyncType: null, locs: [], key: './bar'}, name: './bar'},
+        data: {
+          data: {asyncType: null, isESMImport: false, locs: [], key: './bar'},
+          name: './bar',
+        },
       },
     ],
   ]),

--- a/packages/metro/src/DeltaBundler/Serializers/__tests__/getRamBundleInfo-test.js
+++ b/packages/metro/src/DeltaBundler/Serializers/__tests__/getRamBundleInfo-test.js
@@ -32,7 +32,10 @@ function createModule(
           dep,
           {
             absolutePath: `/root/${dep}.js`,
-            data: {data: {asyncType: null, locs: [], key: dep}, name: dep},
+            data: {
+              data: {asyncType: null, isESMImport: false, locs: [], key: dep},
+              name: dep,
+            },
           },
         ]),
       ),

--- a/packages/metro/src/DeltaBundler/Serializers/__tests__/sourceMapString-test.js
+++ b/packages/metro/src/DeltaBundler/Serializers/__tests__/sourceMapString-test.js
@@ -44,7 +44,10 @@ const fooModule: Module<> = {
       './bar',
       {
         absolutePath: '/root/bar.js',
-        data: {data: {asyncType: null, locs: [], key: './bar'}, name: './bar'},
+        data: {
+          data: {asyncType: null, isESMImport: false, locs: [], key: './bar'},
+          name: './bar',
+        },
       },
     ],
   ]),

--- a/packages/metro/src/DeltaBundler/Serializers/helpers/__tests__/js-test.js
+++ b/packages/metro/src/DeltaBundler/Serializers/helpers/__tests__/js-test.js
@@ -30,14 +30,20 @@ beforeEach(() => {
         'bar',
         {
           absolutePath: '/bar.js',
-          data: {data: {asyncType: null, locs: [], key: 'bar'}, name: 'bar'},
+          data: {
+            data: {asyncType: null, isESMImport: false, locs: [], key: 'bar'},
+            name: 'bar',
+          },
         },
       ],
       [
         'baz',
         {
           absolutePath: '/baz.js',
-          data: {data: {asyncType: null, locs: [], key: 'baz'}, name: 'baz'},
+          data: {
+            data: {asyncType: null, isESMImport: false, locs: [], key: 'baz'},
+            name: 'baz',
+          },
         },
       ],
     ]),

--- a/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-context-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-context-test.js
@@ -91,7 +91,12 @@ describe('DeltaCalculator + require.context', () => {
               absolutePath: '/ctx?ctx=xxx',
               data: {
                 name: 'ctx',
-                data: {key: 'ctx?ctx=xxx', asyncType: null, locs: []},
+                data: {
+                  key: 'ctx?ctx=xxx',
+                  asyncType: null,
+                  isESMImport: false,
+                  locs: [],
+                },
               },
             },
           ],
@@ -109,7 +114,12 @@ describe('DeltaCalculator + require.context', () => {
               absolutePath: '/ctx/foo',
               data: {
                 name: 'foo',
-                data: {key: 'foo', asyncType: null, locs: []},
+                data: {
+                  key: 'foo',
+                  asyncType: null,
+                  isESMImport: false,
+                  locs: [],
+                },
               },
             },
           ],

--- a/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js
@@ -94,7 +94,12 @@ describe.each(['linux', 'win32'])('DeltaCalculator (%s)', osPlatform => {
               absolutePath: p('/foo'),
               data: {
                 name: 'foo',
-                data: {key: 'foo', asyncType: null, locs: []},
+                data: {
+                  key: 'foo',
+                  asyncType: null,
+                  isESMImport: false,
+                  locs: [],
+                },
               },
             },
           ],
@@ -104,7 +109,12 @@ describe.each(['linux', 'win32'])('DeltaCalculator (%s)', osPlatform => {
               absolutePath: p('/bar'),
               data: {
                 name: 'bar',
-                data: {key: 'bar', asyncType: null, locs: []},
+                data: {
+                  key: 'bar',
+                  asyncType: null,
+                  isESMImport: false,
+                  locs: [],
+                },
               },
             },
           ],
@@ -114,7 +124,12 @@ describe.each(['linux', 'win32'])('DeltaCalculator (%s)', osPlatform => {
               absolutePath: p('/baz'),
               data: {
                 name: 'baz',
-                data: {key: 'baz', asyncType: null, locs: []},
+                data: {
+                  key: 'baz',
+                  asyncType: null,
+                  isESMImport: false,
+                  locs: [],
+                },
               },
             },
           ],
@@ -132,7 +147,12 @@ describe.each(['linux', 'win32'])('DeltaCalculator (%s)', osPlatform => {
               absolutePath: p('/qux'),
               data: {
                 name: 'qux',
-                data: {key: 'qux', asyncType: null, locs: []},
+                data: {
+                  key: 'qux',
+                  asyncType: null,
+                  isESMImport: false,
+                  locs: [],
+                },
               },
             },
           ],

--- a/packages/metro/src/DeltaBundler/__tests__/Graph-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/Graph-test.js
@@ -369,6 +369,7 @@ beforeEach(async () => {
           name: dep.name,
           data: {
             asyncType: null,
+            isESMImport: false,
             // $FlowFixMe[missing-empty-array-annot]
             locs: [],
             // $FlowFixMe[incompatible-call]
@@ -3498,6 +3499,7 @@ describe('reorderGraph', () => {
       data: {
         data: {
           asyncType: null,
+          isESMImport: false,
           locs: [],
           key: path.substr(1),
         },

--- a/packages/metro/src/DeltaBundler/__tests__/__snapshots__/Graph-test.js.snap
+++ b/packages/metro/src/DeltaBundler/__tests__/__snapshots__/Graph-test.js.snap
@@ -10,6 +10,7 @@ TestGraph {
           "data": Object {
             "data": Object {
               "asyncType": null,
+              "isESMImport": false,
               "key": "LB7P4TKrvfdUdViBXGaVopqz7Os=",
               "locs": Array [],
             },
@@ -39,6 +40,7 @@ TestGraph {
           "data": Object {
             "data": Object {
               "asyncType": null,
+              "isESMImport": false,
               "key": "W+de6an7x9bzpev84O0W/hS4K8U=",
               "locs": Array [],
             },
@@ -50,6 +52,7 @@ TestGraph {
           "data": Object {
             "data": Object {
               "asyncType": null,
+              "isESMImport": false,
               "key": "x6e9Oz1JO0QPfIBBjUad2qqGFjI=",
               "locs": Array [],
             },
@@ -137,6 +140,7 @@ TestGraph {
           "data": Object {
             "data": Object {
               "asyncType": null,
+              "isESMImport": false,
               "key": "LB7P4TKrvfdUdViBXGaVopqz7Os=",
               "locs": Array [],
             },

--- a/packages/metro/src/DeltaBundler/__tests__/buildSubgraph-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/buildSubgraph-test.js
@@ -17,10 +17,17 @@ import nullthrows from 'nullthrows';
 const makeTransformDep = (
   name: string,
   asyncType: null | 'weak' | 'async' = null,
+  isESMImport: boolean = false,
   contextParams?: RequireContextParams,
 ): TransformResultDependency => ({
   name,
-  data: {key: 'key-' + name, asyncType, locs: [], contextParams},
+  data: {
+    key: 'key-' + name + (isESMImport ? '-import' : ''),
+    asyncType,
+    isESMImport,
+    locs: [],
+    contextParams,
+  },
 });
 
 class BadTransformError extends Error {}
@@ -40,7 +47,7 @@ describe('GraphTraversal', () => {
       [
         '/entryWithContext',
         [
-          makeTransformDep('virtual', null, {
+          makeTransformDep('virtual', null, false, {
             filter: {
               pattern: 'contextMatch.*',
               flags: 'i',

--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -54,6 +54,7 @@ function dep(name: string): TransformResultDependency {
     name,
     data: {
       asyncType: null,
+      isESMImport: false,
       key: name,
       locs: [],
     },

--- a/packages/metro/src/DeltaBundler/types.flow.js
+++ b/packages/metro/src/DeltaBundler/types.flow.js
@@ -45,6 +45,11 @@ export type TransformResultDependency = $ReadOnly<{
      */
     asyncType: AsyncDependencyType | null,
     /**
+     * True if the dependency is declared with a static "import x from 'y'" or
+     * an import() call.
+     */
+    isESMImport: boolean,
+    /**
      * The dependency is enclosed in a try/catch block.
      */
     isOptional?: boolean,

--- a/packages/metro/src/HmrServer.js
+++ b/packages/metro/src/HmrServer.js
@@ -125,6 +125,7 @@ class HmrServer<TClient: Client> {
         data: {
           key: entryFile,
           asyncType: null,
+          isESMImport: false,
           locs: [],
         },
       },

--- a/packages/metro/src/ModuleGraph/worker/__tests__/importLocationsPlugin-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/importLocationsPlugin-test.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {MetroBabelFileMetadata} from 'metro-babel-transformer';
+
+import collectDependencies from '../collectDependencies';
+import nullthrows from 'nullthrows';
+
+const {importLocationsPlugin, locToKey} = require('../importLocationsPlugin');
+const {transformFromAstSync} = require('@babel/core');
+const {parse: hermesParse} = require('hermes-parser');
+
+function parse(code: string) {
+  // $FlowExpectedError[incompatible-exact] - we don't care about the AST structure
+  return hermesParse(code, {
+    babel: true,
+    sourceType: 'module',
+  }) as BabelNodeFile;
+}
+
+test('gathers source locs of static ESM imports and re-exports', () => {
+  const code = `
+  // ESM imports that will be transformed by any ESM->CJS transform, we must
+  // track them.
+  import foo from "./foo";
+  import {bar} from "./bar";
+  export {baz} from "./baz";
+
+  // Not runtime imports
+  export default 47;
+  export const qux = 'qux';
+  export type {TBar} from "./Bar";
+  import type TFoo from "./Foo";
+
+  // CommonJS dependencies
+  const cjs = require("./cjs");
+
+  // This imports ESM but is valid in CommonJS, so preserved by ESM->CJS
+  // transforms - we don't need to track it.
+  export async function importAsync() {
+    await import("./async");
+  }
+  `;
+
+  const result = transformFromAstSync<MetroBabelFileMetadata>(
+    parse(code),
+    code,
+    {
+      filename: 'file.js',
+      cwd: '/my/root',
+      plugins: [importLocationsPlugin],
+    },
+  );
+  expect(result.metadata.metro?.unstable_importDeclarationLocs).toEqual(
+    new Set(['4,2:4,26', '5,2:5,28', '6,2:6,28']),
+  );
+});
+
+test('works end-to-end with collectDependencies to distinguish source ESM imports despite ESM->CJS', () => {
+  const code = `
+  import foo from "./foo";
+  import {bar} from "./bar";
+  export {baz} from "./baz";
+  const {qux} = require("./qux");
+  export default async function() {
+    await import("./async");
+  };
+  `;
+  const {metadata} = transformFromAstSync<MetroBabelFileMetadata>(
+    parse(code),
+    code,
+    {
+      filename: 'file.js',
+      cwd: '/my/root',
+      plugins: [importLocationsPlugin],
+    },
+  );
+  const importDeclarationLocs = metadata.metro?.unstable_importDeclarationLocs;
+
+  const cjsAst = nullthrows(
+    transformFromAstSync(parse(code), code, {
+      code: false,
+      ast: true,
+      filename: 'file.js',
+      cwd: '/my/root',
+      // $FlowFixMe[untyped-import] Untyped in OSS only
+      plugins: [require('@babel/plugin-transform-modules-commonjs')],
+    }).ast,
+  );
+
+  // Transform with collectDependencies
+  const result = collectDependencies(cjsAst, {
+    asyncRequireModulePath: 'asyncRequire',
+    dependencyMapName: null,
+    dynamicRequires: 'reject',
+    inlineableCalls: ['require'],
+    keepRequireNames: true,
+    allowOptionalDependencies: true,
+    unstable_allowRequireContext: false,
+    unstable_isESMImportAtSource: importDeclarationLocs
+      ? loc => importDeclarationLocs.has(locToKey(loc))
+      : null,
+  });
+  expect(result.dependencies).toEqual([
+    {
+      name: './foo',
+      data: expect.objectContaining({
+        isESMImport: true,
+      }),
+    },
+    {
+      name: './bar',
+      data: expect.objectContaining({
+        isESMImport: true,
+      }),
+    },
+    {
+      name: './baz',
+      data: expect.objectContaining({
+        isESMImport: true,
+      }),
+    },
+    {
+      name: './qux',
+      data: expect.objectContaining({
+        isESMImport: false,
+      }),
+    },
+    {
+      name: './async',
+      data: expect.objectContaining({
+        asyncType: 'async',
+        isESMImport: true,
+      }),
+    },
+    {
+      name: 'asyncRequire',
+      data: expect.objectContaining({
+        isESMImport: false,
+      }),
+    },
+  ]);
+});

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -29,6 +29,7 @@ const {isImport} = types;
 
 type ImportDependencyOptions = $ReadOnly<{
   asyncType: AsyncDependencyType,
+  isESMImport: boolean,
 }>;
 
 export type Dependency = $ReadOnly<{
@@ -56,6 +57,11 @@ type DependencyData = $ReadOnly<{
   // If null, then the dependency is synchronous.
   // (ex. `require('foo')`)
   asyncType: AsyncDependencyType | null,
+  // If true, the dependency is declared using an ESM import, e.g.
+  // "import x from 'y'" or "await import('z')". A resolver should typically
+  // use this to assert either "import" or "require" for conditional exports
+  // and subpath imports.
+  isESMImport: boolean,
   isOptional?: boolean,
   locs: $ReadOnlyArray<BabelSourceLocation>,
   /** Context for requiring a collection of modules. */
@@ -82,6 +88,7 @@ export type State = {
   allowOptionalDependencies: AllowOptionalDependencies,
   /** Enable `require.context` statements which can be used to import multiple files in a directory. */
   unstable_allowRequireContext: boolean,
+  unstable_isESMImportAtSource: ?(BabelSourceLocation) => boolean,
 };
 
 export type Options = $ReadOnly<{
@@ -94,6 +101,7 @@ export type Options = $ReadOnly<{
   dependencyTransformer?: DependencyTransformer,
   /** Enable `require.context` statements which can be used to import multiple files in a directory. */
   unstable_allowRequireContext: boolean,
+  unstable_isESMImportAtSource?: ?(BabelSourceLocation) => boolean,
 }>;
 
 export type CollectedDependencies = $ReadOnly<{
@@ -154,6 +162,7 @@ function collectDependencies(
     keepRequireNames: options.keepRequireNames,
     allowOptionalDependencies: options.allowOptionalDependencies,
     unstable_allowRequireContext: options.unstable_allowRequireContext,
+    unstable_isESMImportAtSource: options.unstable_isESMImportAtSource ?? null,
   };
 
   const visitor = {
@@ -171,6 +180,7 @@ function collectDependencies(
       if (isImport(callee)) {
         processImportCall(path, state, {
           asyncType: 'async',
+          isESMImport: true,
         });
         return;
       }
@@ -178,6 +188,7 @@ function collectDependencies(
       if (name === '__prefetchImport' && !path.scope.getBinding(name)) {
         processImportCall(path, state, {
           asyncType: 'prefetch',
+          isESMImport: true,
         });
         return;
       }
@@ -235,6 +246,10 @@ function collectDependencies(
       ) {
         processImportCall(path, state, {
           asyncType: 'maybeSync',
+          // Treat require.unstable_importMaybeSync as an ESM import, like its
+          // async "await import()" counterpart. Subject to change while
+          // unstable_.
+          isESMImport: true,
         });
         visited.add(path.node);
         return;
@@ -408,6 +423,7 @@ function processRequireContextCall(
       // Capture the matching context
       contextParams,
       asyncType: null,
+      isESMImport: false,
       optional: isOptionalDependency(directory, path, state),
     },
     path,
@@ -433,6 +449,7 @@ function processResolveWeakCall(
     {
       name,
       asyncType: 'weak',
+      isESMImport: false,
       optional: isOptionalDependency(name, path, state),
     },
     path,
@@ -458,6 +475,7 @@ See: https://github.com/facebook/metro/pull/1343`,
       {
         name: path.node.source.value,
         asyncType: null,
+        isESMImport: true,
         optional: false,
       },
       path,
@@ -481,6 +499,7 @@ function processImportCall(
     {
       name,
       asyncType: options.asyncType,
+      isESMImport: options.isESMImport,
       optional: isOptionalDependency(name, path, state),
     },
     path,
@@ -523,11 +542,21 @@ function processRequireCall(
     return;
   }
 
+  let isESMImport = false;
+  if (state.unstable_isESMImportAtSource) {
+    const isImport = state.unstable_isESMImportAtSource;
+    const loc = getNearestLocFromPath(path);
+    if (loc) {
+      isESMImport = isImport(loc);
+    }
+  }
+
   const dep = registerDependency(
     state,
     {
       name,
       asyncType: null,
+      isESMImport,
       optional: isOptionalDependency(name, path, state),
     },
     path,
@@ -555,6 +584,7 @@ function getNearestLocFromPath(path: NodePath<>): ?BabelSourceLocation {
 export type ImportQualifier = $ReadOnly<{
   name: string,
   asyncType: AsyncDependencyType | null,
+  isESMImport: boolean,
   optional: boolean,
   contextParams?: RequireContextParams,
 }>;
@@ -801,13 +831,16 @@ function createModuleNameLiteral(dependency: InternalDependency) {
 
 /**
  * Given an import qualifier, return a key used to register the dependency.
- * Generally this return the `ImportQualifier.name` property, but more
- * attributes can be appended to distinguish various combinations that would
- * otherwise conflict.
+ * Attributes can be appended to distinguish various combinations that would
+ * otherwise be considered the same dependency edge.
  *
- * For example, the following case would have collision issues if they all utilized the `name` property:
+ * For example, the following dependencies would collapse into a single edge
+ * if they simply utilized the `name` property:
+ *
  * ```
  * require('./foo');
+ * import foo from './foo'
+ * await import('./foo')
  * require.context('./foo');
  * require.context('./foo', true, /something/);
  * require.context('./foo', false, /something/);
@@ -817,14 +850,13 @@ function createModuleNameLiteral(dependency: InternalDependency) {
  * This method should be utilized by `registerDependency`.
  */
 function getKeyForDependency(qualifier: ImportQualifier): string {
-  let key = qualifier.name;
+  const {asyncType, contextParams, isESMImport, name} = qualifier;
 
-  const {asyncType} = qualifier;
-  if (asyncType) {
-    key += ['', asyncType].join('\0');
+  let key = [name, isESMImport ? 'import' : 'require'].join('\0');
+  if (asyncType != null) {
+    key += '\0' + asyncType;
   }
 
-  const {contextParams} = qualifier;
   // Add extra qualifiers when using `require.context` to prevent collisions.
   if (contextParams) {
     // NOTE(EvanBacon): Keep this synchronized with `RequireContextParams`, if any other properties are added
@@ -854,6 +886,7 @@ class DependencyRegistry {
       const newDependency: MutableInternalDependency = {
         name: qualifier.name,
         asyncType: qualifier.asyncType,
+        isESMImport: qualifier.isESMImport,
         locs: [],
         index: this._dependencies.size,
         key: crypto.createHash('sha1').update(key).digest('base64'),

--- a/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
+++ b/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+'use strict';
+
+import type {PluginObj} from '@babel/core';
+import typeof * as Types from '@babel/types';
+import type {MetroBabelFileMetadata} from 'metro-babel-transformer';
+
+const invariant = require('invariant');
+
+type ImportDeclarationLocs = Set<string>;
+
+function importLocationsPlugin({types: t}: {types: Types, ...}): PluginObj<> {
+  const importDeclarationLocs: ImportDeclarationLocs = new Set();
+  return {
+    visitor: {
+      ImportDeclaration(path) {
+        if (
+          // Ignore type imports
+          path.node.importKind !== 'type' &&
+          // loc may not be set if this plugin runs alongside others which
+          // inject imports - eg Babel runtime helpers. We don't regard these
+          // as source import declarations.
+          path.node.loc != null
+        ) {
+          importDeclarationLocs.add(locToKey(path.node.loc));
+        }
+      },
+      ExportDeclaration(path) {
+        if (
+          // If `source` is set, this is a re-export, so it declares an ESM
+          // dependency.
+          path.node.source != null &&
+          // Ignore type exports
+          path.node.exportKind !== 'type' &&
+          // As above, ignore injected imports.
+          path.node.loc != null
+        ) {
+          importDeclarationLocs.add(locToKey(path.node.loc));
+        }
+      },
+    },
+    pre: ({path, metadata}) => {
+      invariant(
+        path && t.isProgram(path.node),
+        'path missing or not a program node',
+      );
+
+      // $FlowFixMe[prop-missing] Babel `File` is not generically typed
+      const metroMetadata: MetroBabelFileMetadata = metadata;
+
+      // Set the result on a metadata property
+      if (!metroMetadata.metro) {
+        metroMetadata.metro = {
+          unstable_importDeclarationLocs: importDeclarationLocs,
+        };
+      } else {
+        metroMetadata.metro.unstable_importDeclarationLocs =
+          importDeclarationLocs;
+      }
+    },
+  };
+}
+
+// Very simple serialisation of a source location. This should remain opaque to
+// the caller.
+const MISSING_LOC = {line: -1, column: -1};
+function locToKey(loc: BabelSourceLocation): string {
+  const {start = MISSING_LOC, end = MISSING_LOC} = loc;
+  return `${start.line},${start.column}:${end.line},${end.column}`;
+}
+
+module.exports = {importLocationsPlugin, locToKey};

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -1420,7 +1420,7 @@ class Server {
         : this._config.projectRoot;
     return resolutionFn(`${rootDir}/.`, {
       name: filePath,
-      data: {key: filePath, locs: [], asyncType: null},
+      data: {key: filePath, locs: [], asyncType: null, isESMImport: false},
     }).filePath;
   }
 

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -213,7 +213,12 @@ describe('processRequest', () => {
                   {
                     absolutePath: '/root/foo.js',
                     data: {
-                      data: {asyncType: null, key: 'foo', locs: []},
+                      data: {
+                        asyncType: null,
+                        isESMImport: false,
+                        key: 'foo',
+                        locs: [],
+                      },
                       name: 'foo',
                     },
                   },

--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -118,6 +118,7 @@ class ModuleResolver<TPackage: Packageish> {
           data: {
             key: this._options.emptyModulePath,
             asyncType: null,
+            isESMImport: false,
             locs: [],
           },
         },
@@ -165,6 +166,7 @@ class ModuleResolver<TPackage: Packageish> {
             doesFileExist,
             extraNodeModules,
             fileSystemLookup,
+            isESMImport: dependency.data.isESMImport,
             mainFields,
             nodeModulesPaths,
             preferNativePlatform,


### PR DESCRIPTION
## Summary
Correct `package.json#exports` and `package.json#imports` support requires that we assert an `"import"` or `"require"` [condition](https://nodejs.org/docs/latest-v22.x/api/packages.html#conditional-exports).

From the Node.js (where this spec originated) docs:
 
 ```
 "import" - matches when the package is loaded via import or import(), or via any top-level import or resolve operation by the ECMAScript module loader. Applies regardless of the module format of the target file. Always mutually exclusive with "require".
"require" - matches when the package is loaded via require(). The referenced file should be loadable with require() although the condition matches regardless of the module format of the target file. Expected formats include CommonJS, JSON, native addons, and ES modules if --experimental-require-module is enabled. Always mutually exclusive with "import".
```

Currently, we don't distinguish between import-ish and require-ish dependencies. This modifies `collectDependencies` to add `isESMImport` to the collected `DependencyData` and dependency key (so that for example `import('foo')` and `require('foo')` in the same file are considered distinct edges with potentially different resolutions).

Test Plan:
Modified unit tests
Tested E2E further down the stack

Changelog: [Internal]