### PR TITLE
feat: add `globalPrefix` to remaining require polyfill methods

### DIFF
--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -80,10 +80,10 @@ export type DefineFn = (
 type VerboseModuleNameForDev = string;
 type ModuleDefiner = (moduleId: ModuleID) => void;
 
-global.__r = (metroRequire: RequireFn);
+global[`${__METRO_GLOBAL_PREFIX__}__r`] = (metroRequire: RequireFn);
 global[`${__METRO_GLOBAL_PREFIX__}__d`] = (define: DefineFn);
-global.__c = clear;
-global.__registerSegment = registerSegment;
+global[`${__METRO_GLOBAL_PREFIX__}__c`] = clear;
+global[`${__METRO_GLOBAL_PREFIX__}__registerSegment`] = registerSegment;
 
 var modules = clear();
 
@@ -133,7 +133,12 @@ function define(
       // If the module has already been defined and the define method has been
       // called with inverseDependencies, we can hot reload it.
       if (inverseDependencies) {
-        global.__accept(moduleId, factory, dependencyMap, inverseDependencies);
+        global[`${__METRO_GLOBAL_PREFIX__}__accept`](
+          moduleId,
+          factory,
+          dependencyMap,
+          inverseDependencies,
+        );
       }
     }
 
@@ -1006,7 +1011,7 @@ if (__DEV__) {
     }
   };
 
-  global.__accept = metroHotUpdateModule;
+  global[`${__METRO_GLOBAL_PREFIX__}__accept`] = metroHotUpdateModule;
 }
 
 if (__DEV__) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of #1480 

This PR adds `__METRO_GLOBAL_PREFIX__` to other `require` polyfill methods. With Module Federation we use multiple module system in runtime which creates a need for separating module systems from each other with `globalPrefix`.

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Feature] Add global prefix to other module functions in require polyfill

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

TBD
