### PR TITLE
Simplify symlink handling

### DIFF
--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -469,6 +469,16 @@ describe('FileMap', () => {
       }),
     );
 
+    // We should not have read files inside node_modules during a build
+    // if retainAllFiles == false.
+    expect(require('fs').readFileSync.mock.calls).toEqual([
+      ['/project/fruits/Banana.js'],
+      ['/project/fruits/Pear.js'],
+      ['/project/fruits/Strawberry.js'],
+      ['/project/fruits/__mocks__/Pear.js'],
+      ['/project/vegetables/Melon.js'],
+    ]);
+
     expect(hasteMap.getModule('Banana')).toEqual(
       path.join(defaultConfig.rootDir, 'fruits', 'Banana.js'),
     );
@@ -1341,7 +1351,6 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'fruits', 'Banana.js'),
           hasteImplModulePath: undefined,
-          readLink: false,
           rootDir: path.join('/', 'project'),
         },
       ],
@@ -1353,7 +1362,6 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'fruits', 'Pear.js'),
           hasteImplModulePath: undefined,
-          readLink: false,
           rootDir: path.join('/', 'project'),
         },
       ],
@@ -1365,7 +1373,6 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'fruits', 'Strawberry.js'),
           hasteImplModulePath: undefined,
-          readLink: false,
           rootDir: path.join('/', 'project'),
         },
       ],
@@ -1377,7 +1384,6 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'fruits', '__mocks__', 'Pear.js'),
           hasteImplModulePath: undefined,
-          readLink: false,
           rootDir: path.join('/', 'project'),
         },
       ],
@@ -1389,7 +1395,6 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'vegetables', 'Melon.js'),
           hasteImplModulePath: undefined,
-          readLink: false,
           rootDir: path.join('/', 'project'),
         },
       ],

--- a/packages/metro-file-map/src/__tests__/worker-test.js
+++ b/packages/metro-file-map/src/__tests__/worker-test.js
@@ -240,26 +240,6 @@ describe('worker', () => {
     expect(fs.readFile).not.toHaveBeenCalled();
   });
 
-  test('calls readLink and returns symlink target when readLink=true', async () => {
-    expect(
-      await worker({
-        computeDependencies: false,
-        filePath: path.join('/project', 'fruits', 'LinkToStrawberry.js'),
-        readLink: true,
-        rootDir,
-      }),
-    ).toEqual({
-      dependencies: undefined,
-      id: undefined,
-      module: undefined,
-      sha1: undefined,
-      symlinkTarget: path.join('.', 'Strawberry.js'),
-    });
-
-    expect(fs.readFileSync).not.toHaveBeenCalled();
-    expect(fs.promises.readlink).toHaveBeenCalled();
-  });
-
   test('can be loaded directly without transpilation', async () => {
     const code = await jest
       .requireActual('fs')

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -272,6 +272,13 @@ export interface MockMap {
   getMockModule(name: string): ?Path;
 }
 
+export type HasteConflict = {
+  id: string,
+  platform: string | null,
+  absolutePaths: Array<string>,
+  type: 'duplicate' | 'shadowing',
+};
+
 export interface HasteMap {
   getModule(
     name: string,
@@ -286,7 +293,7 @@ export interface HasteMap {
     _supportsNativePlatform: ?boolean,
   ): ?Path;
 
-  getRawHasteMap(): ReadOnlyRawHasteMap;
+  computeConflicts(): Array<HasteConflict>;
 }
 
 export type HasteMapData = Map<string, HasteMapItem>;
@@ -306,14 +313,6 @@ export interface MutableFileSystem extends FileSystem {
 export type Path = string;
 
 export type RawMockMap = Map<string, Path>;
-
-export type ReadOnlyRawHasteMap = $ReadOnly<{
-  duplicates: $ReadOnlyMap<
-    string,
-    $ReadOnlyMap<string, $ReadOnlyMap<string, number>>,
-  >,
-  map: $ReadOnlyMap<string, HasteMapItem>,
-}>;
 
 export type ReadOnlyRawMockMap = $ReadOnlyMap<string, Path>;
 

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -326,7 +326,6 @@ export type WorkerMessage = $ReadOnly<{
   computeSha1: boolean,
   dependencyExtractor?: ?string,
   enableHastePackages: boolean,
-  readLink: boolean,
   rootDir: string,
   filePath: string,
   hasteImplModulePath?: ?string,
@@ -337,5 +336,4 @@ export type WorkerMetadata = $ReadOnly<{
   id?: ?string,
   module?: ?HasteMapItemMetaData,
   sha1?: ?string,
-  symlinkTarget?: ?string,
 }>;

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -307,11 +307,6 @@ export type Path = string;
 
 export type RawMockMap = Map<string, Path>;
 
-export type RawHasteMap = {
-  duplicates: DuplicatesIndex,
-  map: HasteMapData,
-};
-
 export type ReadOnlyRawHasteMap = $ReadOnly<{
   duplicates: $ReadOnlyMap<
     string,

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -385,7 +385,6 @@ export default class FileMap extends EventEmitter {
         await this._takeSnapshotAndPersist(
           fileSystem,
           fileDelta.clocks ?? new Map(),
-          hasteMap,
           mocks,
           fileDelta.changedFiles,
           fileDelta.removedFiles,
@@ -774,7 +773,6 @@ export default class FileMap extends EventEmitter {
   async _takeSnapshotAndPersist(
     fileSystem: FileSystem,
     clocks: WatchmanClocks,
-    hasteMap: MutableHasteMap,
     mockMap: ReadOnlyRawMockMap,
     changed: FileData,
     removed: Set<CanonicalPath>,

--- a/packages/metro-file-map/src/lib/MutableHasteMap.js
+++ b/packages/metro-file-map/src/lib/MutableHasteMap.js
@@ -18,7 +18,6 @@ import type {
   HasteMapItemMetaData,
   HTypeValue,
   Path,
-  RawHasteMap,
   ReadOnlyRawHasteMap,
 } from '../flow-types';
 
@@ -41,13 +40,13 @@ type HasteMapOptions = $ReadOnly<{
 
 export default class MutableHasteMap implements HasteMap {
   +#rootDir: Path;
-  #map: Map<string, HasteMapItem> = new Map();
-  #duplicates: DuplicatesIndex = new Map();
+  +#map: Map<string, HasteMapItem> = new Map();
+  +#duplicates: DuplicatesIndex = new Map();
 
   +#console: ?Console;
   +#pathUtils: RootPathUtils;
   +#platforms: $ReadOnlySet<string>;
-  #throwOnModuleCollision: boolean;
+  +#throwOnModuleCollision: boolean;
 
   constructor(options: HasteMapOptions) {
     this.#console = options.console ?? null;
@@ -55,41 +54,6 @@ export default class MutableHasteMap implements HasteMap {
     this.#rootDir = options.rootDir;
     this.#pathUtils = new RootPathUtils(options.rootDir);
     this.#throwOnModuleCollision = options.throwOnModuleCollision;
-  }
-
-  static fromDeserializedSnapshot(
-    deserializedData: RawHasteMap,
-    options: HasteMapOptions,
-  ): MutableHasteMap {
-    const hasteMap = new MutableHasteMap(options);
-    hasteMap.#map = deserializedData.map;
-    hasteMap.#duplicates = deserializedData.duplicates;
-    return hasteMap;
-  }
-
-  getSerializableSnapshot(): RawHasteMap {
-    const mapMap = <K, V1, V2>(
-      map: $ReadOnlyMap<K, V1>,
-      mapFn: (v: V1) => V2,
-    ): Map<K, V2> => {
-      return new Map(
-        Array.from(map.entries(), ([key, val]): [K, V2] => [key, mapFn(val)]),
-      );
-    };
-
-    return {
-      duplicates: mapMap(this.#duplicates, v =>
-        mapMap(v, v2 => new Map(v2.entries())),
-      ),
-      map: mapMap(this.#map, v =>
-        Object.assign(
-          Object.create(null),
-          Object.fromEntries(
-            Array.from(Object.entries(v), ([key, val]) => [key, [...val]]),
-          ),
-        ),
-      ),
-    };
   }
 
   getModule(
@@ -282,10 +246,6 @@ export default class MutableHasteMap implements HasteMap {
     }
 
     this._recoverDuplicates(moduleName, relativeFilePath);
-  }
-
-  setThrowOnModuleCollision(shouldThrow: boolean) {
-    this.#throwOnModuleCollision = shouldThrow;
   }
 
   /**

--- a/packages/metro-file-map/src/lib/sorting.js
+++ b/packages/metro-file-map/src/lib/sorting.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+// Utilities for working with Array.prototype.sort
+
+export function compareStrings(a: null | string, b: null | string): number {
+  if (a == null) {
+    return b == null ? 0 : -1;
+  }
+  if (b == null) {
+    return 1;
+  }
+  return a.localeCompare(b);
+}
+
+export function chainComparators<T>(
+  ...comparators: Array<(a: T, b: T) => number>
+): (a: T, b: T) => number {
+  return (a, b) => {
+    for (const comparator of comparators) {
+      const result = comparator(a, b);
+      if (result !== 0) {
+        return result;
+      }
+    }
+    return 0;
+  };
+}

--- a/packages/metro-file-map/src/worker.js
+++ b/packages/metro-file-map/src/worker.js
@@ -18,7 +18,6 @@ const H = require('./constants');
 const dependencyExtractor = require('./lib/dependencyExtractor');
 const excludedExtensions = require('./workerExclusionList');
 const {createHash} = require('crypto');
-const {promises: fsPromises} = require('fs');
 const fs = require('graceful-fs');
 const path = require('path');
 
@@ -54,13 +53,11 @@ async function worker(
   let id /*: WorkerMetadata['id'] */;
   let module /*: WorkerMetadata['module'] */;
   let sha1 /*: WorkerMetadata['sha1'] */;
-  let symlinkTarget /*: WorkerMetadata['symlinkTarget'] */;
 
   const {
     computeDependencies,
     computeSha1,
     enableHastePackages,
-    readLink,
     rootDir,
     filePath,
   } = data;
@@ -118,11 +115,7 @@ async function worker(
     sha1 = sha1hex(getContent());
   }
 
-  if (readLink) {
-    symlinkTarget = await fsPromises.readlink(filePath);
-  }
-
-  return {dependencies, id, module, sha1, symlinkTarget};
+  return {dependencies, id, module, sha1};
 }
 
 module.exports = {

--- a/packages/metro-file-map/types/flow-types.d.ts
+++ b/packages/metro-file-map/types/flow-types.d.ts
@@ -304,7 +304,6 @@ export type WorkerMessage = Readonly<{
   computeSha1: boolean;
   dependencyExtractor?: string | null;
   enableHastePackages: boolean;
-  readLink: boolean;
   rootDir: string;
   filePath: string;
   hasteImplModulePath?: string | null;
@@ -315,5 +314,4 @@ export type WorkerMetadata = Readonly<{
   id?: string | null;
   module?: HasteMapItemMetaData | null;
   sha1?: string | null;
-  symlinkTarget?: string | null;
 }>;

--- a/packages/metro-file-map/types/flow-types.d.ts
+++ b/packages/metro-file-map/types/flow-types.d.ts
@@ -287,12 +287,6 @@ export interface MutableFileSystem extends FileSystem {
 
 export type Path = string;
 
-export interface RawHasteMap {
-  rootDir: Path;
-  duplicates: DuplicatesIndex;
-  map: HasteMapData;
-}
-
 export type ReadOnlyRawHasteMap = Readonly<{
   rootDir: Path;
   duplicates: ReadonlyMap<

--- a/packages/metro-file-map/types/flow-types.d.ts
+++ b/packages/metro-file-map/types/flow-types.d.ts
@@ -254,6 +254,13 @@ export type LookupResult =
       type: 'd' | 'f';
     };
 
+export type HasteConflict = {
+  id: string;
+  platform: string | null;
+  absolutePaths: Array<string>;
+  type: 'duplicate' | 'shadowing';
+};
+
 export interface HasteMap {
   getModule(
     name: string,
@@ -268,7 +275,7 @@ export interface HasteMap {
     _supportsNativePlatform: boolean | null,
   ): Path | null;
 
-  getRawHasteMap(): ReadOnlyRawHasteMap;
+  computeConflicts(): Array<HasteConflict>;
 }
 
 export type MockData = Map<string, Path>;
@@ -286,15 +293,6 @@ export interface MutableFileSystem extends FileSystem {
 }
 
 export type Path = string;
-
-export type ReadOnlyRawHasteMap = Readonly<{
-  rootDir: Path;
-  duplicates: ReadonlyMap<
-    string,
-    ReadonlyMap<string, ReadonlyMap<string, number>>
-  >;
-  map: ReadonlyMap<string, HasteMapItem>;
-}>;
 
 export type WatchmanClockSpec =
   | string


### PR DESCRIPTION
Summary:
Reading symlink targets with `readLink` is currently delegated to `metro-file-map`'s worker abstraction. However, due to the way the abstraction is used for symlinks, we never actually use the worker processes/threads, and always process in band.

The key here is that `readLink` is always mutually exclusive with other worker tasks, like `computeSha1` and `computeDependencies` - as it must be, because those operations don't make sense for symlink files.

This lifts the call to `readLink` out of the abstraction and explicitly into the main process, simplifying the worker and improving readability.

Changelog: Internal

Differential Revision: D66899343
