### PR TITLE
Exclude React Compiler runtime from inline requires

### DIFF
--- a/packages/metro/src/lib/transformHelpers.js
+++ b/packages/metro/src/lib/transformHelpers.js
@@ -41,6 +41,7 @@ const baseIgnoredInlineRequires = [
   'react',
   'react/jsx-dev-runtime',
   'react/jsx-runtime',
+  'react-compiler-runtime',
   'react-native',
 ];
 


### PR DESCRIPTION
## Summary

Similar to https://github.com/facebook/metro/pull/1126. This call is in every component on every render and it is not beneficial to inline it. On the contrary, you want to reduce the indirection there.

Changelog: [Performance] Exclude React Compiler runtime from inline requires

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog:

## Test plan

Before:

<img width="846" alt="Screenshot 2024-11-17 at 18 01 25" src="https://github.com/user-attachments/assets/3e04a6b0-dd41-4374-8872-bfc5a1982866">

After:

<img width="814" alt="Screenshot 2024-11-17 at 18 08 05" src="https://github.com/user-attachments/assets/fb9cd5dc-2f50-440a-a175-1859e63752a9">
