### PR TITLE
fix: add missing error type to metro errors

### DIFF
--- a/packages/metro/src/lib/formatBundlingError.js
+++ b/packages/metro/src/lib/formatBundlingError.js
@@ -62,15 +62,18 @@ function formatBundlingError(error: CustomError): FormattedError {
     (error instanceof Error &&
       (error.type === 'TransformError' || error.type === 'NotFoundError'))
   ) {
-    error.errors = [
-      {
-        description: error.message,
-        filename: error.filename,
-        lineNumber: error.lineNumber,
-      },
-    ];
-
-    return serializeError(error);
+    return {
+      ...serializeError(error),
+      // Ensure the type is passed to the client.
+      type: error.type,
+      errors: [
+        {
+          description: error.message,
+          filename: error.filename,
+          lineNumber: error.lineNumber,
+        },
+      ],
+    };
   } else if (error instanceof ResourceNotFoundError) {
     return {
       type: 'ResourceNotFoundError',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

- The serialize-error pkg was not adding the `type` key which leads to an `undefined ...` in the React Native error message.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Fix] Add missing `type` for missing import errors in HMR client.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
