### PR TITLE
Fix edge-case overmatching of pattern keys in package.json exports/imports resolution

### DIFF
--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -510,9 +510,14 @@ describe('with package exports resolution enabled', () => {
             './features/bar/*.js': {
               'react-native': null,
             },
+            './node/*': './lib/node/*.js',
+            './*': './misc/*.js',
+            './node/*/types': './types/*/types.d.ts',
             './assets/*': './assets/*',
           },
         }),
+        '/root/node_modules/test-pkg/lib/node/test.js': '',
+        '/root/node_modules/test-pkg/lib/node/foo/public.js': '',
         '/root/node_modules/test-pkg/src/index.js': '',
         '/root/node_modules/test-pkg/src/features/foo.js': '',
         '/root/node_modules/test-pkg/src/features/foo.js.js': '',
@@ -520,6 +525,7 @@ describe('with package exports resolution enabled', () => {
         '/root/node_modules/test-pkg/src/features/baz.native.js': '',
         '/root/node_modules/test-pkg/src/features/node_modules/foo/index.js':
           '',
+        '/root/node_modules/test-pkg/types/foo/types.d.ts': '',
         '/root/node_modules/test-pkg/assets/Logo.js': '',
       }),
       originModulePath: '/root/src/main.js',
@@ -575,6 +581,32 @@ describe('with package exports resolution enabled', () => {
           /node_modules
         "
       `);
+    });
+
+    test('should resolve prefixed wildcard export, using the most specific export path', () => {
+      const context = baseContext;
+
+      expect(Resolver.resolve(context, 'test-pkg/node/test', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/lib/node/test.js',
+      });
+    });
+
+    test('longer patterns have higher specificity if bases are equal', () => {
+      const context = baseContext;
+      expect(
+        Resolver.resolve(context, 'test-pkg/node/foo/public', null),
+      ).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/lib/node/foo/public.js',
+      });
+
+      expect(
+        Resolver.resolve(context, 'test-pkg/node/foo/types', null),
+      ).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/types/foo/types.d.ts',
+      });
     });
 
     describe('package encapsulation', () => {

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -514,6 +514,7 @@ describe('with package exports resolution enabled', () => {
             './*': './misc/*.js',
             './node/*/types': './types/*/types.d.ts',
             './assets/*': './assets/*',
+            './repeated*/repeated': './repeated*/repeated.js',
           },
         }),
         '/root/node_modules/test-pkg/lib/node/test.js': '',
@@ -525,6 +526,9 @@ describe('with package exports resolution enabled', () => {
         '/root/node_modules/test-pkg/src/features/baz.native.js': '',
         '/root/node_modules/test-pkg/src/features/node_modules/foo/index.js':
           '',
+        '/root/node_modules/test-pkg/misc/repeated.js': '',
+        '/root/node_modules/test-pkg/repeated/repeated.js': '',
+        '/root/node_modules/test-pkg/repeated/repeated/repeated.js': '',
         '/root/node_modules/test-pkg/types/foo/types.d.ts': '',
         '/root/node_modules/test-pkg/assets/Logo.js': '',
       }),
@@ -606,6 +610,22 @@ describe('with package exports resolution enabled', () => {
       ).toEqual({
         type: 'sourceFile',
         filePath: '/root/node_modules/test-pkg/types/foo/types.d.ts',
+      });
+    });
+
+    test('patternBase and patternTrailer must match non-overlapping ends of matchKey', () => {
+      // ./repeated/repeated *should* match ./repeated*/repeated
+      expect(
+        Resolver.resolve(baseContext, 'test-pkg/repeated/repeated', null),
+      ).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/repeated/repeated.js',
+      });
+
+      // ./repeated should *not* match ./repeated*/repeated
+      expect(Resolver.resolve(baseContext, 'test-pkg/repeated', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/misc/repeated.js',
       });
     });
 

--- a/packages/metro-resolver/src/utils/matchSubpathPattern.js
+++ b/packages/metro-resolver/src/utils/matchSubpathPattern.js
@@ -21,7 +21,12 @@ export function matchSubpathPattern(
 ): string | null {
   const [patternBase, patternTrailer] = subpathPattern.split('*');
 
-  if (subpath.startsWith(patternBase) && subpath.endsWith(patternTrailer)) {
+  if (
+    subpath.startsWith(patternBase) &&
+    (patternTrailer.length === 0 ||
+      (subpath.endsWith(patternTrailer) &&
+        subpath.length >= subpathPattern.length))
+  ) {
     return subpath.substring(
       patternBase.length,
       subpath.length - patternTrailer.length,


### PR DESCRIPTION

Summary:
Currently package exports resolution pattern matching may falsely match some patterns because we don't apply a subtle part of the [specification](https://nodejs.org/docs/latest/api/esm.html#resolution-algorithm-specification) - specifically, we check that the subpath starts with the pattern base and ends with the pattern trailer, but not that the subpath length >= the pattern length.

This means the `startsWith` and `endsWith` checks may both be satisfied by the same substring, e.g:

```
  "exports": {
    "./repeated*/repeated": null
  }
```

Will incorrectly match the substring `./repeated`, because it both starts with `./repeated` and ends with `/repeated`.

The spec would disallow this because `matchKey` is shorter than `patternKey`:

> If `patternTrailer` has zero length, or if `matchKey` ends with `patternTrailer` and the length of `matchKey` is greater than or equal to the length of `expansionKey`, then:
Let `target` be the value of `matchObj[expansionKey]`.
...

This diff applies that bit of the spec.

```
 - **[Fix]**: Fix edge-case overmatching of pattern keys in package.json exports/imports resolution.
```

Reviewed By: huntie

Differential Revision: D70971859

fbshipit-source-id: d3a3c317234bd015b58b7ac784aa5ac8f7c48d5e
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/metro/pull/1466).
* #1469
* #1468
* #1467
* __->__ #1466
* #1458