### PR TITLE
fix(metro): avoid using `Program` location when looking up ESM imports

### DIFF
--- a/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
@@ -1476,7 +1476,7 @@ describe('optional dependencies', () => {
       expect(importDeclarations).toBeTruthy();
 
       // Collect the dependencies of the generated code
-      const {dependencies} = collectDependencies(ast, {
+      const {dependencies} = collectDependencies(transform.ast, {
         ...opts,
         unstable_isESMImportAtSource: (loc) =>
           !!importDeclarations?.has(locToKey(loc)),
@@ -1493,7 +1493,7 @@ describe('optional dependencies', () => {
           // Original ESM import
           name: './test',
           data: objectContaining({
-            isESMImport: false,
+            isESMImport: true,
           }),
         },
       ]);

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -12,6 +12,7 @@
 
 import type {NodePath} from '@babel/traverse';
 import type {CallExpression, Identifier, StringLiteral} from '@babel/types';
+import { isProgram } from '@babel/types';
 import type {
   AllowOptionalDependencies,
   AsyncDependencyType,
@@ -574,6 +575,10 @@ function getNearestLocFromPath(path: NodePath<>): ?BabelSourceLocation {
     !current.node.METRO_INLINE_REQUIRES_INIT_LOC
   ) {
     current = current.parentPath;
+  }
+  // Do not use the location of the `Program` node
+  if (current && isProgram(current.node)) {
+    current = null;
   }
   return (
     // $FlowIgnore[prop-missing] METRO_INLINE_REQUIRES_INIT_LOC is Metro-specific and not typed

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -12,11 +12,12 @@
 
 import type {NodePath} from '@babel/traverse';
 import type {CallExpression, Identifier, StringLiteral} from '@babel/types';
-import { isProgram } from '@babel/types';
 import type {
   AllowOptionalDependencies,
   AsyncDependencyType,
 } from 'metro/src/DeltaBundler/types.flow.js';
+
+import {isProgram} from '@babel/types';
 
 const generate = require('@babel/generator').default;
 const template = require('@babel/template').default;


### PR DESCRIPTION
This is a backstream port of https://github.com/expo/expo/pull/36594

## Summary

We noticed a couple of interesting resolution failures due to `@babel/runtime/helpers/interopRequireDefault` being incorrectly resolved as ESM import. It happens for the following two cases:
- https://app.unpkg.com/rc-pagination@5.1.0/files/es/index.js
- https://app.unpkg.com/@redux-devtools/ui@1.4.0/files/lib/esm/Button/index.js

Turns out that the `getNearestLocFromPath` - used in the dependencies collection - traverses the babel AST until it finds a location. Unfortunately, when the `Program` is literally a single line (`export { default } from './x'`), it means that all imports will be resolved as that single line.

It conflates generated `require('@babel/runtime/helpers/interopRequireDefault')` lines with this ESM imports, and tries to use the ESM version of babel - which contains `.default`. Resulting in `_interopRequireDefault is not a function` errors.

# TL;DR;
- When collecting imports, we look up the location to see if it's an ESM import
- We use `getNearestLocFromPath` to look up the location of the import
- This iterated up to the `Program` node
- The `Program` node in Babel has a location for the whole program
- If the file or `Program` has just 1 line, that location is mixed up, causing incorrect `isESMImport` results for generated code.

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Fix] Avoid using `Program` node location when looking up ESM import location

## Test plan

See added test, and repro: https://github.com/expo/expo/discussions/36551#discussioncomment-13015890
