### PR TITLE
refactor: prevent reinitializing `global.$RefreshReg$`

### DIFF
--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -94,8 +94,8 @@ const CYCLE_DETECTED = {};
 const {hasOwnProperty} = {};
 
 if (__DEV__) {
-  global.$RefreshReg$ = () => {};
-  global.$RefreshSig$ = () => type => type;
+  global.$RefreshReg$ = global.$RefreshReg$ ?? (() => {});
+  global.$RefreshSig$ = global.$RefreshReg$ ?? (() => type => type);
 }
 
 function clear(): ModuleList {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of https://github.com/facebook/metro/issues/1480

This PR adds a check for global.$RefreshReg$ to prevent reinitialising it in case there are multiple module systems present in runtime (like it does in the implementation of module-federation in Metro). 

For context: for the HMR in MF we're reusing the global instance of `ReactRefresh`

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Internal] Prevent reinitialising global.$RefreshReg$ in require.js polyfill

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

n/a
