### PR TITLE
Fix watcher path normalisation with Windows and Watchman

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,9 +28,7 @@ if (process.platform === 'win32') {
       'packages/metro-config/src/__tests__/loadConfig-test.js',
       'packages/metro-symbolicate/src/__tests__/symbolicate-test.js',
       'packages/metro-file-map/src/__tests__/index-test.js',
-      'packages/metro-file-map/src/watchers/__tests__/WatchmanWatcher-test.js',
       'packages/metro-file-map/src/crawlers/__tests__/node-test.js',
-      'packages/metro-file-map/src/watchers/__tests__/integration-test.js',
 
       // resolveModulePath failed
       'packages/metro-cache/src/stores/__tests__/FileStore-test.js',

--- a/packages/metro-file-map/src/watchers/__tests__/integration-test.js
+++ b/packages/metro-file-map/src/watchers/__tests__/integration-test.js
@@ -35,7 +35,9 @@ describe.each(Object.keys(WATCHERS))(
     // If all tests are skipped, Jest will not run before/after hooks either.
     const maybeTest = WATCHERS[watcherName] ? test : test.skip;
     const maybeTestOn = (...platforms: $ReadOnlyArray<string>) =>
-      platforms.includes(os.platform()) ? test : test.skip;
+      platforms.includes(os.platform()) && WATCHERS[watcherName]
+        ? test
+        : test.skip;
 
     beforeAll(async () => {
       watchRoot = await createTempWatchRoot(watcherName);

--- a/packages/metro-file-map/src/watchers/__tests__/integration-test.js
+++ b/packages/metro-file-map/src/watchers/__tests__/integration-test.js
@@ -34,6 +34,8 @@ describe.each(Object.keys(WATCHERS))(
 
     // If all tests are skipped, Jest will not run before/after hooks either.
     const maybeTest = WATCHERS[watcherName] ? test : test.skip;
+    const maybeTestOn = (...platforms: $ReadOnlyArray<string>) =>
+      platforms.includes(os.platform()) ? test : test.skip;
 
     beforeAll(async () => {
       watchRoot = await createTempWatchRoot(watcherName);
@@ -233,7 +235,9 @@ describe.each(Object.keys(WATCHERS))(
       });
     });
 
-    maybeTest(
+    /* FIXME: Disabled on Windows and Darwin due to flakiness (occasional
+       timeouts) - see history. */
+    maybeTestOn('darwin')(
       'emits deletion for all files when a directory is deleted',
       async () => {
         await eventHelpers.allEvents(
@@ -267,8 +271,6 @@ describe.each(Object.keys(WATCHERS))(
           {rejectUnexpected: true},
         );
       },
-      // We see occasional failures in CI with default 5s timeout.
-      45000,
     );
   },
 );


### PR DESCRIPTION
Summary:
Fixes an issue with the Watchman watcher backend on Windows where emitted posix-style paths were not properly normalised, leading to inconsistencies with other watchers and broken tests.

Adds the necessary normalisation and reenables tests.

Changelog: Internal

(This is luckily corrected downstream by the use of `path.join` on `relativePath`, which performs normalisation, so there was no observable bug here, it was just fragile.)

Reviewed By: huntie

Differential Revision: D67700720


