### PR TITLE
[metro] Flow-ignore .hg directory

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 <PROJECT_ROOT>/packages/.*/build/.*
+<PROJECT_ROOT>/\.hg/.*
 # this transient dep bundles tests with their package, which flow attempts to parse
 # and crashes out as the test includes purposely malformed json
 <PROJECT_ROOT>\(/.*\)?/node_modules/resolve/test/.*


### PR DESCRIPTION

Summary:
When using Sapling in an OSS checkout, Flow does not ignore files under `.hg`, leading to false errors especially in Saplings `origbackups`, which may contain old versions of files out of context.

Changelog: Internal

Test Plan:
## Before
```
yarn flow ls | grep '\.hg'
/Users/robhogan/workspace/metro-sl/.hg/runlog/41hxy19HHF6cGBn491508.json
/Users/robhogan/workspace/metro-sl/.hg/runlog/37Z4u1Env4S8RkEa44097.json
<...>
/Users/robhogan/workspace/metro-sl/.hg/origbackups/packages/metro-file-map/src/watchers/common.js
/Users/robhogan/workspace/metro-sl/.hg/origbackups/packages/metro-file-map/src/watchers/FSEventsWatcher.js
```

```
yarn flow ls | wc -l
   25908
```

## After
```
yarn flow ls | grep '\.hg'
<empty response>
```

```
yarn flow ls | wc -l
   25861
```

Reviewers:

Subscribers:

Tasks:

Tags:
