### PR TITLE
Update docs for "package exports" to promote deferring platform specific requires

### DIFF
--- a/docs/PackageExports.md
+++ b/docs/PackageExports.md
@@ -191,9 +191,9 @@ We chose not to introduce `"android"` and `"ios"` conditions, due to the prevale
 // src/FooComponent.js
 
 const FooComponent = Platform.select({
-  android: require('./FooComponentAndroid.js'),
-  ios: require('FooComponentIOS.js'),
-});
+  android: () => require('./FooComponentAndroid.js'),
+  ios: () => require('FooComponentIOS.js'),
+})();
 
 export default FooComponent;
 ```


### PR DESCRIPTION
## Summary

This is a suggestion to update the docs on "PackageExports" to ensure only one platform specific file is ever required.
This aligns with the React Native docs that are linked to: https://reactnative.dev/docs/platform#select
Without this, the source-code for both platforms will be required, which is not ideal and not something we'd want to promote.

Changelog: [Internal] Updating docs of "package exports".

## Test plan

None.
