### PR TITLE
Breaking: Enable lazy hashing by default, changes to Transformer and DependencyGraph APIs

### DIFF
--- a/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/loadConfig-test.js.snap
@@ -174,7 +174,7 @@ Object {
       "debounceMs": 5000,
       "enabled": true,
     },
-    "unstable_lazySha1": false,
+    "unstable_lazySha1": true,
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [
@@ -359,7 +359,7 @@ Object {
       "debounceMs": 5000,
       "enabled": true,
     },
-    "unstable_lazySha1": false,
+    "unstable_lazySha1": true,
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [
@@ -544,7 +544,7 @@ Object {
       "debounceMs": 5000,
       "enabled": true,
     },
-    "unstable_lazySha1": false,
+    "unstable_lazySha1": true,
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [
@@ -729,7 +729,7 @@ Object {
       "debounceMs": 5000,
       "enabled": true,
     },
-    "unstable_lazySha1": false,
+    "unstable_lazySha1": true,
     "unstable_workerThreads": false,
     "watchman": Object {
       "deferStates": Array [

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -147,7 +147,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
       interval: 30000,
       timeout: 5000,
     },
-    unstable_lazySha1: false,
+    unstable_lazySha1: true,
     unstable_workerThreads: false,
     unstable_autoSaveCache: {
       enabled: true,

--- a/packages/metro/src/Bundler.js
+++ b/packages/metro/src/Bundler.js
@@ -36,17 +36,10 @@ class Bundler {
       .ready()
       .then(() => {
         config.reporter.update({type: 'transformer_load_started'});
-        this._transformer = new Transformer(
-          config,
-          config.watcher.unstable_lazySha1
-            ? // This object-form API is expected to replace passing a function
-              // once lazy SHA1 is stable. This will be a breaking change.
-              {
-                unstable_getOrComputeSha1: filePath =>
-                  this._depGraph.unstable_getOrComputeSha1(filePath),
-              }
-            : (...args) => this._depGraph.getSha1(...args),
-        );
+        this._transformer = new Transformer(config, {
+          getOrComputeSha1: filePath =>
+            this._depGraph.getOrComputeSha1(filePath),
+        });
         config.reporter.update({type: 'transformer_load_done'});
       })
       .catch(error => {

--- a/packages/metro/src/DeltaBundler/__tests__/Transformer-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/Transformer-test.js
@@ -27,7 +27,9 @@ describe('Transformer', function () {
   let watchFolders;
   let projectRoot;
   let commonOptions;
-  const getSha1 = jest.fn(() => '0123456789012345678901234567890123456789');
+  const getOrComputeSha1 = jest.fn(() => ({
+    sha1: '0123456789012345678901234567890123456789',
+  }));
 
   beforeEach(function () {
     const baseConfig = {
@@ -69,7 +71,7 @@ describe('Transformer', function () {
         cacheStores: [{get, set}],
         watchFolders,
       },
-      getSha1,
+      {getOrComputeSha1},
     );
 
     require('../WorkerFarm').prototype.transform.mockReturnValue({
@@ -80,7 +82,7 @@ describe('Transformer', function () {
     await transformerInstance.transformFile('./foo.js', {});
 
     // We got the SHA-1 of the file from the dependency graph.
-    expect(getSha1).toBeCalledWith('./foo.js');
+    expect(getOrComputeSha1).toBeCalledWith('./foo.js');
 
     // Only one get, with the original SHA-1.
     expect(get).toHaveBeenCalledTimes(1);
@@ -118,7 +120,7 @@ describe('Transformer', function () {
         cacheStores: [{get, set}],
         watchFolders,
       },
-      getSha1,
+      {getOrComputeSha1},
     );
 
     require('../WorkerFarm').prototype.transform.mockReturnValue({
@@ -158,7 +160,7 @@ describe('Transformer', function () {
         cacheStores: [store],
         watchFolders,
       },
-      getSha1,
+      {getOrComputeSha1},
     );
 
     require('../WorkerFarm').prototype.transform.mockReturnValue({
@@ -199,7 +201,7 @@ describe('Transformer', function () {
         cacheStores: [],
         watchFolders,
       },
-      getSha1,
+      {getOrComputeSha1},
     );
 
     require('../WorkerFarm').prototype.transform.mockReturnValue({

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -630,7 +630,7 @@ class Server {
     const depGraph = await this._bundler.getBundler().getDependencyGraph();
     const filePath = path.join(rootDir, relativePathname);
     try {
-      depGraph.getSha1(filePath);
+      await depGraph.getOrComputeSha1(filePath);
     } catch {
       res.writeHead(404);
       res.end();

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -55,14 +55,6 @@ function getOrCreateMap<T>(
   return subMap;
 }
 
-const missingSha1Error = (mixedPath: string) =>
-  new Error(`Failed to get the SHA-1 for: ${mixedPath}.
-  Potential causes:
-    1) The file is not watched. Ensure it is under the configured \`projectRoot\` or \`watchFolders\`.
-    2) Check \`blockList\` in your metro.config.js and make sure it isn't excluding the file path.
-    3) The file may have been deleted since it was resolved - try refreshing your app.
-    4) Otherwise, this is a bug in Metro or the configured resolver - please report it.`);
-
 class DependencyGraph extends EventEmitter {
   _config: ConfigT;
   _haste: MetroFileMap;
@@ -264,23 +256,20 @@ class DependencyGraph extends EventEmitter {
     return nullthrows(this._fileSystem).getAllFiles();
   }
 
-  getSha1(filename: string): string {
-    const sha1 = this._fileSystem.getSha1(filename);
-    if (!sha1) {
-      throw missingSha1Error(filename);
-    }
-    return sha1;
-  }
-
   /**
    * Used when watcher.unstable_lazySha1 is true
    */
-  async unstable_getOrComputeSha1(
+  async getOrComputeSha1(
     mixedPath: string,
   ): Promise<{content?: Buffer, sha1: string}> {
     const result = await this._fileSystem.getOrComputeSha1(mixedPath);
     if (!result || !result.sha1) {
-      throw missingSha1Error(mixedPath);
+      throw new Error(`Failed to get the SHA-1 for: ${mixedPath}.
+      Potential causes:
+        1) The file is not watched. Ensure it is under the configured \`projectRoot\` or \`watchFolders\`.
+        2) Check \`blockList\` in your metro.config.js and make sure it isn't excluding the file path.
+        3) The file may have been deleted since it was resolved - try refreshing your app.
+        4) Otherwise, this is a bug in Metro or the configured resolver - please report it.`);
     }
     return result;
   }

--- a/packages/metro/types/node-haste/DependencyGraph.d.ts
+++ b/packages/metro/types/node-haste/DependencyGraph.d.ts
@@ -34,7 +34,7 @@ export default class DependencyGraph extends EventEmitter {
   ): Promise<DependencyGraph>;
 
   getAllFiles(): string[];
-  getSha1(filename: string): string;
+  getOrComputeSha1(filename: string): Promise<{sha1: string; content?: Buffer}>;
   getWatcher(): EventEmitter;
   end(): void;
 


### PR DESCRIPTION
Summary:
Lazy hashing was released in Metro 0.81.2 as an opt-in. It significantly reduces the IO Metro needs to perform on startup and generally improves cold start speed >3x, while being fully compatible with cache lookups even on a cold start.

![image](https://github.com/user-attachments/assets/d9c26df7-77ea-4842-9007-b44c7aa06332)

(We announced this in https://x.com/MetroBundler/status/1895102434889850960 )

There's very little risk to this feature - the technically-breaking change required only affects integrators using an "internal" API - instantiating a `Transformer`.

This flips it to default-on ahead of Metro 0.82.0

Changelog:
```
 - **[Breaking]**: Integrators consuming `metro/src/DeltaBundler/Transformer` must now pass an options object with `getOrComputeSha1`
 - **[Breaking]**: `getSha1` removed from `metro/src/node-haste/DependencyGraph`, prefer `getOrComputeSha1`
 - **[Performance]**: Enable lazy file hashing by default (disable with `watcher.unstable_lazySha1: false`)
```

Reviewed By: huntie

Differential Revision: D70463022


