### PR TITLE
`package.json#exports` resolution: assert import / require according to source syntax

### DIFF
--- a/docs/Resolution.md
+++ b/docs/Resolution.md
@@ -120,7 +120,7 @@ Parameters: (*context*, *packagePath*, *filePath*, *exportsField*, *platform*)
 2. If *exportsField* contains an invalid configuration or values, raise an `InvalidPackageConfigurationError`.
 3. If *subpath* is not defined by *exportsField*, raise a `PackagePathNotExportedError`.
 4. Let *target* be the result of matching *subpath* in *exportsField* after applying any [conditional exports](https://nodejs.org/docs/latest-v19.x/api/packages.html#conditional-exports) and/or substituting a [subpath pattern match](https://nodejs.org/docs/latest-v19.x/api/packages.html#subpath-patterns).
-    1. Condition names will be asserted from the union of `context.unstable_conditionNames` and `context.unstable_conditionNamesByPlatform` for *platform*, in the order defined by *exportsField*.
+    1. Condition names will be asserted from the union of `'default'`, `'import'` OR `'require'` according to `context.isESMImport`, `context.unstable_conditionNames` and `context.unstable_conditionNamesByPlatform` for *platform*, in the order defined by *exportsField*.
 5. If *target* refers to an [asset](#assetexts-readonlysetstring), then
     1. Return the result of [**RESOLVE_ASSET**](#resolve_asset)(*context*, *target*, *platform*).
 6. Return *target* as a [source file resolution](#source-file) **without** applying redirections or trying any platform or extension variants.

--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -75,10 +75,7 @@ Object {
       "ts",
       "tsx",
     ],
-    "unstable_conditionNames": Array [
-      "require",
-      "import",
-    ],
+    "unstable_conditionNames": Array [],
     "unstable_conditionsByPlatform": Object {
       "web": Array [
         "browser",
@@ -263,10 +260,7 @@ Object {
       "ts",
       "tsx",
     ],
-    "unstable_conditionNames": Array [
-      "require",
-      "import",
-    ],
+    "unstable_conditionNames": Array [],
     "unstable_conditionsByPlatform": Object {
       "web": Array [
         "browser",
@@ -451,10 +445,7 @@ Object {
       "ts",
       "tsx",
     ],
-    "unstable_conditionNames": Array [
-      "require",
-      "import",
-    ],
+    "unstable_conditionNames": Array [],
     "unstable_conditionsByPlatform": Object {
       "web": Array [
         "browser",
@@ -639,10 +630,7 @@ Object {
       "ts",
       "tsx",
     ],
-    "unstable_conditionNames": Array [
-      "require",
-      "import",
-    ],
+    "unstable_conditionNames": Array [],
     "unstable_conditionsByPlatform": Object {
       "web": Array [
         "browser",

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -49,7 +49,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     nodeModulesPaths: [],
     resolveRequest: null,
     resolverMainFields: ['browser', 'main'],
-    unstable_conditionNames: ['require', 'import'],
+    unstable_conditionNames: [],
     unstable_conditionsByPlatform: {
       web: ['browser'],
     },

--- a/packages/metro-resolver/src/PackageExportsResolve.js
+++ b/packages/metro-resolver/src/PackageExportsResolve.js
@@ -305,6 +305,7 @@ function matchSubpathFromExports(
 }> {
   const conditionNames = new Set([
     'default',
+    context.isESMImport === true ? 'import' : 'require',
     ...context.unstable_conditionNames,
     ...(platform != null
       ? context.unstable_conditionsByPlatform[platform] ?? []

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -365,21 +365,9 @@ function resolvePackage(
     const exportsField = pkg?.packageJson.exports;
 
     if (pkg != null && exportsField != null) {
-      let conditionNamesOverride = context.unstable_conditionNames;
-
-      // HACK!: Do not assert the "import" condition for `@babel/runtime`. This
-      // is a workaround for ESM <-> CJS interop, as we need the CJS versions of
-      // `@babel/runtime` helpers.
-      // TODO(T154157178): Remove with better "require"/"import" solution
-      if (pkg.packageJson.name === '@babel/runtime') {
-        conditionNamesOverride = context.unstable_conditionNames.filter(
-          condition => condition !== 'import',
-        );
-      }
-
       try {
         const packageExportsResult = resolvePackageTargetFromExports(
-          {...context, unstable_conditionNames: conditionNamesOverride},
+          context,
           pkg.rootPath,
           absoluteCandidatePath,
           pkg.packageRelativePath,


### PR DESCRIPTION
Summary:
A longstanding limitation of our current package `exports` resolution (and upcoming `imports` resolution) is that we have not been able to correctly implement the `import` / `require` condition.

 - By always asserting only `'require'`, we would be needlessly incompatible with increasingly common ESM-only packages.
 - By always asserting only `'import'`, we would be incompatible with CJS-only, and more likely to consume code containing top-level await. 
 - By asserting *both* `'import'` and `'require'` as we do before this diff, we are violating [spec](https://nodejs.org/api/packages.html#conditional-exports), and potentially "jumping between" CommonJS <-> ESM builds where packages export both, in ways no other bundler does and package authors won't expect. This _mostly_ happens to work, but has weird edge cases - for example, we have to hackily remove the `import` assertion when resolving `require('babel/runtime')` helpers to avoid pulling ESM builds of ESM->CJS interop helpers.

## This change
Assert `import` or `require` mutually exclusively, respecting the syntax used in the file being transformed. This should mean we traverse the same dependency tree as Node.js and other bundlers.

This builds on the [`ResolutionContext.isESMImport`](https://github.com/facebook/metro/pull/1376) feature just added, which threads information about the source dependency declaration through to the resolver.

Changelog:
```
 - **[Experimental]**: With `unstable_enablePackageExports`, assert exactly one of the conditions `import`/`require` according to source syntax.
```

Differential Revision: D70462551


