### PR TITLE
FSEventsWatcher: use common recReadDir

### DIFF
--- a/packages/metro-file-map/src/watchers/FSEventsWatcher.js
+++ b/packages/metro-file-map/src/watchers/FSEventsWatcher.js
@@ -25,8 +25,6 @@ import walker from 'walker';
 
 const debug = require('debug')('Metro:FSEventsWatcher');
 
-type Matcher = typeof anymatch.Matcher;
-
 // $FlowFixMe[value-as-type]
 let fsevents: ?FSEvents = null;
 try {
@@ -54,7 +52,7 @@ type FsEventsWatcherEvent =
  */
 export default class FSEventsWatcher extends EventEmitter {
   +root: string;
-  +ignored: ?Matcher;
+  +ignored: ?RegExp;
   +glob: $ReadOnlyArray<string>;
   +dot: boolean;
   +doIgnore: (path: string) => boolean;
@@ -81,7 +79,7 @@ export default class FSEventsWatcher extends EventEmitter {
     endCallback: () => void,
     // $FlowFixMe[unclear-type] Add types for callback
     errorCallback: Function,
-    ignored?: Matcher,
+    ignored: ?RegExp,
   ) {
     walker(dir)
       .filterDir(
@@ -97,7 +95,7 @@ export default class FSEventsWatcher extends EventEmitter {
   constructor(
     dir: string,
     opts: $ReadOnly<{
-      ignored?: Matcher,
+      ignored: ?RegExp,
       glob: string | $ReadOnlyArray<string>,
       dot: boolean,
       ...

--- a/packages/metro-file-map/src/watchers/NodeWatcher.js
+++ b/packages/metro-file-map/src/watchers/NodeWatcher.js
@@ -48,7 +48,7 @@ module.exports = class NodeWatcher extends EventEmitter {
   doIgnore: string => boolean;
   dot: boolean;
   globs: $ReadOnlyArray<string>;
-  ignored: ?(boolean | RegExp);
+  ignored: ?RegExp;
   root: string;
   watched: {[key: string]: FSWatcher, __proto__: null};
   watchmanDeferStates: $ReadOnlyArray<string>;

--- a/packages/metro-file-map/src/watchers/__tests__/WatchmanWatcher-test.js
+++ b/packages/metro-file-map/src/watchers/__tests__/WatchmanWatcher-test.js
@@ -36,7 +36,7 @@ describe('WatchmanWatcher', () => {
   test('initializes with watch-project, clock, subscribe', () => {
     const watchmanWatcher = new WatchmanWatcher('/project/subdir/js', {
       dot: true,
-      ignored: false,
+      ignored: null,
       glob: ['**/*.js'],
       watchmanDeferStates: ['busy'],
     });
@@ -86,7 +86,7 @@ describe('WatchmanWatcher', () => {
     beforeEach(() => {
       watchmanWatcher = new WatchmanWatcher('/project/subdir/js', {
         dot: true,
-        ignored: false,
+        ignored: null,
         glob: ['**/*.js'],
         watchmanDeferStates: ['busy'],
       });

--- a/packages/metro-file-map/src/watchers/common.js
+++ b/packages/metro-file-map/src/watchers/common.js
@@ -39,7 +39,7 @@ export const ALL_EVENT = 'all';
 export type WatcherOptions = $ReadOnly<{
   glob: $ReadOnlyArray<string>,
   dot: boolean,
-  ignored: boolean | RegExp,
+  ignored: ?RegExp,
   watchmanDeferStates: $ReadOnlyArray<string>,
   watchman?: mixed,
   watchmanPath?: string,
@@ -49,7 +49,7 @@ interface Watcher {
   doIgnore: string => boolean;
   dot: boolean;
   globs: $ReadOnlyArray<string>;
-  ignored?: ?(boolean | RegExp);
+  ignored?: ?RegExp;
   watchmanDeferStates: $ReadOnlyArray<string>;
   watchmanPath?: ?string;
 }
@@ -68,16 +68,14 @@ export const assignOptions = function (
 ): WatcherOptions {
   watcher.globs = opts.glob ?? [];
   watcher.dot = opts.dot ?? false;
-  watcher.ignored = opts.ignored ?? false;
+  watcher.ignored = opts.ignored ?? null;
   watcher.watchmanDeferStates = opts.watchmanDeferStates;
 
   if (!Array.isArray(watcher.globs)) {
     watcher.globs = [watcher.globs];
   }
   watcher.doIgnore =
-    opts.ignored != null && opts.ignored !== false
-      ? anymatch(opts.ignored)
-      : () => false;
+    opts.ignored != null ? anymatch(opts.ignored) : () => false;
 
   if (opts.watchman == true && opts.watchmanPath != null) {
     watcher.watchmanPath = opts.watchmanPath;
@@ -117,7 +115,7 @@ export function recReaddir(
   symlinkCallback: (string, Stats) => void,
   endCallback: () => void,
   errorCallback: Error => void,
-  ignored: ?(boolean | RegExp),
+  ignored: ?RegExp,
 ) {
   walker(dir)
     .filterDir(currentDir => !anymatch(ignored, currentDir))


### PR DESCRIPTION
Summary:
`FSEventsWatcher` has its own implementation of `recReaddir` which is almost identical to the one in `./common.js`, except that it wraps handlers in `path.normalize`.

There’s only one handler, so we can trivially remove this proxy abstraction and reuse the common `recReaddir`.

(The end goal here is to slim down and tidy up FSEventsWatcher ahead of using it as a basis for native recursive watching)

Changelog: Internal

Differential Revision: D67286092


