### PR TITLE
feat(metro): Improve stack frame handling by showing the first valid frame when all frames are collapsed

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -1221,11 +1221,17 @@ class Server {
       urls: Set<string>,
       symbolicatedStack: $ReadOnlyArray<StackFrameOutput>,
     ) => {
+      const allFramesCollapsed = symbolicatedStack.every(
+        ({collapse}) => collapse,
+      );
+
       for (let i = 0; i < symbolicatedStack.length; i++) {
         const {collapse, column, file, lineNumber} = symbolicatedStack[i];
 
         if (
-          collapse ||
+          // If all the frames are collapsed then we should ignore the collapse flag
+          // and always show the first valid frame.
+          (!allFramesCollapsed && collapse) ||
           lineNumber == null ||
           (file != null && urls.has(file))
         ) {

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -992,6 +992,7 @@ describe('processRequest', () => {
           '/root/mybundle.js',
           'this\nis\njust an example and it is all fake data, yay!',
         );
+        fs.writeFileSync('/root/foo.js', 'mock data');
       });
 
       test('should symbolicate given stack trace', async () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

When an error comes from the internals of your app it can be especially devastating. This generally happens when you have a versioning issue from upgrading. The stacks are currently optimized for user-space errors which make up the majority of issues, but when all frames are collapsed we should assume the issue is an internal bug and show anything to give the user some sort of hint for what to fix.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->

Changelog: [Feature] Fallback to showing first collapsed frame when all frames in a stack are collapsed.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
