### PR TITLE
Cache auto-save 3/3: Expose watcher.unstable_autoSaveCache, default enabled

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -173,6 +173,10 @@ Object {
       "interval": 30000,
       "timeout": 5000,
     },
+    "unstable_autoSaveCache": Object {
+      "debounceMs": 5000,
+      "enabled": true,
+    },
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [
@@ -355,6 +359,10 @@ Object {
       "filePrefix": ".metro-health-check",
       "interval": 30000,
       "timeout": 5000,
+    },
+    "unstable_autoSaveCache": Object {
+      "debounceMs": 5000,
+      "enabled": true,
     },
     "unstable_workerThreads": false,
     "watchman": Object {
@@ -539,6 +547,10 @@ Object {
       "interval": 30000,
       "timeout": 5000,
     },
+    "unstable_autoSaveCache": Object {
+      "debounceMs": 5000,
+      "enabled": true,
+    },
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [
@@ -721,6 +733,10 @@ Object {
       "filePrefix": ".metro-health-check",
       "interval": 30000,
       "timeout": 5000,
+    },
+    "unstable_autoSaveCache": Object {
+      "debounceMs": 5000,
+      "enabled": true,
     },
     "unstable_workerThreads": false,
     "watchman": Object {

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -201,6 +201,10 @@ type WatcherConfigT = {
     timeout: number,
     filePrefix: string,
   }>,
+  unstable_autoSaveCache: $ReadOnly<{
+    enabled: boolean,
+    debounceMs?: number,
+  }>,
   unstable_workerThreads: boolean,
   watchman: $ReadOnly<{
     deferStates: $ReadOnlyArray<string>,
@@ -223,6 +227,9 @@ export type InputConfigT = $ReadOnly<
         Partial<{
           ...WatcherConfigT,
           healthCheck?: $ReadOnly<Partial<WatcherConfigT['healthCheck']>>,
+          unstable_autoSaveCache?: $ReadOnly<
+            Partial<WatcherConfigT['unstable_autoSaveCache']>,
+          >,
         }>,
       >,
     }>,

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -148,6 +148,10 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
       timeout: 5000,
     },
     unstable_workerThreads: false,
+    unstable_autoSaveCache: {
+      enabled: true,
+      debounceMs: 5000,
+    },
     watchman: {
       deferStates: ['hg.update'],
     },

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -176,6 +176,11 @@ function mergeConfig<T: $ReadOnly<InputConfigT>>(
           // $FlowFixMe: Spreading shapes creates an explosion of union types
           ...nextConfig.watcher?.healthCheck,
         },
+        unstable_autoSaveCache: {
+          // $FlowFixMe[exponential-spread]
+          ...totalConfig.watcher?.unstable_autoSaveCache,
+          ...nextConfig.watcher?.unstable_autoSaveCache,
+        },
       },
     }),
     defaultConfig,

--- a/packages/metro-config/types/configTypes.d.ts
+++ b/packages/metro-config/types/configTypes.d.ts
@@ -200,11 +200,18 @@ export interface WatcherConfigT {
     timeout: number;
     filePrefix: string;
   };
+  unstable_autoSaveCache: {
+    enabled: boolean;
+    debounceMs?: number;
+  };
 }
 
 export interface WatcherInputConfigT
-  extends Partial<Omit<WatcherConfigT, 'healthCheck'>> {
+  extends Partial<
+    Omit<WatcherConfigT, 'healthCheck' | 'unstable_autoSaveCache'>
+  > {
   healthCheck?: Partial<WatcherConfigT['healthCheck']>;
+  unstable_autoSaveCache?: Partial<WatcherConfigT['unstable_autoSaveCache']>;
 }
 
 export interface InputConfigT

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -260,8 +260,8 @@ describe('FileMap', () => {
 
     mockCacheManager = {
       read: jest.fn().mockImplementation(async () => cacheContent),
-      write: jest.fn().mockImplementation(async dataSnapshot => {
-        cacheContent = dataSnapshot;
+      write: jest.fn().mockImplementation(async getSnapshot => {
+        cacheContent = getSnapshot();
       }),
     };
 

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -263,6 +263,7 @@ describe('FileMap', () => {
       write: jest.fn().mockImplementation(async getSnapshot => {
         cacheContent = getSnapshot();
       }),
+      end: jest.fn(),
     };
 
     H = FileMap.H;

--- a/packages/metro-file-map/src/cache/DiskCacheManager.js
+++ b/packages/metro-file-map/src/cache/DiskCacheManager.js
@@ -86,4 +86,6 @@ export class DiskCacheManager implements CacheManager {
       await fsPromises.writeFile(this._cachePath, serialize(getSnapshot()));
     }
   }
+
+  async end() {}
 }

--- a/packages/metro-file-map/src/cache/DiskCacheManager.js
+++ b/packages/metro-file-map/src/cache/DiskCacheManager.js
@@ -12,9 +12,9 @@
 import type {
   BuildParameters,
   CacheData,
-  CacheDelta,
   CacheManager,
   CacheManagerFactoryOptions,
+  CacheManagerWriteOptions,
 } from '../flow-types';
 
 import rootRelativeCacheKeys from '../lib/rootRelativeCacheKeys';
@@ -79,11 +79,11 @@ export class DiskCacheManager implements CacheManager {
   }
 
   async write(
-    dataSnapshot: CacheData,
-    {changed, removed}: CacheDelta,
+    getSnapshot: () => CacheData,
+    {changedSinceCacheRead}: CacheManagerWriteOptions,
   ): Promise<void> {
-    if (changed.size > 0 || removed.size > 0) {
-      await fsPromises.writeFile(this._cachePath, serialize(dataSnapshot));
+    if (changedSinceCacheRead) {
+      await fsPromises.writeFile(this._cachePath, serialize(getSnapshot()));
     }
   }
 }

--- a/packages/metro-file-map/src/cache/__tests__/DiskCacheManager-test.js
+++ b/packages/metro-file-map/src/cache/__tests__/DiskCacheManager-test.js
@@ -194,6 +194,8 @@ describe('cacheManager', () => {
     );
     await cacheManager.write(getSnapshot, {
       changedSinceCacheRead: true,
+      eventSource: {onChange: () => () => {}},
+      onWriteError: () => {},
     });
     expect(getSnapshot).toHaveBeenCalled();
     expect(mockWriteFile).toHaveBeenCalledWith(
@@ -215,7 +217,11 @@ describe('cacheManager', () => {
     await cacheManager.write(
       getSnapshot,
       // No changes
-      {changedSinceCacheRead: false},
+      {
+        changedSinceCacheRead: false,
+        eventSource: {onChange: () => () => {}},
+        onWriteError: () => {},
+      },
     );
     expect(getSnapshot).not.toHaveBeenCalled();
     expect(mockWriteFile).not.toHaveBeenCalled();

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -51,14 +51,21 @@ export type CacheData = $ReadOnly<{
   plugins: $ReadOnlyMap<string, mixed>,
 }>;
 
-export type CacheDelta = $ReadOnly<{
-  changed: $ReadOnlyMap<CanonicalPath, FileMetaData>,
-  removed: $ReadOnlySet<CanonicalPath>,
-}>;
-
 export interface CacheManager {
+  /**
+   * Called during startup to load initial state, if available. Provided to
+   * a crawler, which will return the delta between the initial state and the
+   * current file system state.
+   */
   read(): Promise<?CacheData>;
-  write(dataSnapshot: CacheData, delta: CacheDelta): Promise<void>;
+  /**
+   * Called when metro-file-map `build()` has applied changes returned by the
+   * crawler - i.e. internal state reflects the current file system state.
+   */
+  write(
+    getSnapshot: () => CacheData,
+    opts: CacheManagerWriteOptions,
+  ): Promise<void>;
 }
 
 export type CacheManagerFactory = (
@@ -67,6 +74,10 @@ export type CacheManagerFactory = (
 
 export type CacheManagerFactoryOptions = $ReadOnly<{
   buildParameters: BuildParameters,
+}>;
+
+export type CacheManagerWriteOptions = $ReadOnly<{
+  changedSinceCacheRead: boolean,
 }>;
 
 // A path that is

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -58,14 +58,30 @@ export interface CacheManager {
    * current file system state.
    */
   read(): Promise<?CacheData>;
+
   /**
    * Called when metro-file-map `build()` has applied changes returned by the
    * crawler - i.e. internal state reflects the current file system state.
+   *
+   * getSnapshot may be retained and called at any time before end(), such as
+   * in response to eventSource 'change' events.
    */
   write(
     getSnapshot: () => CacheData,
     opts: CacheManagerWriteOptions,
   ): Promise<void>;
+
+  /**
+   * The last call that will be made to this CacheManager. Any handles should
+   * be closed by the time this settles.
+   */
+  end(): Promise<void>;
+}
+
+export interface CacheManagerEventSource {
+  onChange(
+    listener: (change: ChangeEvent) => void,
+  ): () => void /* unsubscribe */;
 }
 
 export type CacheManagerFactory = (
@@ -78,6 +94,8 @@ export type CacheManagerFactoryOptions = $ReadOnly<{
 
 export type CacheManagerWriteOptions = $ReadOnly<{
   changedSinceCacheRead: boolean,
+  eventSource: CacheManagerEventSource,
+  onWriteError: Error => void,
 }>;
 
 // A path that is

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -136,10 +136,10 @@ export {default as HastePlugin} from './plugins/HastePlugin';
 export type {HasteMap} from './flow-types';
 export type {HealthCheckResult} from './Watcher';
 export type {
-  CacheDelta,
   CacheManager,
   CacheManagerFactory,
   CacheManagerFactoryOptions,
+  CacheManagerWriteOptions,
   ChangeEvent,
   WatcherStatus,
 } from './flow-types';
@@ -741,7 +741,7 @@ export default class FileMap extends EventEmitter {
   ) {
     this._startupPerfLogger?.point('persist_start');
     await this._cacheManager.write(
-      {
+      () => ({
         fileSystemData: fileSystem.getSerializableSnapshot(),
         clocks: new Map(clocks),
         plugins: new Map(
@@ -750,8 +750,10 @@ export default class FileMap extends EventEmitter {
             plugin.getSerializableSnapshot(),
           ]),
         ),
+      }),
+      {
+        changedSinceCacheRead: changed.size + removed.size > 0,
       },
-      {changed, removed},
     );
     this._startupPerfLogger?.point('persist_end');
   }

--- a/packages/metro-file-map/types/cache/DiskCacheManager.d.ts
+++ b/packages/metro-file-map/types/cache/DiskCacheManager.d.ts
@@ -12,7 +12,7 @@ import type {
   BuildParameters,
   CacheData,
   CacheManager,
-  FileData,
+  CacheManagerWriteOptions,
 } from '../flow-types';
 
 export interface DiskCacheConfig {
@@ -31,7 +31,8 @@ export class DiskCacheManager implements CacheManager {
   getCacheFilePath(): string;
   read(): Promise<CacheData | null>;
   write(
-    dataSnapshot: CacheData,
-    {changed, removed}: Readonly<{changed: FileData; removed: FileData}>,
+    getSnapshot: () => CacheData,
+    opts: CacheManagerWriteOptions,
   ): Promise<void>;
+  end(): Promise<void>;
 }

--- a/packages/metro-file-map/types/flow-types.d.ts
+++ b/packages/metro-file-map/types/flow-types.d.ts
@@ -42,21 +42,56 @@ export interface BuildResult {
 
 export interface CacheData {
   readonly clocks: WatchmanClocks;
-  readonly mocks: RawMockMap;
-  readonly files: FileData;
+  readonly fileSystemData: unknown;
+  readonly plugins: ReadonlyMap<string, unknown>;
 }
 
 export interface CacheManager {
+  /**
+   * Called during startup to load initial state, if available. Provided to
+   * a crawler, which will return the delta between the initial state and the
+   * current file system state.
+   */
   read(): Promise<CacheData | null>;
+
+  /**
+   * Called when metro-file-map `build()` has applied changes returned by the
+   * crawler - i.e. internal state reflects the current file system state.
+   *
+   * getSnapshot may be retained and called at any time before end(), such as
+   * in response to eventSource 'change' events.
+   */
   write(
-    dataSnapshot: CacheData,
-    delta: Readonly<{changed: FileData; removed: FileData}>,
+    getSnapshot: () => CacheData,
+    opts: CacheManagerWriteOptions,
   ): Promise<void>;
+
+  /**
+   * The last call that will be made to this CacheManager. Any handles should
+   * be closed by the time this settles.
+   */
+  end(): Promise<void>;
+}
+
+export interface CacheManagerEventSource {
+  onChange(
+    listener: (change: ChangeEvent) => void,
+  ): () => void /* unsubscribe */;
 }
 
 export type CacheManagerFactory = (
-  buildParameters: BuildParameters,
+  options: CacheManagerFactoryOptions,
 ) => CacheManager;
+
+export type CacheManagerFactoryOptions = {
+  buildParameters: BuildParameters;
+};
+
+export type CacheManagerWriteOptions = {
+  changedSinceCacheRead: boolean;
+  eventSource: CacheManagerEventSource;
+  onWriteError: (e: Error) => void;
+};
 
 export interface ChangeEvent {
   logger: RootPerfLogger | null;

--- a/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
+++ b/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
@@ -68,6 +68,11 @@ function createFileMap(
       : config.resolver.dependencyExtractor;
   const computeDependencies = dependencyExtractor != null;
 
+  const watch = options?.watch == null ? !ci.isCI : options.watch;
+  const {enabled: autoSaveEnabled, ...autoSaveOpts} =
+    config.watcher.unstable_autoSaveCache ?? {};
+  const autoSave = watch && autoSaveEnabled ? autoSaveOpts : false;
+
   return MetroFileMap.create({
     cacheManagerFactory:
       config?.unstable_fileMapCacheManagerFactory ??
@@ -76,6 +81,7 @@ function createFileMap(
           cacheDirectory:
             config.fileMapCacheDirectory ?? config.hasteMapCacheDirectory,
           cacheFilePrefix: options?.cacheFilePrefix,
+          autoSave,
         })),
     perfLoggerFactory: config.unstable_perfLoggerFactory,
     computeDependencies,
@@ -104,7 +110,7 @@ function createFileMap(
     roots: config.watchFolders,
     throwOnModuleCollision: options?.throwOnModuleCollision ?? true,
     useWatchman: config.resolver.useWatchman,
-    watch: options?.watch == null ? !ci.isCI : options.watch,
+    watch,
     watchmanDeferStates: config.watcher.watchman.deferStates,
   });
 }


### PR DESCRIPTION
Pull Request resolved: https://github.com/facebook/metro/pull/1434

Configures a new mechanism for the file map cache to re-save after changes made to the file system while Metro is running.

Currently, If you make a change while Metro is running, Metro will re-process (hash) that file and update an in-memory record, but won't save it. The next time Metro starts up, it will process that file again, and write the cache at the end of startup.

In most cases this provides a modest reduction in startup work/time - proportional to the number of changes in the previous Metro session.

However, it unlocks the potential of doing more processing lazily - ie, we don't need to hash everything up front if we can hash only what we need for a bundle, and then save those hashes in a cache.

**We'll use this to implement lazy hashing.**

## Implementation
The auto save mechanism is contained within `DiskCacheManager` via generic listening APIs. When the file map emits a `change` event to Metro, we start/restart a configurable debounce timer, and save the cache asynchronously.

The 5 second default is chosen so that we don't try to save while Metro may be busy - eg, a change is likely to be followed by an HMR exchange over the next second or two.

Changelog:
```
 - **[Experimental]**: Auto-save file cache via `config.watcher.unstable_autoSaveCache`
```

Differential Revision: D69024198
