### PR TITLE
Upgrade `glob@7` to `glob@10` to resolve deprecation warnings

### DIFF
--- a/flow-typed/npm/glob_v7.x.x.js
+++ b/flow-typed/npm/glob_v7.x.x.js
@@ -1,0 +1,79 @@
+// flow-typed signature: d2a519d7d007e9ba3e5bf2ac3ff76eca
+// flow-typed version: f243e51ed7/glob_v7.x.x/flow_>=v0.104.x
+
+declare module "glob" {
+  declare type MinimatchOptions = {|
+    debug?: boolean,
+    nobrace?: boolean,
+    noglobstar?: boolean,
+    dot?: boolean,
+    noext?: boolean,
+    nocase?: boolean,
+    nonull?: boolean,
+    matchBase?: boolean,
+    nocomment?: boolean,
+    nonegate?: boolean,
+    flipNegate?: boolean
+  |};
+
+  declare type Options = {|
+    ...MinimatchOptions,
+    cwd?: string,
+    root?: string,
+    nomount?: boolean,
+    mark?: boolean,
+    nosort?: boolean,
+    stat?: boolean,
+    silent?: boolean,
+    strict?: boolean,
+    cache?: { [path: string]: boolean | "DIR" | "FILE" | $ReadOnlyArray<string>, ... },
+    statCache?: { [path: string]: boolean | { isDirectory(): boolean, ... } | void, ... },
+    symlinks?: { [path: string]: boolean | void, ... },
+    realpathCache?: { [path: string]: string, ... },
+    sync?: boolean,
+    nounique?: boolean,
+    nodir?: boolean,
+    ignore?: string | $ReadOnlyArray<string>,
+    follow?: boolean,
+    realpath?: boolean,
+    absolute?: boolean
+  |};
+
+  /**
+   * Called when an error occurs, or matches are found
+   *   err
+   *   matches: filenames found matching the pattern
+   */
+  declare type CallBack = (err: ?Error, matches: Array<string>) => void;
+
+  declare class Glob extends events$EventEmitter {
+    constructor(pattern: string): this;
+    constructor(pattern: string, callback: CallBack): this;
+    constructor(pattern: string, options: Options, callback: CallBack): this;
+
+    minimatch: {...};
+    options: Options;
+    aborted: boolean;
+    cache: { [path: string]: boolean | "DIR" | "FILE" | $ReadOnlyArray<string>, ... };
+    statCache: { [path: string]: boolean | { isDirectory(): boolean, ... } | void, ... };
+    symlinks: { [path: string]: boolean | void, ... };
+    realpathCache: { [path: string]: string, ... };
+    found: Array<string>;
+
+    pause(): void;
+    resume(): void;
+    abort(): void;
+  }
+
+  declare class GlobModule {
+    Glob: Class<Glob>;
+
+    (pattern: string, callback: CallBack): void;
+    (pattern: string, options: Options, callback: CallBack): void;
+
+    hasMagic(pattern: string, options?: Options): boolean;
+    sync(pattern: string, options?: Options): Array<string>;
+  }
+
+  declare module.exports: GlobModule;
+}


### PR DESCRIPTION
Summary:
This is a long overdue follow-up from https://github.com/facebook/react-native/issues/46724, and upgrades the deprecated `glob@7` to `glob@10`.

When creating any React Native project today, you are greeted by a wall of deprecation warnings when installing with `npm` -- with the most frequent offender being `glob@7.2.3`. This hurts UX and diminishes developers' trust, even before starting their project.

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/a5661470-98df-4f3f-8be2-7b0baa9711b6" />

Unfortunately, no [flow types are available for `glob@9+`](https://github.com/flow-typed/flow-typed/tree/main/definitions/npm). I've tried creating a flow definition, but it turns out that the `glob@10` types use `path-scurry@^1.11.1`, `minimatch@^9.0.4`, and `minipass@^7.1.2` -- all without flow type definitions. Writing the flow definitions for glob@9+ is non-trivial work, I'd be happy to help but I can't fix that on my own.

> [!IMPORTANT]
> `glob@11` has already been released, but it's only supporting Node 20+. I believe React Native still supports Node 18 until the EOL in April 2025, that's why I used `glob@10`.

## Changelog:

[GENERAL] [CHANGED] - Upgrade from deprecated `glob@7` to supported `glob@10`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [CHANGED] - Upgrade from deprecated `glob@7` to supported `glob@10`

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests

X-link: https://github.com/facebook/react-native/pull/48875

Reviewed By: robhogan, cortinico

Differential Revision: D69594539

Pulled By: huntie
