### PR TITLE
Fix handling of export map targets with zero or 2+ wildcard characters in package.json imports/exports resolution

### DIFF
--- a/packages/metro-resolver/src/PackageExportsResolve.js
+++ b/packages/metro-resolver/src/PackageExportsResolve.js
@@ -97,7 +97,7 @@ export function resolvePackageTargetFromExports(
 
     const filePath = path.join(
       packagePath,
-      patternMatch != null ? target.replace('*', patternMatch) : target,
+      patternMatch != null ? target.replaceAll('*', patternMatch) : target,
     );
 
     if (isAssetFile(filePath, context.assetExts)) {

--- a/packages/metro-resolver/src/PackageImportsResolve.js
+++ b/packages/metro-resolver/src/PackageImportsResolve.js
@@ -84,7 +84,7 @@ export function resolvePackageTargetFromImports(
 
   const filePath = path.join(
     packagePath,
-    patternMatch != null ? target.replace('*', patternMatch) : target,
+    patternMatch != null ? target.replaceAll('*', patternMatch) : target,
   );
 
   if (isAssetFile(filePath, context.assetExts)) {

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -510,9 +510,14 @@ describe('with package exports resolution enabled', () => {
             './features/bar/*.js': {
               'react-native': null,
             },
+            './node/*': './lib/node/*.js',
+            './*': './misc/*.js',
+            './node/*/types': './types/*/types.d.ts',
             './assets/*': './assets/*',
           },
         }),
+        '/root/node_modules/test-pkg/lib/node/test.js': '',
+        '/root/node_modules/test-pkg/lib/node/foo/public.js': '',
         '/root/node_modules/test-pkg/src/index.js': '',
         '/root/node_modules/test-pkg/src/features/foo.js': '',
         '/root/node_modules/test-pkg/src/features/foo.js.js': '',
@@ -520,6 +525,7 @@ describe('with package exports resolution enabled', () => {
         '/root/node_modules/test-pkg/src/features/baz.native.js': '',
         '/root/node_modules/test-pkg/src/features/node_modules/foo/index.js':
           '',
+        '/root/node_modules/test-pkg/types/foo/types.d.ts': '',
         '/root/node_modules/test-pkg/assets/Logo.js': '',
       }),
       originModulePath: '/root/src/main.js',
@@ -575,6 +581,32 @@ describe('with package exports resolution enabled', () => {
           /node_modules
         "
       `);
+    });
+
+    test('should resolve prefixed wildcard export, using the most specific export path', () => {
+      const context = baseContext;
+
+      expect(Resolver.resolve(context, 'test-pkg/node/test', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/lib/node/test.js',
+      });
+    });
+
+    test('longer patterns have higher specificity if bases are equal', () => {
+      const context = baseContext;
+      expect(
+        Resolver.resolve(context, 'test-pkg/node/foo/public', null),
+      ).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/lib/node/foo/public.js',
+      });
+
+      expect(
+        Resolver.resolve(context, 'test-pkg/node/foo/types', null),
+      ).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/types/foo/types.d.ts',
+      });
     });
 
     describe('package encapsulation', () => {

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -514,6 +514,7 @@ describe('with package exports resolution enabled', () => {
             './*': './misc/*.js',
             './node/*/types': './types/*/types.d.ts',
             './assets/*': './assets/*',
+            './repeated*/repeated': './repeated*/repeated.js',
           },
         }),
         '/root/node_modules/test-pkg/lib/node/test.js': '',
@@ -525,6 +526,9 @@ describe('with package exports resolution enabled', () => {
         '/root/node_modules/test-pkg/src/features/baz.native.js': '',
         '/root/node_modules/test-pkg/src/features/node_modules/foo/index.js':
           '',
+        '/root/node_modules/test-pkg/misc/repeated.js': '',
+        '/root/node_modules/test-pkg/repeated/repeated.js': '',
+        '/root/node_modules/test-pkg/repeated/repeated/repeated.js': '',
         '/root/node_modules/test-pkg/types/foo/types.d.ts': '',
         '/root/node_modules/test-pkg/assets/Logo.js': '',
       }),
@@ -606,6 +610,22 @@ describe('with package exports resolution enabled', () => {
       ).toEqual({
         type: 'sourceFile',
         filePath: '/root/node_modules/test-pkg/types/foo/types.d.ts',
+      });
+    });
+
+    test('patternBase and patternTrailer must match non-overlapping ends of matchKey', () => {
+      // ./repeated/repeated *should* match ./repeated*/repeated
+      expect(
+        Resolver.resolve(baseContext, 'test-pkg/repeated/repeated', null),
+      ).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/repeated/repeated.js',
+      });
+
+      // ./repeated should *not* match ./repeated*/repeated
+      expect(Resolver.resolve(baseContext, 'test-pkg/repeated', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/misc/repeated.js',
       });
     });
 

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -515,6 +515,8 @@ describe('with package exports resolution enabled', () => {
             './node/*/types': './types/*/types.d.ts',
             './assets/*': './assets/*',
             './repeated*/repeated': './repeated*/repeated.js',
+            './*/private': './src/forbidden.js',
+            './data.*': './data/*/data.*',
           },
         }),
         '/root/node_modules/test-pkg/lib/node/test.js': '',
@@ -526,11 +528,14 @@ describe('with package exports resolution enabled', () => {
         '/root/node_modules/test-pkg/src/features/baz.native.js': '',
         '/root/node_modules/test-pkg/src/features/node_modules/foo/index.js':
           '',
+        '/root/node_modules/test-pkg/src/forbidden.js': '',
         '/root/node_modules/test-pkg/misc/repeated.js': '',
         '/root/node_modules/test-pkg/repeated/repeated.js': '',
         '/root/node_modules/test-pkg/repeated/repeated/repeated.js': '',
         '/root/node_modules/test-pkg/types/foo/types.d.ts': '',
         '/root/node_modules/test-pkg/assets/Logo.js': '',
+        '/root/node_modules/test-pkg/data/json/data.json': '',
+        '/root/node_modules/test-pkg/data/csv/data.csv': '',
       }),
       originModulePath: '/root/src/main.js',
       unstable_enablePackageExports: true,
@@ -626,6 +631,27 @@ describe('with package exports resolution enabled', () => {
       expect(Resolver.resolve(baseContext, 'test-pkg/repeated', null)).toEqual({
         type: 'sourceFile',
         filePath: '/root/node_modules/test-pkg/misc/repeated.js',
+      });
+    });
+
+    test('patterns can resolve to static targets', () => {
+      const context = baseContext;
+      expect(Resolver.resolve(context, 'test-pkg/foo/private', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/src/forbidden.js',
+      });
+    });
+
+    test('patterns can resolve to targets with multiple *', () => {
+      const context = baseContext;
+      expect(Resolver.resolve(context, 'test-pkg/data.json', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/data/json/data.json',
+      });
+
+      expect(Resolver.resolve(context, 'test-pkg/data.csv', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/test-pkg/data/csv/data.csv',
       });
     });
 

--- a/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js
+++ b/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js
@@ -72,11 +72,6 @@ export function matchSubpathFromExportsLike(
     for (const {key} of expansionKeys) {
       const value = exportsLikeMapAfterConditions.get(key);
 
-      // Skip invalid values (must include a single '*' or be `null`)
-      if (typeof value === 'string' && value.split('*').length !== 2) {
-        break;
-      }
-
       patternMatch = matchSubpathPattern(key, subpath);
 
       if (patternMatch != null) {

--- a/packages/metro-resolver/src/utils/matchSubpathPattern.js
+++ b/packages/metro-resolver/src/utils/matchSubpathPattern.js
@@ -21,7 +21,12 @@ export function matchSubpathPattern(
 ): string | null {
   const [patternBase, patternTrailer] = subpathPattern.split('*');
 
-  if (subpath.startsWith(patternBase) && subpath.endsWith(patternTrailer)) {
+  if (
+    subpath.startsWith(patternBase) &&
+    (patternTrailer.length === 0 ||
+      (subpath.endsWith(patternTrailer) &&
+        subpath.length >= subpathPattern.length))
+  ) {
     return subpath.substring(
       patternBase.length,
       subpath.length - patternTrailer.length,


### PR DESCRIPTION

Summary:
Currently, metro-resolver will break if an exports map includes a pattern key whose target does not have exactly one `*` character.

This is an incorrect limitation according to the spec - values may have any number (including zero) `*` characters (*keys* must have no more than one). The spec requires that *all* occurrences of `*` in the matched target are replaced with the `patternMatch` substring of the specified subpath.

Worse, we *`break`* rather than `continue` on such an "invalid" target, which means the presence of one of these targets can mean we fail resolution before other keys in the export map are tried.

This diff implements the spec:

[https://nodejs.org/docs/latest/api/esm.html#resolution-algorithm-specification](https://nodejs.org/docs/latest/api/esm.html#resolution-algorithm-specification)

> If `patternMatch` is a `String`, then
> Return **`PACKAGE_RESOLVE`**(`target` with every instance of "*" replaced by `patternMatch`, `packageURL + "/"`).

```javascript
 - **[Fix]**: Fix handling of export map targets with zero or 2+ wildcard characters in package.json imports/exports resolution
```

Reviewed By: huntie

Differential Revision: D70973129

fbshipit-source-id: 68632b68dbc37dc24988cd68529a5cebfcb5a5d3
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/metro/pull/1467).
* #1469
* #1468
* __->__ #1467
* #1466
* #1458