### PR TITLE
Add support for ArrayBuffer in asDeserializedBuffer

### DIFF
--- a/packages/metro/src/DeltaBundler/Worker.flow.js
+++ b/packages/metro/src/DeltaBundler/Worker.flow.js
@@ -66,6 +66,9 @@ function asDeserializedBuffer(value: any): Buffer | null {
   if (value && value.type === 'Buffer') {
     return Buffer.from(value.data);
   }
+  if (ArrayBuffer.isView(value)) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  }
   return null;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Running `expo` + `metro` in Bun gives an error like:
```
SyntaxError: src/app?ctx=e5807cc4e93b7ea02120ad0165264d893ac772db: ENOENT: no such file or directory, open '/usr/dev/apps/expo/src/app?ctx=e5807c
```

I drilled down quite a bit and it turns out that the `transform` function _is_ being called with a `fileBuffer` already, so it shouldn't be trying to read the file. The issue is that, in Bun, this seems to be returned as a `Uint8Array` instead of a `Buffer`

So, I've just added a simple check and conversion for ArrayView -> Buffer

## Testing
Here's how to reproduce:
```sh
bun create tamagui@latest --template expo-router
# Name app "bun-test" -- at this point it will try to yarn install and might fail, but we want to use bun
cd bun-test
rm yarn.lock && bun install
bunx --bun expo export --platform web
```

This fails before the change and succeeds after.

## Root cause
It seems to be more specifically that Bun and Node give different results when using `jest-worker` to send a Buffer:
```ts
// test.ts
import { resolve } from "node:path";
import { Worker as JestWorker } from "jest-worker";

const path = resolve(import.meta.dirname, "worker.ts");
async function main() {
  const worker = new JestWorker(path, { enableWorkerThreads: false });
  const result = await worker.giveMeABuffer();
  console.log(result);
}

main();

// worker.ts
export function giveMeABuffer() {
  return Buffer.from("hello");
}
```

```bash
> node --experimental-strip-types test.ts
<Buffer 77 6f 72 6c 64>

> bun run test.ts
Uint8Array(5) [ 119, 111, 114, 108, 100 ]
```

Interestingly, if I set `enableWorkerThreads` to `true`, node _also_ returns a Uint8Array:
```bash
// with { enableWorkerThreads: true }
> node --experimental-strip-types test.ts
Uint8Array(5) [ 119, 111, 114, 108, 100 ]

// with { enableWorkerThreads: true }, but Bun ends up breaking:
> bun run test.ts
NotImplementedError: worker_threads.Worker option "resourceLimits" is not yet implemented in Bun.
 code: "ERR_NOT_IMPLEMENTED"
```