### PR TITLE
Expose lazy SHA1 via transformer.unstable_lazySha1

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -177,6 +177,7 @@ Object {
       "debounceMs": 5000,
       "enabled": true,
     },
+    "unstable_lazySha1": false,
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [
@@ -364,6 +365,7 @@ Object {
       "debounceMs": 5000,
       "enabled": true,
     },
+    "unstable_lazySha1": false,
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [
@@ -551,6 +553,7 @@ Object {
       "debounceMs": 5000,
       "enabled": true,
     },
+    "unstable_lazySha1": false,
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [
@@ -738,6 +741,7 @@ Object {
       "debounceMs": 5000,
       "enabled": true,
     },
+    "unstable_lazySha1": false,
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [

--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -205,6 +205,7 @@ type WatcherConfigT = {
     enabled: boolean,
     debounceMs?: number,
   }>,
+  unstable_lazySha1: boolean,
   unstable_workerThreads: boolean,
   watchman: $ReadOnly<{
     deferStates: $ReadOnlyArray<string>,

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -147,6 +147,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
       interval: 30000,
       timeout: 5000,
     },
+    unstable_lazySha1: false,
     unstable_workerThreads: false,
     unstable_autoSaveCache: {
       enabled: true,

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -1395,6 +1395,7 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'fruits', 'Banana.js'),
           hasteImplModulePath: undefined,
+          maybeReturnContent: false,
         },
       ],
       [
@@ -1405,6 +1406,7 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'fruits', 'Pear.js'),
           hasteImplModulePath: undefined,
+          maybeReturnContent: false,
         },
       ],
       [
@@ -1415,6 +1417,7 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'fruits', 'Strawberry.js'),
           hasteImplModulePath: undefined,
+          maybeReturnContent: false,
         },
       ],
       [
@@ -1425,6 +1428,7 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'fruits', '__mocks__', 'Pear.js'),
           hasteImplModulePath: undefined,
+          maybeReturnContent: false,
         },
       ],
       [
@@ -1435,6 +1439,7 @@ describe('FileMap', () => {
           enableHastePackages: true,
           filePath: path.join('/', 'project', 'vegetables', 'Melon.js'),
           hasteImplModulePath: undefined,
+          maybeReturnContent: false,
         },
       ],
     ]);

--- a/packages/metro-file-map/src/__tests__/worker-test.js
+++ b/packages/metro-file-map/src/__tests__/worker-test.js
@@ -207,6 +207,35 @@ describe('worker', () => {
     expect(fs.readFile).not.toHaveBeenCalled();
   });
 
+  test('returns content if requested and content is read', async () => {
+    expect(
+      await worker({
+        computeSha1: true,
+        filePath: path.join('/project', 'fruits', 'Pear.js'),
+        maybeReturnContent: true,
+      }),
+    ).toEqual({
+      content: expect.any(Buffer),
+      sha1: 'c7a7a68a1c8aaf452669dd2ca52ac4a434d25552',
+    });
+  });
+
+  test('does not return content if maybeReturnContent but content is not read', async () => {
+    expect(
+      await worker({
+        computeSha1: false,
+        filePath: path.join('/project', 'fruits', 'Pear.js'),
+        hasteImplModulePath: path.resolve(__dirname, 'haste_impl.js'),
+        maybeReturnContent: true,
+      }),
+    ).toEqual({
+      content: undefined,
+      dependencies: undefined,
+      id: 'Pear',
+      sha1: undefined,
+    });
+  });
+
   test('can be loaded directly without transpilation', async () => {
     const code = await jest
       .requireActual('fs')

--- a/packages/metro-file-map/src/crawlers/__tests__/integration-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/integration-test.js
@@ -125,6 +125,9 @@ describe.each(Object.keys(CRAWLERS))(
             fileSystem: new TreeFS({
               rootDir: FIXTURES_DIR,
               files: new Map([['removed.js', ['', 123, 234, 0, '', null, 0]]]),
+              processFile: () => {
+                throw new Error('Not implemented');
+              },
             }),
             clocks: new Map(),
           },

--- a/packages/metro-file-map/src/crawlers/watchman/__tests__/index-test.js
+++ b/packages/metro-file-map/src/crawlers/watchman/__tests__/index-test.js
@@ -46,7 +46,12 @@ const DEFAULT_OPTIONS: CrawlerOptions = {
   perfLogger: null,
   previousState: {
     clocks: new Map(),
-    fileSystem: new TreeFS({rootDir: systemPath('/roots')}),
+    fileSystem: new TreeFS({
+      rootDir: systemPath('/roots'),
+      processFile: () => {
+        throw new Error('Not implemented');
+      },
+    }),
   },
   rootDir: systemPath('/roots'),
   roots: [

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -248,6 +248,7 @@ export interface FileSystem {
   getModuleName(file: Path): ?string;
   getSerializableSnapshot(): CacheData['fileSystemData'];
   getSha1(file: Path): ?string;
+  getOrComputeSha1(file: Path): Promise<?{sha1: string, content?: Buffer}>;
 
   /**
    * Given a start path (which need not exist), a subpath and type, and
@@ -381,6 +382,12 @@ export interface MutableFileSystem extends FileSystem {
 }
 
 export type Path = string;
+
+export type ProcessFileFunction = (
+  absolutePath: string,
+  metadata: FileMetaData,
+  request: $ReadOnly<{computeSha1: boolean}>,
+) => Promise<?Buffer>;
 
 export type RawMockMap = $ReadOnly<{
   duplicates: Map<

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -441,10 +441,12 @@ export type WorkerMessage = $ReadOnly<{
   enableHastePackages: boolean,
   filePath: string,
   hasteImplModulePath?: ?string,
+  maybeReturnContent: boolean,
 }>;
 
 export type WorkerMetadata = $ReadOnly<{
   dependencies?: ?$ReadOnlyArray<string>,
   id?: ?string,
   sha1?: ?string,
+  content?: ?Buffer,
 }>;

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -622,6 +622,7 @@ export default class FileMap extends EventEmitter {
       this._fileProcessor.processBatch(filesToProcess, {
         computeSha1: this._options.computeSha1,
         computeDependencies: this._options.computeDependencies,
+        maybeReturnContent: false,
       }),
       Promise.all(readLinkPromises),
     ]);
@@ -887,6 +888,7 @@ export default class FileMap extends EventEmitter {
                   {
                     computeSha1: this._options.computeSha1,
                     computeDependencies: this._options.computeDependencies,
+                    maybeReturnContent: false,
                   },
                 );
               }

--- a/packages/metro-file-map/src/lib/__tests__/FileProcessor-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/FileProcessor-test.js
@@ -50,6 +50,7 @@ describe('processBatch', () => {
     await processor.processBatch(getNMockFiles(100), {
       computeDependencies: false,
       computeSha1: true,
+      maybeReturnContent: false,
     });
 
     expect(MockJestWorker).toHaveBeenCalledWith(
@@ -70,6 +71,7 @@ describe('processBatch', () => {
     await processor.processBatch(getNMockFiles(50), {
       computeDependencies: false,
       computeSha1: true,
+      maybeReturnContent: false,
     });
 
     expect(MockJestWorker).not.toHaveBeenCalled();

--- a/packages/metro-file-map/src/worker.js
+++ b/packages/metro-file-map/src/worker.js
@@ -102,7 +102,9 @@ async function worker(
     sha1 = sha1hex(getContent());
   }
 
-  return {dependencies, id, sha1};
+  return content && data.maybeReturnContent
+    ? {content, dependencies, id, sha1}
+    : {dependencies, id, sha1};
 }
 
 module.exports = {

--- a/packages/metro/src/Bundler.js
+++ b/packages/metro/src/Bundler.js
@@ -36,8 +36,16 @@ class Bundler {
       .ready()
       .then(() => {
         config.reporter.update({type: 'transformer_load_started'});
-        this._transformer = new Transformer(config, (...args) =>
-          this._depGraph.getSha1(...args),
+        this._transformer = new Transformer(
+          config,
+          config.watcher.unstable_lazySha1
+            ? // This object-form API is expected to replace passing a function
+              // once lazy SHA1 is stable. This will be a breaking change.
+              {
+                unstable_getOrComputeSha1: filePath =>
+                  this._depGraph.unstable_getOrComputeSha1(filePath),
+              }
+            : (...args) => this._depGraph.getSha1(...args),
         );
         config.reporter.update({type: 'transformer_load_done'});
       })

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -55,6 +55,14 @@ function getOrCreateMap<T>(
   return subMap;
 }
 
+const missingSha1Error = (mixedPath: string) =>
+  new Error(`Failed to get the SHA-1 for: ${mixedPath}.
+  Potential causes:
+    1) The file is not watched. Ensure it is under the configured \`projectRoot\` or \`watchFolders\`.
+    2) Check \`blockList\` in your metro.config.js and make sure it isn't excluding the file path.
+    3) The file may have been deleted since it was resolved - try refreshing your app.
+    4) Otherwise, this is a bug in Metro or the configured resolver - please report it.`);
+
 class DependencyGraph extends EventEmitter {
   _config: ConfigT;
   _haste: MetroFileMap;
@@ -258,19 +266,23 @@ class DependencyGraph extends EventEmitter {
 
   getSha1(filename: string): string {
     const sha1 = this._fileSystem.getSha1(filename);
-
     if (!sha1) {
-      throw new ReferenceError(
-        `Failed to get the SHA-1 for ${filename}.
-         Potential causes:
-           1) The file is not watched. Ensure it is under the configured \`projectRoot\` or \`watchFolders\`.
-           2) Check \`blockList\` in your metro.config.js and make sure it isn't excluding the file path.
-           3) The file may have been deleted since it was resolved - try refreshing your app.
-           4) Otherwise, this is a bug in Metro or the configured resolver - please report it.`,
-      );
+      throw missingSha1Error(filename);
     }
-
     return sha1;
+  }
+
+  /**
+   * Used when watcher.unstable_lazySha1 is true
+   */
+  async unstable_getOrComputeSha1(
+    mixedPath: string,
+  ): Promise<{content?: Buffer, sha1: string}> {
+    const result = await this._fileSystem.getOrComputeSha1(mixedPath);
+    if (!result || !result.sha1) {
+      throw missingSha1Error(mixedPath);
+    }
+    return result;
   }
 
   getWatcher(): EventEmitter {

--- a/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
+++ b/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
@@ -85,7 +85,7 @@ function createFileMap(
         })),
     perfLoggerFactory: config.unstable_perfLoggerFactory,
     computeDependencies,
-    computeSha1: true,
+    computeSha1: !config.watcher.unstable_lazySha1,
     dependencyExtractor: config.resolver.dependencyExtractor,
     enableHastePackages: config?.resolver.enableGlobalPackages,
     enableSymlinks: true,


### PR DESCRIPTION
## Stack
In this stack we're moving towards metro-file-map being able to *lazily* compute file metadata - in particular the SHA1 hash - only when required by the transformer.

More context in https://github.com/facebook/metro/issues/1325#issuecomment-2303019051

## Implementing config `watcher.unstable_lazySha1`
This diff introduces a new opt-in config that
 - Disables eager computation of `sha1` for all watched files.
 - Adds support in `Transformer` to accept a callback that asynchronously returns SHA1, and optionally file content.
 - Maintains support for the old sync API, for anyone using `Transformer` directly. This will likely be dropped in a coming major.

Along with the already landed, default-on [auto-saving cache](https://github.com/facebook/metro/pull/1434), this should provide order of magnitude[1] faster startup on large projects, with no compromise to warm build perf, and very little slowdown in cold builds in most cases[2].

[1] Metro needs to watch file subtrees, but typically only a small proportion of those files are used in a build. By hashing up front, we can spend up to several minutes hashing files that will never be used.

[2] Cold file caches with warm transform caches - typically only when using a remote cache - may be observably slower due to the need to read and hash a file that wouldn't otherwise need to be read, though this still only moves the cost from startup to build. For truly cold builds, this change adds SHA1 computation time to transform time, but requires no additional IO. SHA1 computation is typically much faster than Babel transformation, and we might consider faster algorithms in future (SHA1 is Eden-native).

Changelog:
```
 - **[Experimental]**: Add `watcher.unstable_lazySha1` to defer SHA1 calculation until files are needed by the transformer

Differential Revision: D69373618
