### PR TITLE
Track duplicates in MockMap, refactor setThrowOnModuleCollision -> assertValid

### DIFF
--- a/packages/metro-file-map/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/metro-file-map/src/__tests__/__snapshots__/index-test.js.snap
@@ -22,14 +22,6 @@ exports[`FileMap tries to crawl using node as a fallback 1`] = `
   Error: watchman error"
 `;
 
-exports[`FileMap warns on duplicate mock files 1`] = `
-"metro-file-map: duplicate manual mock found: subdir/Blueberry
-  The following files share their name; please delete one of them:
-    * <rootDir>/fruits1/__mocks__/subdir/Blueberry.js
-    * <rootDir>/fruits2/__mocks__/subdir/Blueberry.js
-"
-`;
-
 exports[`FileMap warns on duplicate module ids 1`] = `
 "metro-file-map: Haste module naming collision: Strawberry
   The following files share their name; please adjust your hasteImpl:

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -48,7 +48,7 @@ export type BuildResult = {
 
 export type CacheData = $ReadOnly<{
   clocks: WatchmanClocks,
-  mocks: RawMockMap,
+  mocks: ?RawMockMap,
   fileSystemData: mixed,
 }>;
 
@@ -312,9 +312,15 @@ export interface MutableFileSystem extends FileSystem {
 
 export type Path = string;
 
-export type RawMockMap = Map<string, Path>;
+export type RawMockMap = $ReadOnly<{
+  duplicates: Map<string, Set<string>>,
+  mocks: Map<string, Path>,
+}>;
 
-export type ReadOnlyRawMockMap = $ReadOnlyMap<string, Path>;
+export type ReadOnlyRawMockMap = $ReadOnly<{
+  duplicates: $ReadOnlyMap<string, $ReadOnlySet<string>>,
+  mocks: $ReadOnlyMap<string, Path>,
+}>;
 
 export type WatchmanClockSpec =
   | string

--- a/packages/metro-file-map/src/lib/__tests__/MockMap-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/MockMap-test.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type MockMapType from '../MockMap';
+
+let mockPathModule;
+jest.mock('path', () => mockPathModule);
+
+describe.each([['win32'], ['posix']])('MockMap on %s', platform => {
+  const p: string => string = filePath =>
+    platform === 'win32'
+      ? filePath.replace(/\//g, '\\').replace(/^\\/, 'C:\\')
+      : filePath;
+
+  let MockMap: Class<MockMapType>;
+
+  const opts = {
+    console,
+    mocksPattern: /__mocks__[\/\\].+\.(js|json)$/,
+    rootDir: p('/root'),
+    throwOnModuleCollision: true,
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockPathModule = jest.requireActual<{}>('path')[platform];
+    MockMap = require('../MockMap').default;
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.clearAllMocks();
+  });
+
+  test('set and get a mock module', () => {
+    const mockMap = new MockMap(opts);
+    mockMap.onNewOrModifiedFile(p('/root/__mocks__/foo.js'));
+    expect(mockMap.getMockModule('foo')).toBe(p('/root/__mocks__/foo.js'));
+  });
+
+  test('assertValid throws on duplicates', () => {
+    const mockMap = new MockMap(opts);
+    mockMap.onNewOrModifiedFile(p('/root/__mocks__/foo.js'));
+    mockMap.onNewOrModifiedFile(p('/root/other/__mocks__/foo.js'));
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(() => mockMap.assertValid()).toThrowError(
+      `Mock map has 1 error:
+Duplicate manual mock found for \`foo\`:
+    * <rootDir>/../../__mocks__/foo.js
+    * <rootDir>/../../other/__mocks__/foo.js
+`.replaceAll('/', mockPathModule.sep),
+    );
+  });
+
+  test('recovers from duplicates', () => {
+    const mockMap = new MockMap(opts);
+    mockMap.onNewOrModifiedFile(p('/root/__mocks__/foo.js'));
+    mockMap.onNewOrModifiedFile(p('/root/other/__mocks__/foo.js'));
+
+    expect(() => mockMap.assertValid()).toThrow();
+
+    // Latest mock wins
+    expect(mockMap.getMockModule('foo')).toBe(
+      p('/root/other/__mocks__/foo.js'),
+    );
+
+    expect(mockMap.getSerializableSnapshot()).toEqual({
+      mocks: new Map([['foo', p('other/__mocks__/foo.js')]]),
+      duplicates: new Map([
+        ['foo', new Set([p('other/__mocks__/foo.js'), p('__mocks__/foo.js')])],
+      ]),
+    });
+
+    mockMap.onRemovedFile(p('/root/other/__mocks__/foo.js'));
+
+    expect(() => mockMap.assertValid()).not.toThrow();
+
+    // Recovery after the latest mock is deleted
+    expect(mockMap.getMockModule('foo')).toBe(p('/root/__mocks__/foo.js'));
+
+    expect(mockMap.getSerializableSnapshot()).toEqual({
+      mocks: new Map([['foo', p('__mocks__/foo.js')]]),
+      duplicates: new Map(),
+    });
+  });
+});

--- a/packages/metro-file-map/types/flow-types.d.ts
+++ b/packages/metro-file-map/types/flow-types.d.ts
@@ -43,7 +43,7 @@ export interface BuildResult {
 
 export interface CacheData {
   readonly clocks: WatchmanClocks;
-  readonly mocks: MockData;
+  readonly mocks: RawMockMap;
   readonly files: FileData;
 }
 
@@ -278,7 +278,11 @@ export interface HasteMap {
   computeConflicts(): Array<HasteConflict>;
 }
 
-export type MockData = Map<string, Path>;
+export type RawMockMap = {
+  readonly mocks: Map<string, string>;
+  readonly duplicates: Map<string, Set<string>>;
+};
+
 export type HasteMapData = Map<string, HasteMapItem>;
 
 export interface HasteMapItem {


### PR DESCRIPTION
 - Refactors mock duplicate handling from "throw the next time you see an error" to "throw now if there are errors"
 - The new structure is more generic and more plugin-friendly. We'll use plugins for two main purporses:
   - Remove non-Metro concerns from Metro.
   - Extensibility, for using metro-file-map outside Metro for other purposes - eg processing Buck file changes.
 - We'll make the same change for Haste duplicates, so that Haste and Mocks are each (eventually) plugins to metro-file-map.

Changelog: Internal