### PR TITLE
Replace this with globalThis

### DIFF
--- a/packages/metro/src/lib/getPreludeCode.js
+++ b/packages/metro/src/lib/getPreludeCode.js
@@ -25,10 +25,10 @@ function getPreludeCode({
   const vars = [
     // Ensure these variable names match the ones referenced in metro-runtime
     // require.js
-    '__BUNDLE_START_TIME__=this.nativePerformanceNow?nativePerformanceNow():Date.now()',
+    '__BUNDLE_START_TIME__=globalThis.nativePerformanceNow?nativePerformanceNow():Date.now()',
     `__DEV__=${String(isDev)}`,
     ...formatExtraVars(extraVars),
-    'process=this.process||{}',
+    'process=globalThis.process||{}',
     `__METRO_GLOBAL_PREFIX__='${globalPrefix}'`,
   ];
 


### PR DESCRIPTION


I am using Metro to build a Service Worker for my web application (created with Expo). And I get an error because `this` value  is `undefined` [here](https://github.com/facebook/metro/blob/87f717b8f5987827c75c82b3cb390060672628f0/packages/metro/src/lib/getPreludeCode.js#L28). This piece of code is static and is added to every bundle.

## Summary
Provide a standard way of accessing the global `this` value across environments.