### PR TITLE
[rfc] Support import.meta with experimentalImportSupport

### DIFF
--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -467,6 +467,22 @@ function loadModuleImplementation(
     }
     moduleObject.id = moduleId;
 
+    if (!moduleObject.importMeta) {
+      let importMeta;
+      Object.defineProperty(moduleObject, 'importMeta', {
+        enumerable: false,
+        configurable: false,
+        get: () =>
+          importMeta ??
+          (importMeta = {
+            __proto__: null,
+            ...global[`${__METRO_GLOBAL_PREFIX__}__getImportMetaProperties`]?.(
+              moduleObject,
+            ),
+          }),
+      });
+    }
+
     // keep args in sync with with defineModuleCode in
     // metro/src/Resolver/index.js
     // and metro/src/ModuleGraph/worker.js

--- a/packages/metro-transform-plugins/src/__tests__/import-export-plugin-test.js
+++ b/packages/metro-transform-plugins/src/__tests__/import-export-plugin-test.js
@@ -22,6 +22,10 @@ const collectDependencies = require('metro/src/ModuleGraph/worker/collectDepende
 const opts = {
   importAll: '_$$_IMPORT_ALL',
   importDefault: '_$$_IMPORT_DEFAULT',
+  transformImportMeta: {
+    objectName: 'module',
+    propertyName: '_importMeta',
+  },
 };
 
 test('correctly transforms and extracts "import" statements', () => {
@@ -373,6 +377,26 @@ test('supports `import {default as LocalName}`', () => {
     > 5 |     } from 'react-native';
         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ dep #0 (react-native)"
   `);
+});
+
+test('transforms import.meta', () => {
+  const code = `
+    function foo() {
+      const module = 'bar';
+      console.log(import.meta.url);
+      return module;
+    }
+  `;
+
+  const expected = `
+    function foo() {
+      const _module = 'bar';
+      console.log(module._importMeta.url);
+      return _module;
+    }
+  `;
+
+  compare([importExportPlugin], code, expected, opts);
 });
 
 function showTransformedDeps(code: string) {

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -305,6 +305,10 @@ async function transformJS(
         importAll,
         importDefault,
         resolve: false,
+        transformImportMeta: {
+          objectName: 'module',
+          propertyName: 'importMeta',
+        },
       } as ImportExportPluginOptions,
     ]);
   }

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/import-export-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/import-export-test.js.snap
@@ -13,6 +13,7 @@ Object {
   "asyncImportMaybeSyncESM": Object {
     "default": "export-8: DEFAULT",
     "foo": "export-8: FOO",
+    "url": "metro:///11",
   },
   "default": "export-4: FOO",
   "extraData": Object {

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/server-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/server-test.js.snap
@@ -58,6 +58,7 @@ exports[`Metro development server serves bundles via HTTP should serve lazy bund
 Object {
   "default": "export-8: DEFAULT",
   "foo": "export-8: FOO",
+  "url": "metro://module/11",
 }
 `;
 
@@ -90,6 +91,7 @@ exports[`Metro development server serves bundles via HTTP should serve non-lazy 
 Object {
   "default": "export-8: DEFAULT",
   "foo": "export-8: FOO",
+  "url": "metro://module/11",
 }
 `;
 

--- a/packages/metro/src/integration_tests/__tests__/import-export-test.js
+++ b/packages/metro/src/integration_tests/__tests__/import-export-test.js
@@ -26,7 +26,14 @@ test('builds a simple bundle', async () => {
     entry: 'import-export/index.js',
   });
 
-  const object = execBundle(result.code);
+  const object = execBundle(result.code, {
+    // Framework/host-defined props
+    __getImportMetaProperties: module => {
+      return {
+        url: new URL(String(module.id), 'metro://'),
+      };
+    },
+  });
   const cjs = await object.asyncImportCJS;
 
   expect(object).toMatchSnapshot();

--- a/packages/metro/src/integration_tests/__tests__/server-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-test.js
@@ -92,6 +92,13 @@ describe('Metro development server serves bundles via HTTP', () => {
   test('should serve lazy bundles', async () => {
     const object = await downloadAndExec(
       '/import-export/index.bundle?platform=ios&dev=true&minify=false&lazy=true',
+      {
+        __getImportMetaProperties: module => {
+          return {
+            url: new URL(`metro://module/${module.id}`),
+          };
+        },
+      },
     );
     await expect(object.asyncImportCJS).resolves.toMatchSnapshot();
     await expect(object.asyncImportESM).resolves.toMatchSnapshot();
@@ -111,6 +118,13 @@ describe('Metro development server serves bundles via HTTP', () => {
   test('should serve non-lazy bundles by default', async () => {
     const object = await downloadAndExec(
       '/import-export/index.bundle?platform=ios&dev=true&minify=false',
+      {
+        __getImportMetaProperties: module => {
+          return {
+            url: new URL(`metro://module/${module.id}`),
+          };
+        },
+      },
     );
     await expect(object.asyncImportCJS).resolves.toMatchSnapshot();
     await expect(object.asyncImportESM).resolves.toMatchSnapshot();

--- a/packages/metro/src/integration_tests/basic_bundle/import-export/export-8.js
+++ b/packages/metro/src/integration_tests/basic_bundle/import-export/export-8.js
@@ -13,3 +13,4 @@
 export default 'export-8: DEFAULT';
 
 export const foo = 'export-8: FOO';
+export const url = import.meta.url;


### PR DESCRIPTION

Currently, Metro leaves `import.meta` accesses untransformed, but provides no `import` pseudoglobal, so (unless polyfilled) this throws at runtime.

`import.meta` is [specified](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-meta-properties) as a writable null-proto object. Though the spec is silent on any properties, it provides a mechanism ([`HostGetImportMetaProperties`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-hostgetimportmetaproperties)) for hosts to set properties, given a module object. Eg: `url`, `resolve` are defined by Node.js and browsers (and notably `env` by Vite).

We emulate that mechanism here with the `__getImportMetaProperties(module) => {[key: string]: mixed}` optional, framework-defined global function.
