### PR TITLE
Add package.json "exports" to Metro packages, alias "private" to "src"

### DIFF
--- a/packages/buck-worker-tool/package.json
+++ b/packages/buck-worker-tool/package.json
@@ -4,6 +4,13 @@
   "description": "Implementation of the Buck worker protocol for Node.js.",
   "license": "MIT",
   "main": "src/worker-tool.js",
+  "exports": {
+    ".": "./src/worker-tool.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "dependencies": {
     "duplexer": "^0.1.1",
     "flow-enums-runtime": "^0.0.6",

--- a/packages/metro-babel-register/package.json
+++ b/packages/metro-babel-register/package.json
@@ -3,6 +3,13 @@
   "version": "0.81.1",
   "description": "🚇 babel/register configuration for Metro.",
   "main": "src/babel-register.js",
+  "exports": {
+    ".": "./src/babel-register.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-babel-transformer/package.json
+++ b/packages/metro-babel-transformer/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Base Babel transformer for Metro.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-cache-key/package.json
+++ b/packages/metro-cache-key/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Cache key utility.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-cache/package.json
+++ b/packages/metro-cache/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Cache layers for Metro.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -3,6 +3,15 @@
   "version": "0.81.1",
   "description": "🚇 Config parser for Metro.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js",
+    "./src/defaults": "./src/defaults/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-core/package.json
+++ b/packages/metro-core/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Metro's core package.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-file-map/package.json
+++ b/packages/metro-file-map/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "[Experimental] - 🚇 File crawling, watching and mapping for Metro",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-memory-fs/package.json
+++ b/packages/metro-memory-fs/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 A memory-based implementation of `fs` useful for testing.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Minifier for Metro based on Terser.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-resolver/package.json
+++ b/packages/metro-resolver/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Implementation of Metro's resolution logic.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-resolver/package.json
+++ b/packages/metro-resolver/package.json
@@ -2,7 +2,7 @@
   "name": "metro-resolver",
   "version": "0.81.1",
   "description": "🚇 Implementation of Metro's resolution logic.",
-  "main": "src",
+  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-runtime/package.json
+++ b/packages/metro-runtime/package.json
@@ -2,7 +2,6 @@
   "name": "metro-runtime",
   "version": "0.81.1",
   "description": "🚇 Module required for evaluating Metro bundles.",
-  "main": "src",
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-runtime/package.json
+++ b/packages/metro-runtime/package.json
@@ -2,6 +2,12 @@
   "name": "metro-runtime",
   "version": "0.81.1",
   "description": "🚇 Module required for evaluating Metro bundles.",
+  "exports": {
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-source-map/package.json
+++ b/packages/metro-source-map/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Source map generator for Metro.",
   "main": "src/source-map.js",
+  "exports": {
+    ".": "./src/source-map.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js",
+    "./src/Consumer": "./src/Consumer/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-symbolicate/package.json
+++ b/packages/metro-symbolicate/package.json
@@ -5,6 +5,14 @@
   "license": "MIT",
   "main": "./src/index.js",
   "bin": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-transform-plugins/package.json
+++ b/packages/metro-transform-plugins/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Transform plugins for Metro.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro-transform-worker/package.json
+++ b/packages/metro-transform-worker/package.json
@@ -3,6 +3,14 @@
   "version": "0.81.1",
   "description": "🚇 Transform worker for Metro.",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -4,6 +4,14 @@
   "description": "🚇 The JavaScript bundler for React Native.",
   "main": "src/index.js",
   "bin": "src/cli.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src": "./src/index.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/packages/ob1/package.json
+++ b/packages/ob1/package.json
@@ -3,6 +3,13 @@
   "version": "0.81.1",
   "description": "A small library for working with 0- and 1-based offsets in a type-checked way.",
   "main": "src/ob1.js",
+  "exports": {
+    ".": "./src/ob1.js",
+    "./package.json": "./package.json",
+    "./private/*": "./src/*.js",
+    "./src/*.js": "./src/*.js",
+    "./src/*": "./src/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:facebook/metro.git"

--- a/scripts/__tests__/subpackages-test.js
+++ b/scripts/__tests__/subpackages-test.js
@@ -106,3 +106,32 @@ test('forces all packages to have an .npmignore with expected entries', () => {
     );
   });
 });
+
+test('use package.json#exports, exporting a main and package.json', () => {
+  checkAssertionInPackages(getPackages(), packagePath => {
+    const packageJson = readPackageJson(packagePath);
+    expect(packageJson.exports).toEqual(
+      expect.objectContaining({
+        ...(packageJson.main != null
+          ? {
+              '.': packageJson.main.startsWith('./')
+                ? packageJson.main
+                : './' + packageJson.main,
+            }
+          : null),
+        ...(packageJson.main?.endsWith('src/index.js')
+          ? {
+              // For backward compatibility, allow importing src as a directory
+              './src': './src/index.js',
+            }
+          : null),
+        './package.json': './package.json',
+        './private/*': './src/*.js',
+        // If an import specifies .js, keep it
+        './src/*.js': './src/*.js',
+        // Add .js to extensionless imports
+        './src/*': './src/*.js',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Summary:
Add an `exports` field to the `package.json` of each Metro package, exposing all current exports, and a new `./private/x` alias for `./src/x.js`.

This is intended to be non-breaking - all current uses of deep imports to any source file in Metro should continue to work (whether or not they use extensionless or directory imports).

We'll encourage any consumers of `metro*/src/` imports to either move to `metro*/private/` with no semver guarantees - or accommodate their use case with a public API where it makes sense.

The high-level idea here is to keep Metro "hackable" for integrators and not immediately break anyone, but to allow us to move faster by reducing the API surface that's implicitly semver-stable, but in most cases has no public consumers.

Changelog:
```
 - **[Deprecated]**: Deprecate deep `src` imports e.g. `metro/src/x.js` across all `metro*` packages, pending removal from the stable API.
 - **[Experimental]**: Expose deep imports of Metro packages (`metro/src/x.js` as `metro/private/x`) as explicitly private (non-semver).
```

Reviewed By: huntie

Differential Revision: D70038572


