### PR TITLE
Constant folding: Don't fold non-literal `void` expressions

### DIFF
--- a/packages/metro-transform-plugins/src/__tests__/constant-folding-plugin-test.js
+++ b/packages/metro-transform-plugins/src/__tests__/constant-folding-plugin-test.js
@@ -128,6 +128,24 @@ describe('constant expressions', () => {
     compare([constantFoldingPlugin], code, '');
   });
 
+  test('does not fold non-literal void expressions', () => {
+    const code = `
+      void obj.prop;
+    `;
+
+    compare([constantFoldingPlugin], code, code);
+  });
+
+  test('folds literal void expressions', () => {
+    const code = `
+      if (void 0) {
+        foo();
+      }
+    `;
+
+    compare([constantFoldingPlugin], code, '');
+  });
+
   test('can optimize if-else-branches with constant conditions', () => {
     const code = `
       if ('production' == 'development') {


### PR DESCRIPTION
Summary:
Fixes: https://github.com/facebook/metro/issues/1505

`void` expressions always evaluate to `undefined` but would rarely be used to express a constant (with the exception of `void 0`, which is a common shortening of `undefined`). 

More often, they're used to discard the value of an effectful expression, eg `() => void foo()`, or even `() => void obj.prop` where property access has side effects.

Interpret these more conservatively as not foldable unless we can be confident that they have no side-effects because the argument is a literal.

Changelog:
```
 - **[Fix]**: Don't constant-fold potentially side-effectful void expressions
```

Differential Revision: D74403187


