### PR TITLE
Breaking: Enable `unstable_enablePackageExports` by default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,6 +29,7 @@ if (process.platform === 'win32') {
       'packages/metro-symbolicate/src/__tests__/symbolicate-test.js',
       'packages/metro-file-map/src/__tests__/index-test.js',
       'packages/metro-file-map/src/crawlers/__tests__/node-test.js',
+      'packages/metro-resolver/src/__tests__/package-imports-test.js',
 
       // resolveModulePath failed
       'packages/metro-cache/src/stores/__tests__/FileStore-test.js',

--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -81,7 +81,7 @@ Object {
         "browser",
       ],
     },
-    "unstable_enablePackageExports": false,
+    "unstable_enablePackageExports": true,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -266,7 +266,7 @@ Object {
         "browser",
       ],
     },
-    "unstable_enablePackageExports": false,
+    "unstable_enablePackageExports": true,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -451,7 +451,7 @@ Object {
         "browser",
       ],
     },
-    "unstable_enablePackageExports": false,
+    "unstable_enablePackageExports": true,
     "useWatchman": true,
   },
   "serializer": Object {
@@ -636,7 +636,7 @@ Object {
         "browser",
       ],
     },
-    "unstable_enablePackageExports": false,
+    "unstable_enablePackageExports": true,
     "useWatchman": true,
   },
   "serializer": Object {

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -53,7 +53,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     unstable_conditionsByPlatform: {
       web: ['browser'],
     },
-    unstable_enablePackageExports: false,
+    unstable_enablePackageExports: true,
     useWatchman: true,
     requireCycleIgnorePatterns: [/(^|\/|\\)node_modules($|\/|\\)/],
   },

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -688,7 +688,7 @@ describe('processRequest', () => {
         unstable_transformProfile: 'default',
       },
       unstable_allowRequireContext: false,
-      unstable_enablePackageExports: false,
+      unstable_enablePackageExports: true,
     });
   });
 
@@ -750,7 +750,7 @@ describe('processRequest', () => {
         unstable_transformProfile: 'hermes-stable',
       },
       unstable_allowRequireContext: false,
-      unstable_enablePackageExports: false,
+      unstable_enablePackageExports: true,
     });
   });
 
@@ -981,7 +981,7 @@ describe('processRequest', () => {
           unstable_transformProfile: 'default',
         },
         unstable_allowRequireContext: false,
-        unstable_enablePackageExports: false,
+        unstable_enablePackageExports: true,
       });
     });
   });


### PR DESCRIPTION
Summary:
Metro 0.81.3 added support for `package.json#imports` and addressed the main outstanding issue with `package.json#exports` - correct assertion of the `import` or `require` condition.

This flips `unstable_enablePackageExports` to `true` ahead of Metro 0.82.0 / RN 0.79-rc.0, which will allow some stabilisation time before this default reaches users.

Since this potentially changes the way existing imports are resolved, I'm labelling it semver breaking out of an abundance of caution. I wouldn't expect this to be disruptive, especially because `unstable_enablePackageExports` is already widely enabled in practice.

Leaving the flag in place so that anyone who runs into trouble has an escape hatch via `unstable_enablePackageExports: false`. This option will be removed in a later release.

Changelog:
```
 - **[Breaking]**: Enable support for `package.json#exports` resolution by default.
```

Reviewed By: huntie

Differential Revision: D70463018


