### PR TITLE
support non-ASCII filesystem bundle paths with metro server

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -1123,7 +1123,7 @@ class Server {
         );
         mres.setHeader(DELTA_ID_HEADER, String(result.nextRevId));
         if (serializerOptions?.sourceUrl != null) {
-          mres.setHeader('Content-Location', serializerOptions.sourceUrl);
+          mres.setHeader('Content-Location', new URL(serializerOptions.sourceUrl));
         }
         mres.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
         mres.setHeader('Last-Modified', result.lastModifiedDate.toUTCString());


### PR DESCRIPTION
> [!WARNING]  
> This PR will shortly be merged after being modified by @vzaidman to prevent non-ASCII from crashing Metro a bit more upstream than what is suggested in the PR. However, in both cases, while Metro is **not crashing** it doesn't fully support non-ASCII.
> Instead, in a later commit that will be linked here in the upcoming days, a comprehensive support to non-ASCII in Metro with tests will be linked from this PR.
> The split is intended to credit the author of this current work and to allow us to revert the latter diff without reverting this former one, allowing us to revert the more complex code without removing this fix.

In a codebase with non-ascii characters in file paths (e.g. Japanese or Chinese characters), metro has an error when serving bundles:

```
TypeError: Invalid character in header content
```

This was reported in the Expo project https://github.com/expo/expo/issues/27397 but it's not Expo code and was later closed.

The problem is fairly simple—HTTP headers need to use ASCII characters only, but filesystems are not limited to ASCII so trying to put a filesystem path directly into a HTTP header value is going to cause a problem.

The solution also seems relatively simple—URL encode the path so that it uses percent encoding of non-ASCII characters.

I did three tests of this code, looking at the response headers for the chunk served by metro to look for backwards compatibility of using `new URL(…)` on paths that don't use non-ASCII characters.

```
with new URL(…) patch and /你/ path segment

Content-Location: http://localhost:8081/projects/app/src/client/wiki/%E4%BD%A0/hello.bundle//&platform=web&dev=true&hot=false&lazy=true&transform.routerRoot=src%2Fapp&transform.reactCompiler=true&modulesOnly=true&runModule=false

---

with new URL(…) and /ni/ path segment

Content-Location: http://localhost:8081/projects/app/src/client/wiki/ni/hello.bundle//&platform=web&dev=true&hot=false&lazy=true&transform.routerRoot=src%2Fapp&transform.reactCompiler=true&modulesOnly=true&runModule=false

---

original code with /ni/ path segment

Content-Location: http://localhost:8081/projects/app/src/client/wiki/ni/hello.bundle//&platform=web&dev=true&hot=false&lazy=true&transform.routerRoot=src%2Fapp&transform.reactCompiler=true&modulesOnly=true&runModule=false
```

This demonstrates that it's backwards compatible, while properly encoding non-ASCII characters.

## Summary

Changelog: [Fix] non-ascii files processed by Metro no longer crash the server