### PR TITLE
feat: optimize getMaxWorkers using os.availableParallelism

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -143,7 +143,7 @@ If `true`, Metro will use a stable mapping from files to transformer workers, so
 
 Type: `number`
 
-The number of workers to use for parallel processing in Metro. Defaults to approximately half of the number of cores available on the machine, as reported by [`os.availableParallelism()`](https://nodejs.org/api/os.html#availableparallelism).
+The number of workers to use for parallel processing in Metro. Defaults to approximately half of the number of cores available on the machine, as reported by [`os.availableParallelism()`](https://nodejs.org/api/os.html#osavailableparallelism).
 
 :::note
 1. Values exceeding the number of available cores have no effect.

--- a/packages/metro/src/lib/__tests__/getMaxWorkers-test.js
+++ b/packages/metro/src/lib/__tests__/getMaxWorkers-test.js
@@ -20,17 +20,17 @@ test('calculates the number of max workers', () => {
   /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an error
    * found when Flow v0.99 was deployed. To see the error, delete this comment
    * and run Flow. */
-  os.cpus.mockReturnValue({length: 1});
+  os.availableParallelism.mockReturnValue(1);
   expect(getMaxWorkers()).toBe(1);
   /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an error
    * found when Flow v0.99 was deployed. To see the error, delete this comment
    * and run Flow. */
-  os.cpus.mockReturnValue({length: 8});
+  os.availableParallelism.mockReturnValue(8);
   expect(getMaxWorkers()).toBe(6);
   /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an error
    * found when Flow v0.99 was deployed. To see the error, delete this comment
    * and run Flow. */
-  os.cpus.mockReturnValue({length: 24});
+  os.availableParallelism.mockReturnValue(24);
   expect(getMaxWorkers()).toBe(14);
   expect(getMaxWorkers(5)).toBe(5);
 });

--- a/packages/metro/src/lib/getMaxWorkers.js
+++ b/packages/metro/src/lib/getMaxWorkers.js
@@ -14,8 +14,7 @@
 const os = require('os');
 
 module.exports = (workers: ?number): number => {
-  const cores = os.cpus().length;
   return typeof workers === 'number' && Number.isInteger(workers)
-    ? Math.min(cores, workers > 0 ? workers : 1)
-    : Math.max(1, Math.ceil(cores * (0.5 + 0.5 * Math.exp(-cores * 0.07)) - 1));
+    ? workers
+    : os.availableParallelism();
 };

--- a/packages/metro/src/lib/getMaxWorkers.js
+++ b/packages/metro/src/lib/getMaxWorkers.js
@@ -14,7 +14,8 @@
 const os = require('os');
 
 module.exports = (workers: ?number): number => {
+  const cores = os.availableParallelism();
   return typeof workers === 'number' && Number.isInteger(workers)
-    ? workers
-    : os.availableParallelism();
+    ? Math.min(cores, workers > 0 ? workers : 1)
+    : Math.max(1, Math.ceil(cores * (0.5 + 0.5 * Math.exp(-cores * 0.07)) - 1));
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Optimize  the maximum number of worker parallelism using os.availableParallelism

`os.cpus().length` returns the number of CPUs in the physical device, which is static. It should be replaced with the maximum number of computations the system can execute simultaneously. In Node.js, this is provided by `os.availableParallelism()`.


Currently, Metro requires Node.js version 18.18 or higher, which includes `os.availableParallelism`.



## Test plan

Green CI


