### PR TITLE
feat: Add host configuration support for Metro server

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -613,6 +613,12 @@ Type: `number`
 
 Which port to listen on.
 
+#### `host`
+
+Type: `string`
+
+Which host to use.
+
 #### `useGlobalHotkey`
 
 Type: `boolean`

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -172,6 +172,7 @@ type ServerConfigT = {
   enhanceMiddleware: (Middleware, MetroServer) => Middleware | Server,
   forwardClientLogs: boolean,
   port: number,
+  host: string,
   rewriteRequestUrl: string => string,
   unstable_serverRoot: ?string,
   useGlobalHotkey: boolean,

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -76,6 +76,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     enhanceMiddleware: (middleware, _) => middleware,
     forwardClientLogs: true,
     port: 8081,
+    host: 'localhost',
     rewriteRequestUrl: url => url,
     unstable_serverRoot: null,
     useGlobalHotkey: true,

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -234,6 +234,10 @@ function overrideConfigWithArguments(
     output.server.port = Number(argv.port);
   }
 
+  if (argv.host != null) {
+    output.server.host = argv.host;
+  }
+
   if (argv.projectRoot != null) {
     output.projectRoot = argv.projectRoot;
   }

--- a/packages/metro-config/types/configTypes.d.ts
+++ b/packages/metro-config/types/configTypes.d.ts
@@ -169,6 +169,7 @@ export interface ServerConfigT {
   ) => Middleware | Server;
   forwardClientLogs: boolean;
   port: number;
+  host: string;
   rewriteRequestUrl: (url: string) => string;
   unstable_serverRoot: string | null;
   useGlobalHotkey: boolean;

--- a/packages/metro/src/commands/serve.js
+++ b/packages/metro/src/commands/serve.js
@@ -107,7 +107,10 @@ module.exports = (): {
         resetCache: _resetCache,
         ...runServerOptions
       } = argv;
-      server = await MetroApi.runServer(config, runServerOptions);
+      server = await MetroApi.runServer(config, {
+        ...runServerOptions,
+        host: config.server.host,
+      });
 
       restarting = false;
     }


### PR DESCRIPTION
## Summary
Resolves #1389

This PR adds support for configuring the host address that Metro server listens on.The default value is 'localhost'. It allows users to:
1. Configure host via metro.config.js:
```
module.exports = {
  server: {
    host: '0.0.0.0'  // Listen on all network interfaces
  }
};
```
2. Configure host via CLI:
```metro serve --host 0.0.0.0```


## Test plan

Green CI
