### PR TITLE
metro-file-map: Spawn fewer workers for smaller workloads

### DIFF
--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -1371,9 +1371,18 @@ describe('FileMap', () => {
       dependencyExtractor,
       hasteImplModulePath: undefined,
       maxWorkers: 4,
+      maxFilesPerWorker: 2,
     }).build();
 
-    expect(jestWorker.mock.calls.length).toBe(1);
+    expect(jestWorker).toHaveBeenCalledTimes(1);
+
+    expect(jestWorker).toHaveBeenCalledWith(
+      expect.stringContaining('worker.js'),
+      expect.objectContaining({
+        // With maxFilesPerWorker = 2 and 5 files, we should have 3 workers.
+        numWorkers: 3,
+      }),
+    );
 
     expect(mockWorker.mock.calls.length).toBe(5);
 

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -93,6 +93,7 @@ export type InputOptions = $ReadOnly<{
   cacheManagerFactory?: ?CacheManagerFactory,
   console?: Console,
   healthCheck: HealthCheckOptions,
+  maxFilesPerWorker?: ?number,
   maxWorkers: number,
   perfLoggerFactory?: ?PerfLoggerFactory,
   resetCache?: ?boolean,
@@ -326,6 +327,7 @@ export default class FileMap extends EventEmitter {
       enableHastePackages: buildParameters.enableHastePackages,
       enableWorkerThreads: options.enableWorkerThreads ?? false,
       hasteImplModulePath: buildParameters.hasteImplModulePath,
+      maxFilesPerWorker: options.maxFilesPerWorker,
       maxWorkers: options.maxWorkers,
       perfLogger: this._startupPerfLogger,
     });

--- a/packages/metro-file-map/src/lib/__tests__/FileProcessor-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/FileProcessor-test.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @oncall react_native
+ */
+
+import type {FileMetaData} from '../../flow-types';
+
+const MockJestWorker = jest.fn().mockImplementation(() => ({
+  worker: async () => ({}),
+}));
+const mockWorkerFn = jest.fn().mockResolvedValue({});
+
+describe('processBatch', () => {
+  const defaultOptions = {
+    dependencyExtractor: null,
+    enableHastePackages: false,
+    enableWorkerThreads: true,
+    hasteImplModulePath: null,
+    maxWorkers: 5,
+    perfLogger: null,
+  };
+
+  let FileProcessor;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.mock('jest-worker', () => ({
+      Worker: MockJestWorker,
+    }));
+    jest.mock('../../worker.js', () => ({
+      worker: mockWorkerFn,
+    }));
+    FileProcessor = require('../FileProcessor').FileProcessor;
+  });
+
+  test('never creates more than maxWorkers', async () => {
+    const processor = new FileProcessor({
+      ...defaultOptions,
+      maxWorkers: 5,
+      maxFilesPerWorker: 1,
+    });
+
+    await processor.processBatch(getNMockFiles(100), {
+      computeDependencies: false,
+      computeSha1: true,
+    });
+
+    expect(MockJestWorker).toHaveBeenCalledWith(
+      expect.stringContaining('worker.js'),
+      expect.objectContaining({
+        numWorkers: 5,
+      }),
+    );
+  });
+
+  test('processes in band if workload <= maxFilesPerWorker', async () => {
+    const processor = new FileProcessor({
+      ...defaultOptions,
+      maxWorkers: 5,
+      maxFilesPerWorker: 50,
+    });
+
+    await processor.processBatch(getNMockFiles(50), {
+      computeDependencies: false,
+      computeSha1: true,
+    });
+
+    expect(MockJestWorker).not.toHaveBeenCalled();
+    expect(mockWorkerFn).toHaveBeenCalledTimes(50);
+  });
+});
+
+function getNMockFiles(numFiles: number): Array<[string, FileMetaData]> {
+  return new Array<?[string, FileMetaData]>(numFiles)
+    .fill(null)
+    .map((_, i) => [
+      `file${i}.js`,
+      ['', 123, 234, 0, '', '', 0] as FileMetaData,
+    ]);
+}

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -261,10 +261,12 @@ class DependencyGraph extends EventEmitter {
 
     if (!sha1) {
       throw new ReferenceError(
-        `SHA-1 for file ${filename} is not computed.
+        `Failed to get the SHA-1 for ${filename}.
          Potential causes:
-           1) You have symlinks in your project - watchman does not follow symlinks.
-           2) Check \`blockList\` in your metro.config.js and make sure it isn't excluding the file path.`,
+           1) The file is not watched. Ensure it is under the configured \`projectRoot\` or \`watchFolders\`.
+           2) Check \`blockList\` in your metro.config.js and make sure it isn't excluding the file path.
+           3) The file may have been deleted since it was resolved - try refreshing your app.
+           4) Otherwise, this is a bug in Metro or the configured resolver - please report it.`,
       );
     }
 


### PR DESCRIPTION
Summary:
`metro-file-map` currently spins up `maxWorkers` workers (processes, or threads if `enableWorkerThreads`) for any batch workload. `maxWorkers` is `os.availableParallelism` by default.

When we have a warm cache or Saved State, we may only have a handful of changed files to process, and frequently create more workers than we have files.

This implements a simple heuristic factor `maxFilesPerWorker`, such that we use `Math.ceil(numFiles/maxFilesPerWorker)` parallelism (where 1 "worker" means we process in-band).

The default value of  100 is somewhat finger-in-air as a bunch of factors would determine the optimal value - including threads or not, which host platform, and computational cost of the haste impl and dependency extraction. We could expose this as Metro configuration in future.

Changelog:
 - **[Performance]** Don't start an excessive number of workers for hashing files during startup.

Differential Revision: D69704168


