### PR TITLE
Breaking: Disallow deep imports under `./src` for all Metro packages except `metro-runtime`

### DIFF
--- a/packages/buck-worker-tool/package.json
+++ b/packages/buck-worker-tool/package.json
@@ -7,9 +7,7 @@
   "exports": {
     ".": "./src/worker-tool.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "dependencies": {
     "duplexer": "^0.1.1",

--- a/packages/metro-babel-register/package.json
+++ b/packages/metro-babel-register/package.json
@@ -6,9 +6,7 @@
   "exports": {
     ".": "./src/babel-register.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-babel-transformer/package.json
+++ b/packages/metro-babel-transformer/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-cache-key/package.json
+++ b/packages/metro-cache-key/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-cache/package.json
+++ b/packages/metro-cache/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -6,11 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js",
-    "./src/defaults": "./src/defaults/index.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-core/package.json
+++ b/packages/metro-core/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-file-map/package.json
+++ b/packages/metro-file-map/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-memory-fs/package.json
+++ b/packages/metro-memory-fs/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-resolver/package.json
+++ b/packages/metro-resolver/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-source-map/package.json
+++ b/packages/metro-source-map/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/source-map.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js",
-    "./src/Consumer": "./src/Consumer/index.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-symbolicate/package.json
+++ b/packages/metro-symbolicate/package.json
@@ -8,10 +8,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-transform-plugins/package.json
+++ b/packages/metro-transform-plugins/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro-transform-worker/package.json
+++ b/packages/metro-transform-worker/package.json
@@ -6,10 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -7,10 +7,7 @@
   "exports": {
     ".": "./src/index.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src": "./src/index.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/packages/ob1/package.json
+++ b/packages/ob1/package.json
@@ -6,9 +6,7 @@
   "exports": {
     ".": "./src/ob1.js",
     "./package.json": "./package.json",
-    "./private/*": "./src/*.js",
-    "./src/*.js": "./src/*.js",
-    "./src/*": "./src/*.js"
+    "./private/*": "./src/*.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/__tests__/subpackages-test.js
+++ b/scripts/__tests__/subpackages-test.js
@@ -119,18 +119,8 @@ test('use package.json#exports, exporting a main and package.json', () => {
                 : './' + packageJson.main,
             }
           : null),
-        ...(packageJson.main?.endsWith('src/index.js')
-          ? {
-              // For backward compatibility, allow importing src as a directory
-              './src': './src/index.js',
-            }
-          : null),
         './package.json': './package.json',
         './private/*': './src/*.js',
-        // If an import specifies .js, keep it
-        './src/*.js': './src/*.js',
-        // Add .js to extensionless imports
-        './src/*': './src/*.js',
       }),
     );
   });


### PR DESCRIPTION
Summary:
In https://github.com/facebook/metro/pull/1441 (Metro 0.81.2 onwards) we added `package.json#exports` maps to Metro packages, and introduced an alternative `metro*/private/...` format for deep imports from Metro packages, deprecating importing from `metro*/src/`.

This follows up with the removal of support for importing from `metro*/src`, which were implicitly part of the public API.

Integrators may (at their own risk!) import from `/private/` subpaths, with no semver guarantees. Please open an issue with your use case so we can help to expose the right stable APIs.

For now, all public APIs are accessed via package roots.

`metro-runtime` support is preserved because it's subpaths are resolved by Metro itself, and we allow opting out of `package.json#exports` support.

Changelog:

```javascript
 - **[Breaking]**: Prevent importing from `/src/`, make all non-root exports semver-private
```

Differential Revision: D70038623


