### PR TITLE
Watcher backends: merge 'add' and 'change' events into 'touch'

### DIFF
--- a/packages/metro-file-map/src/Watcher.js
+++ b/packages/metro-file-map/src/Watcher.js
@@ -22,7 +22,7 @@ import type {AbortSignal} from 'node-abort-controller';
 
 import nodeCrawl from './crawlers/node';
 import watchmanCrawl from './crawlers/watchman';
-import {ADD_EVENT, CHANGE_EVENT} from './watchers/common';
+import {TOUCH_EVENT} from './watchers/common';
 import FSEventsWatcher from './watchers/FSEventsWatcher';
 import NodeWatcher from './watchers/NodeWatcher';
 import WatchmanWatcher from './watchers/WatchmanWatcher';
@@ -210,7 +210,7 @@ export class Watcher extends EventEmitter {
           watcher.on('all', (change: WatcherBackendChangeEvent) => {
             const basename = path.basename(change.relativePath);
             if (basename.startsWith(this._options.healthCheckFilePrefix)) {
-              if (change.event === ADD_EVENT || change.event === CHANGE_EVENT) {
+              if (change.event === TOUCH_EVENT) {
                 debug(
                   'Observed possible health check cookie: %s in %s',
                   change.relativePath,

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -1621,13 +1621,13 @@ describe('FileMap', () => {
       `;
       const e = mockEmitters[path.join('/', 'project', 'fruits')];
       e.emit('all', {
-        event: 'add',
+        event: 'touch',
         relativePath: 'Tomato.js',
         root: path.join('/', 'project', 'fruits'),
         metadata: MOCK_CHANGE_FILE,
       });
       e.emit('all', {
-        event: 'change',
+        event: 'touch',
         relativePath: 'Pear.js',
         root: path.join('/', 'project', 'fruits'),
         metadata: MOCK_CHANGE_FILE,
@@ -1662,13 +1662,13 @@ describe('FileMap', () => {
         // Tomato!
       `;
       e.emit('all', {
-        event: 'change',
+        event: 'touch',
         relativePath: 'Tomato.js',
         root: path.join('/', 'project', 'fruits'),
         metadata: MOCK_CHANGE_FILE,
       });
       e.emit('all', {
-        event: 'change',
+        event: 'touch',
         relativePath: 'Tomato.js',
         root: path.join('/', 'project', 'fruits'),
         metadata: MOCK_CHANGE_FILE,
@@ -1683,17 +1683,14 @@ describe('FileMap', () => {
         const {fileSystem} = await hm.build();
         const fruitsRoot = path.join('/', 'project', 'fruits');
         const e = mockEmitters[fruitsRoot];
-        mockFs[path.join(fruitsRoot, 'Tomato.js')] = `
-        // Tomato!
-      `;
         e.emit('all', {
-          event: 'change',
-          relativePath: 'Tomato.js',
+          event: 'touch',
+          relativePath: 'Strawberry.js',
           root: fruitsRoot,
           metadata: MOCK_CHANGE_FILE,
         });
         e.emit('all', {
-          event: 'change',
+          event: 'touch',
           relativePath: 'LinkToStrawberry.js',
           root: fruitsRoot,
           metadata: MOCK_CHANGE_LINK,
@@ -1701,7 +1698,7 @@ describe('FileMap', () => {
         const {eventsQueue} = await waitForItToChange(hm);
         expect(eventsQueue).toEqual([
           {
-            filePath: path.join(fruitsRoot, 'Tomato.js'),
+            filePath: path.join(fruitsRoot, 'Strawberry.js'),
             metadata: MOCK_CHANGE_FILE,
             type: 'change',
           },
@@ -1718,17 +1715,14 @@ describe('FileMap', () => {
         const {fileSystem} = await hm.build();
         const fruitsRoot = path.join('/', 'project', 'fruits');
         const e = mockEmitters[fruitsRoot];
-        mockFs[path.join(fruitsRoot, 'Tomato.js')] = `
-        // Tomato!
-      `;
         e.emit('all', {
-          event: 'change',
-          relativePath: 'Tomato.js',
+          event: 'touch',
+          relativePath: 'Strawberry.js',
           root: fruitsRoot,
           metadata: MOCK_CHANGE_FILE,
         });
         e.emit('all', {
-          event: 'change',
+          event: 'touch',
           relativePath: 'LinkToStrawberry.js',
           root: fruitsRoot,
           metadata: MOCK_CHANGE_LINK,
@@ -1736,7 +1730,7 @@ describe('FileMap', () => {
         const {eventsQueue} = await waitForItToChange(hm);
         expect(eventsQueue).toEqual([
           {
-            filePath: path.join(fruitsRoot, 'Tomato.js'),
+            filePath: path.join(fruitsRoot, 'Strawberry.js'),
             metadata: MOCK_CHANGE_FILE,
             type: 'change',
           },
@@ -1759,7 +1753,7 @@ describe('FileMap', () => {
         const {fileSystem} = await hm.build();
         const e = mockEmitters[path.join('/', 'project', 'fruits')];
         e.emit('all', {
-          event: 'add',
+          event: 'touch',
           relativePath: 'apple.js',
           root: path.join('/', 'project', 'fruits', 'node_modules', ''),
           metadata: MOCK_CHANGE_FILE,
@@ -1788,13 +1782,13 @@ describe('FileMap', () => {
 
         const e = mockEmitters[path.join('/', 'project', 'fruits')];
         e.emit('all', {
-          event: 'add',
+          event: 'touch',
           relativePath: 'Banana.js',
           root: path.join('/', 'project', 'fruits', ''),
           metadata: MOCK_CHANGE_FILE,
         });
         e.emit('all', {
-          event: 'add',
+          event: 'touch',
           relativePath: 'Banana.unwatched',
           root: path.join('/', 'project', 'fruits', ''),
           metadata: MOCK_CHANGE_FILE,
@@ -1803,7 +1797,7 @@ describe('FileMap', () => {
         const filePath = path.join('/', 'project', 'fruits', 'Banana.js');
         expect(eventsQueue).toHaveLength(1);
         expect(eventsQueue).toEqual([
-          {filePath, metadata: MOCK_CHANGE_FILE, type: 'add'},
+          {filePath, metadata: MOCK_CHANGE_FILE, type: 'change'},
         ]);
         expect(fileSystem.getModuleName(filePath)).toBeDefined();
       },
@@ -1844,7 +1838,7 @@ describe('FileMap', () => {
           link: 'Strawberry.js',
         };
         e.emit('all', {
-          event: 'add',
+          event: 'touch',
           relativePath: 'LinkToStrawberry.ext',
           root: path.join('/', 'project', 'fruits', ''),
           metadata: MOCK_CHANGE_LINK,
@@ -1921,13 +1915,13 @@ describe('FileMap', () => {
         expect(hasteMap.getModule('Orange', 'android')).toBeTruthy();
         const e = mockEmitters[path.join('/', 'project', 'fruits')];
         e.emit('all', {
-          event: 'change',
+          event: 'touch',
           relativePath: 'Orange.ios.js',
           root: path.join('/', 'project', 'fruits'),
           metadata: MOCK_CHANGE_FILE,
         });
         e.emit('all', {
-          event: 'change',
+          event: 'touch',
           relativePath: 'Orange.android.js',
           root: path.join('/', 'project', 'fruits'),
           metadata: MOCK_CHANGE_FILE,
@@ -1994,7 +1988,7 @@ describe('FileMap', () => {
         root: path.join('/', 'project', 'vegetables'),
       });
       mockEmitters[path.join('/', 'project', 'fruits')].emit('all', {
-        event: 'add',
+        event: 'touch',
         relativePath: 'Melon.js',
         root: path.join('/', 'project', 'fruits'),
         metadata: MOCK_CHANGE_FILE,
@@ -2033,13 +2027,13 @@ describe('FileMap', () => {
         `;
         const e = mockEmitters[path.join('/', 'project', 'fruits')];
         e.emit('all', {
-          event: 'change',
+          event: 'touch',
           relativePath: 'Pear.js',
           root: path.join('/', 'project', 'fruits'),
           metadata: MOCK_CHANGE_FILE,
         });
         e.emit('all', {
-          event: 'add',
+          event: 'touch',
           relativePath: 'Pear.js',
           root: path.join('/', 'project', 'fruits', 'another'),
           metadata: MOCK_CHANGE_FILE,
@@ -2081,13 +2075,13 @@ describe('FileMap', () => {
           const {fileSystem} = await hm.build();
           const e = mockEmitters[path.join('/', 'project', 'fruits')];
           e.emit('all', {
-            event: 'change',
+            event: 'touch',
             relativePath: 'Pear.js',
             root: path.join('/', 'project', 'fruits'),
             metadata: MOCK_CHANGE_FILE,
           });
           e.emit('all', {
-            event: 'add',
+            event: 'touch',
             relativePath: 'Pear.js',
             root: path.join('/', 'project', 'fruits', 'another'),
             metadata: MOCK_CHANGE_FILE,
@@ -2139,7 +2133,7 @@ describe('FileMap', () => {
             metadata: MOCK_CHANGE_FILE,
           });
           e.emit('all', {
-            event: 'add',
+            event: 'touch',
             relativePath: 'Pear2.js',
             root: path.join('/', 'project', 'fruits'),
             metadata: MOCK_CHANGE_FILE,
@@ -2164,7 +2158,7 @@ describe('FileMap', () => {
         `;
         const e = mockEmitters[path.join('/', 'project', 'fruits')];
         e.emit('all', {
-          event: 'add',
+          event: 'touch',
           relativePath: 'Pear2.js',
           root: path.join('/', 'project', 'fruits', 'another'),
           metadata: MOCK_CHANGE_FILE,
@@ -2189,13 +2183,13 @@ describe('FileMap', () => {
         // Tomato!
       `;
         e.emit('all', {
-          event: 'change',
+          event: 'touch',
           relativePath: 'tomato.js',
           root: path.join('/', 'project', 'fruits'),
           metadata: MOCK_CHANGE_FOLDER,
         });
         e.emit('all', {
-          event: 'change',
+          event: 'touch',
           relativePath: path.join('tomato.js', 'index.js'),
           root: path.join('/', 'project', 'fruits'),
           metadata: MOCK_CHANGE_FILE,

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -324,7 +324,7 @@ export type ReadOnlyRawMockMap = $ReadOnly<{
 
 export type WatcherBackendChangeEvent =
   | $ReadOnly<{
-      event: 'change' | 'add',
+      event: 'touch',
       relativePath: string,
       root: string,
       metadata: ChangeEventMetadata,

--- a/packages/metro-file-map/src/watchers/WatchmanWatcher.js
+++ b/packages/metro-file-map/src/watchers/WatchmanWatcher.js
@@ -32,9 +32,8 @@ import path from 'path';
 
 const debug = require('debug')('Metro:WatchmanWatcher');
 
-const CHANGE_EVENT = common.CHANGE_EVENT;
 const DELETE_EVENT = common.DELETE_EVENT;
-const ADD_EVENT = common.ADD_EVENT;
+const TOUCH_EVENT = common.TOUCH_EVENT;
 const ALL_EVENT = common.ALL_EVENT;
 const SUB_PREFIX = 'metro-file-map';
 
@@ -274,7 +273,6 @@ export default class WatchmanWatcher extends EventEmitter {
     if (!exists) {
       self._emitEvent({event: DELETE_EVENT, relativePath});
     } else {
-      const eventType = isNew ? ADD_EVENT : CHANGE_EVENT;
       invariant(
         type != null && mtime_ms != null && size != null,
         'Watchman file change event for "%s" missing some requested metadata. ' +
@@ -287,11 +285,11 @@ export default class WatchmanWatcher extends EventEmitter {
 
       if (
         // Change event on dirs are mostly useless.
-        !(type === 'd' && eventType === CHANGE_EVENT)
+        !(type === 'd' && !isNew)
       ) {
         const mtime = Number(mtime_ms);
         self._emitEvent({
-          event: eventType,
+          event: TOUCH_EVENT,
           relativePath,
           metadata: {
             modifiedTime: mtime !== 0 ? mtime : null,

--- a/packages/metro-file-map/src/watchers/__tests__/helpers.js
+++ b/packages/metro-file-map/src/watchers/__tests__/helpers.js
@@ -65,11 +65,11 @@ export type EventHelpers = {
   untilEvent: (
     afterFn: () => Promise<void>,
     expectedPath: string,
-    expectedEvent: 'add' | 'delete' | 'change',
+    expectedEvent: 'touch' | 'delete',
   ) => Promise<void>,
   allEvents: (
     afterFn: () => Promise<void>,
-    events: $ReadOnlyArray<[string, 'add' | 'delete' | 'change']>,
+    events: $ReadOnlyArray<[string, 'touch' | 'delete']>,
     opts?: {rejectUnexpected: boolean},
   ) => Promise<void>,
 };
@@ -122,7 +122,7 @@ export const startWatching = async (
         }>((resolve, reject) => {
           const listener = (change: WatcherBackendChangeEvent) => {
             if (change.relativePath === '') {
-              // FIXME: FSEventsWatcher sometimes reports 'change' events to
+              // FIXME: FSEventsWatcher sometimes reports 'touch' events to
               // the watch root.
               return;
             }
@@ -160,7 +160,7 @@ export const startWatching = async (
           );
           const listener = (change: WatcherBackendChangeEvent) => {
             if (change.relativePath === '') {
-              // FIXME: FSEventsWatcher sometimes reports 'change' events to
+              // FIXME: FSEventsWatcher sometimes reports 'touch' events to
               // the watch root.
               return;
             }

--- a/packages/metro-file-map/src/watchers/__tests__/integration-test.js
+++ b/packages/metro-file-map/src/watchers/__tests__/integration-test.js
@@ -52,7 +52,7 @@ describe.each(Object.keys(WATCHERS))(
         symlink('target', join(watchRoot, 'existing', 'symlink-to-delete')),
       ]);
 
-      // Short delay to ensure that 'add' events for the files above are not
+      // Short delay to ensure that 'touch' events for the files above are not
       // reported by the OS to the watcher we haven't established yet.
       await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -77,7 +77,7 @@ describe.each(Object.keys(WATCHERS))(
     beforeEach(async () => {
       expect(await eventHelpers.nextEvent(() => mkdir(appRoot))).toStrictEqual({
         path: 'app',
-        eventType: 'add',
+        eventType: 'touch',
         metadata: expect.any(Object),
       });
     });
@@ -90,7 +90,7 @@ describe.each(Object.keys(WATCHERS))(
         await eventHelpers.nextEvent(() =>
           writeFile(join(watchRoot, cookieName), ''),
         ),
-      ).toMatchObject({path: cookieName, eventType: 'add'});
+      ).toMatchObject({path: cookieName, eventType: 'touch'});
       // Cleanup and wait until the app root deletion is reported - this should
       // be the last cleanup event emitted.
       await eventHelpers.untilEvent(
@@ -112,7 +112,7 @@ describe.each(Object.keys(WATCHERS))(
         await eventHelpers.nextEvent(() => writeFile(testFile, 'hello world')),
       ).toStrictEqual({
         path: relativePath,
-        eventType: 'add',
+        eventType: 'touch',
         metadata: {
           type: 'f',
           modifiedTime: expect.any(Number),
@@ -128,7 +128,7 @@ describe.each(Object.keys(WATCHERS))(
         ),
       ).toStrictEqual({
         path: relativePath,
-        eventType: 'change',
+        eventType: 'touch',
         metadata: expect.any(Object),
       });
       expect(
@@ -151,7 +151,7 @@ describe.each(Object.keys(WATCHERS))(
         await eventHelpers.nextEvent(() => symlink(target, newLink)),
       ).toStrictEqual({
         path: relativePath,
-        eventType: 'add',
+        eventType: 'touch',
         metadata: {
           type: 'l',
           modifiedTime: expect.any(Number),
@@ -201,7 +201,7 @@ describe.each(Object.keys(WATCHERS))(
         ),
       ).toStrictEqual({
         path: join('existing', 'file-to-modify.js'),
-        eventType: 'change',
+        eventType: 'touch',
         metadata: expect.any(Object),
       });
     });
@@ -211,7 +211,7 @@ describe.each(Object.keys(WATCHERS))(
         await eventHelpers.nextEvent(() => mkdir(join(watchRoot, 'newdir'))),
       ).toStrictEqual({
         path: join('newdir'),
-        eventType: 'add',
+        eventType: 'touch',
         metadata: {
           modifiedTime: expect.any(Number),
           size: expect.any(Number),
@@ -224,7 +224,7 @@ describe.each(Object.keys(WATCHERS))(
         ),
       ).toStrictEqual({
         path: join('newdir', 'file-in-new-dir.js'),
-        eventType: 'add',
+        eventType: 'touch',
         metadata: {
           modifiedTime: expect.any(Number),
           size: expect.any(Number),
@@ -246,10 +246,10 @@ describe.each(Object.keys(WATCHERS))(
             ]);
           },
           [
-            [join('app', 'subdir'), 'add'],
-            [join('app', 'subdir', 'subdir2'), 'add'],
-            [join('app', 'subdir', 'deep.js'), 'add'],
-            [join('app', 'subdir', 'subdir2', 'deeper.js'), 'add'],
+            [join('app', 'subdir'), 'touch'],
+            [join('app', 'subdir', 'subdir2'), 'touch'],
+            [join('app', 'subdir', 'deep.js'), 'touch'],
+            [join('app', 'subdir', 'subdir2', 'deeper.js'), 'touch'],
           ],
           {rejectUnexpected: true},
         );

--- a/packages/metro-file-map/src/watchers/common.js
+++ b/packages/metro-file-map/src/watchers/common.js
@@ -29,9 +29,8 @@ const walker = require('walker');
 /**
  * Constants
  */
-export const CHANGE_EVENT = 'change';
 export const DELETE_EVENT = 'delete';
-export const ADD_EVENT = 'add';
+export const TOUCH_EVENT = 'touch';
 export const ALL_EVENT = 'all';
 
 export type WatcherOptions = $ReadOnly<{


### PR DESCRIPTION
Summary:
Refactor watcher backends so that they're not required to disambiguate "add" file events from "change" file events, instead emitting ambiguous "touch" events.

This distinction isn't typically available from the host OS (`fsevents`, `ReadDirectoryChangesW`, `inotify`), so for the backends to supply it, they must track all files to know whether they existed prior to the OS event. Watchman does this by design anyway, and typically only once per session, but both our `FSEventsWatcher` and `NodeWatcher` currently crawl the whole directory tree and keep an in-memory list of files, and must do so on each Metro start.

We don't need this information from the watchers anyway, because we can already infer new vs modified according to whether the file is present in `TreeFS` (ie, from the crawl, or subsequent event). Therefore we *don't* need to reduce the granularity of `metro-file-map`'s *public* events, only the internal ones.

By simplifying this, we can follow up by taking a huge burden off the watcher backends.

Changelog: Internal

Differential Revision: D67579233


