### PR TITLE
allow detecting babel registrations of large files that could have been avoided

### DIFF
--- a/packages/metro-babel-register/package.json
+++ b/packages/metro-babel-register/package.json
@@ -24,6 +24,7 @@
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
     "babel-plugin-syntax-hermes-parser": "0.28.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",
+    "debug": "^4.4.0",
     "escape-string-regexp": "^1.0.5",
     "flow-enums-runtime": "^0.0.6"
   },

--- a/packages/metro-babel-register/src/babel-register.js
+++ b/packages/metro-babel-register/src/babel-register.js
@@ -15,9 +15,13 @@
 import type {BabelCoreOptions} from '@babel/core';
 */
 
+const debug = require('debug')('Metro:BabelRegister');
 const escapeRegExp = require('escape-string-regexp');
 const fs = require('fs');
 const path = require('path');
+const {Script} = require('vm');
+
+const MIN_FILE_SIZE_TO_WARN_ABOUT /*: number */ = 50000;
 
 let _only /*: $ReadOnlyArray<RegExp | string> */ = [];
 
@@ -50,6 +54,39 @@ function register(onlyList /*: $ReadOnlyArray<RegExp | string> */) {
   require('@babel/register')(registerConfig);
 }
 
+function warnIfFileCouldSkipRegistration(
+  {opts: {filename}, code} /*: {opts: {filename: string}, code: string} */,
+) /*: void*/ {
+  const fileSize = Buffer.byteLength(code, 'utf8');
+  if (fileSize < MIN_FILE_SIZE_TO_WARN_ABOUT) {
+    return;
+  }
+
+  if (code.includes('\x40flow')) {
+    return;
+  }
+
+  if (!isFileValidJS(code)) {
+    return;
+  }
+
+  debug(
+    `[metro-babel-register] A large, non flow, valid JS of size ${fileSize / 1000}kb that can be read by node.js witout a transpilation was transpiled using @babel/register:
+${filename}.
+Consider removing that file from the files being registered in "xplat/js/tools/babel-register/index.js" to speed up the import of that file.
+${'\n'.repeat(8)}`, // 8 new lines to ensure that a terminal status update won't erase the warning
+  );
+}
+
+function isFileValidJS(contents /*: string*/) /*: boolean*/ {
+  try {
+    void new Script(contents);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
+
 function config(
   onlyList /*: $ReadOnlyArray<RegExp | string> */,
   options /*: ?$ReadOnly<{
@@ -66,6 +103,18 @@ function config(
     ignore: [/\/node_modules\//],
     only: [..._only],
     plugins: [
+      function BabelPluginDetectTranspiledFiles() {
+        const pluginObj = {
+          name: 'detect-transpiled-files',
+        };
+
+        if (debug.enabled) {
+          // $FlowIgnore
+          pluginObj.pre = warnIfFileCouldSkipRegistration;
+        }
+
+        return pluginObj;
+      },
       [require('@babel/plugin-proposal-export-namespace-from').default],
       [
         require('@babel/plugin-transform-modules-commonjs').default,


### PR DESCRIPTION
Summary:
Changelog:
[General][Internal] allow detecting babel registrations of large files that could have been not registered

Differential Revision: D72632991
