### PR TITLE
Fix leftover Node 20.x version in CI

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -3,7 +3,7 @@ inputs:
   node-version:
     type: string
     required: false
-    default: '20.x'
+    default: '22.x'
   no-lockfile:
     type: string
     required: false


### PR DESCRIPTION
Summary:
Follows D76037015. Unfortunately, didn't seem to be caught in PR signals.

Changelog: [Internal]

Differential Revision: D76129390


