### PR TITLE
Allow .asset.json files to be treated as assets

### DIFF
--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -650,17 +650,6 @@ module.exports = {
       }
     }
 
-    if (filename.endsWith('.json')) {
-      const jsonFile: JSONFile = {
-        filename,
-        inputFileSize: data.length,
-        code: sourceCode,
-        type: options.type,
-      };
-
-      return await transformJSON(jsonFile, context);
-    }
-
     if (options.type === 'asset') {
       const file: AssetFile = {
         filename,
@@ -670,6 +659,17 @@ module.exports = {
       };
 
       return await transformAsset(file, context);
+    }
+
+    if (filename.endsWith('.json')) {
+      const jsonFile: JSONFile = {
+        filename,
+        inputFileSize: data.length,
+        code: sourceCode,
+        type: options.type,
+      };
+
+      return await transformJSON(jsonFile, context);
     }
 
     const file: JSFile = {


### PR DESCRIPTION
This patch in conjunction with adding `asset.json` to `assetExts` allows JSON files to be treated as assets. This is helpful in cases where the JSON file is large and would cause too much bloat in the main bundle.

Perhaps because `json` was previously in the `assetExts` array (removed in https://github.com/facebook/metro/pull/593) it was necessary to have a special code path for transforming `.json` files rather than letting standard asset transformation take priority. However this logic prevents large JSON files from being treated as assets (i.e. not included in the bundle) even when using a custom extension like `.asset.json`. There is a test for `asset.json` that hints this should be supported, but the transform prevents it from working in practice (see https://github.com/facebook/metro/blob/412771475c540b6f85d75d9dcd5a39a6e0753582/packages/metro-resolver/src/__tests__/assets-test.js#L67).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog:

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
