### PR TITLE
Use builtin libdefs from flow-typed

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -2381,7 +2381,11 @@ declare class readline$Interface extends events$EventEmitter {
   close(): void;
   pause(): void;
   prompt(preserveCursor?: boolean): void;
-  question(query: string, callback: (answer: string) => void): void;
+  question(
+    query: string,
+    optionsOrCallback: {|signal?: AbortSignal|} | ((answer: string) => void),
+    callback?: (answer: string) => void,
+  ): void;
   resume(): void;
   setPrompt(prompt: string): void;
   write(
@@ -2399,29 +2403,38 @@ declare class readline$Interface extends events$EventEmitter {
 
 declare module 'readline' {
   declare var Interface: typeof readline$Interface;
-  declare function clearLine(stream: stream$Stream, dir: -1 | 1 | 0): void;
-  declare function clearScreenDown(stream: stream$Stream): void;
+  declare function clearLine(
+    stream: stream$Stream,
+    dir: -1 | 1 | 0,
+    callback?: () => void,
+  ): void;
+  declare function clearScreenDown(
+    stream: stream$Stream,
+    callback?: () => void,
+  ): void;
   declare function createInterface(opts: {
+    completer?: readline$InterfaceCompleter,
+    crlfDelay?: number,
+    escapeCodeTimeout?: number,
+    historySize?: number,
     input: stream$Readable,
     output?: ?stream$Stream,
-    completer?: readline$InterfaceCompleter,
-    terminal?: boolean,
-    historySize?: number,
     prompt?: string,
-    crlfDelay?: number,
     removeHistoryDuplicates?: boolean,
-    escapeCodeTimeout?: number,
+    terminal?: boolean,
     ...
   }): readline$Interface;
   declare function cursorTo(
     stream: stream$Stream,
     x?: number,
     y?: number,
+    callback?: () => void,
   ): void;
   declare function moveCursor(
     stream: stream$Stream,
     dx: number,
     dy: number,
+    callback?: () => void,
   ): void;
   declare function emitKeypressEvents(
     stream: stream$Stream,


### PR DESCRIPTION
Summary:
In the next version of Flow, we will stop bundling many of the builtin libdefs, and they have been moved to flow-typed. This diff checks in them to prepare for the deployment of the next version of Flow.

Changelog: [Internal]

Differential Revision: D70896122


