### PR TITLE
fix(metro): create a new set for every `importLocationPlugin` file

### DIFF
--- a/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
+++ b/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
@@ -20,7 +20,7 @@ const invariant = require('invariant');
 type ImportDeclarationLocs = Set<string>;
 
 function importLocationsPlugin({types: t}: {types: Types, ...}): PluginObj<> {
-  const importDeclarationLocs: ImportDeclarationLocs = new Set();
+  let importDeclarationLocs: ImportDeclarationLocs;
   return {
     visitor: {
       ImportDeclaration(path) {
@@ -54,6 +54,8 @@ function importLocationsPlugin({types: t}: {types: Types, ...}): PluginObj<> {
         path && t.isProgram(path.node),
         'path missing or not a program node',
       );
+
+      importDeclarationLocs = new Set();
 
       // $FlowFixMe[prop-missing] Babel `File` is not generically typed
       const metroMetadata: MetroBabelFileMetadata = metadata;

--- a/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
+++ b/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
@@ -11,19 +11,27 @@
 
 'use strict';
 
-import type {PluginObj} from '@babel/core';
+import type {File, PluginObj} from '@babel/core';
 import typeof * as Types from '@babel/types';
 import type {MetroBabelFileMetadata} from 'metro-babel-transformer';
 
-const invariant = require('invariant');
-
 type ImportDeclarationLocs = Set<string>;
 
-function importLocationsPlugin({types: t}: {types: Types, ...}): PluginObj<> {
-  let importDeclarationLocs: ImportDeclarationLocs;
+type State = {
+  importDeclarationLocs: ImportDeclarationLocs,
+  file: File,
+  ...
+};
+
+function importLocationsPlugin({
+  types: t,
+}: {
+  types: Types,
+  ...
+}): PluginObj<State> {
   return {
     visitor: {
-      ImportDeclaration(path) {
+      ImportDeclaration(path, {importDeclarationLocs}) {
         if (
           // Ignore type imports
           path.node.importKind !== 'type' &&
@@ -35,7 +43,7 @@ function importLocationsPlugin({types: t}: {types: Types, ...}): PluginObj<> {
           importDeclarationLocs.add(locToKey(path.node.loc));
         }
       },
-      ExportDeclaration(path) {
+      ExportDeclaration(path, {importDeclarationLocs}) {
         if (
           // If `source` is set, this is a re-export, so it declares an ESM
           // dependency.
@@ -48,27 +56,23 @@ function importLocationsPlugin({types: t}: {types: Types, ...}): PluginObj<> {
           importDeclarationLocs.add(locToKey(path.node.loc));
         }
       },
-    },
-    pre: ({path, metadata}) => {
-      invariant(
-        path && t.isProgram(path.node),
-        'path missing or not a program node',
-      );
+      Program(path, state) {
+        // Initialise state
+        state.importDeclarationLocs = new Set();
 
-      importDeclarationLocs = new Set();
+        // $FlowFixMe[prop-missing] Babel `File` is not generically typed
+        const metroMetadata: MetroBabelFileMetadata = state.file.metadata;
 
-      // $FlowFixMe[prop-missing] Babel `File` is not generically typed
-      const metroMetadata: MetroBabelFileMetadata = metadata;
-
-      // Set the result on a metadata property
-      if (!metroMetadata.metro) {
-        metroMetadata.metro = {
-          unstable_importDeclarationLocs: importDeclarationLocs,
-        };
-      } else {
-        metroMetadata.metro.unstable_importDeclarationLocs =
-          importDeclarationLocs;
-      }
+        // Set the result on a metadata property
+        if (!metroMetadata.metro) {
+          metroMetadata.metro = {
+            unstable_importDeclarationLocs: state.importDeclarationLocs,
+          };
+        } else {
+          metroMetadata.metro.unstable_importDeclarationLocs =
+            state.importDeclarationLocs;
+        }
+      },
     },
   };
 }


### PR DESCRIPTION
## Summary

I came across the `file.unstable_importDeclarationLocs` property when investigating an anomaly with the `isESMImport` detection with [`rc-pagination/es/index.js`](https://app.unpkg.com/rc-pagination@5.1.0/files/es/index.js) - used in [`antd` and reported to not-work with `package.json:exports`](https://github.com/expo/expo/discussions/36551#discussioncomment-13015890).

When investigating, I noticed that this file seemingly had 1351 import locations, which ofc is incorrect. Turns out, we don't recreate the import location set when collecting new dependencies - meaning the set contained the import locations of _all files collected_.

![image](https://github.com/user-attachments/assets/9975d5b5-f4fe-489d-a412-cd799d34793e)

This creates a new set every time the import location plugin is being expected - it creates a new set in `Pre`, before running any of the visitors.

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Fix] Create new import locations set for every individual files

## Test plan

Hard to test, you could add logging or breakpoints [right after this line](https://github.com/facebook/metro/blob/1d90d082c6049ed0712d89dc03223278b608de23/packages/metro-transform-worker/src/index.js#L389). Here you can spot if the location set is going over reasonable sizes.