### PR TITLE
Restore prettier shim as correctly FB-only

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -9,11 +9,7 @@
 
 let plugins;
 try {
-  plugins = [
-    require.resolve(
-      '../../../../tools/third-party/prettier/node_modules/prettier-plugin-hermes-parser/index.mjs',
-    ),
-  ];
+  plugins = require('./.prettier-plugins.fb.js');
 } catch {
   plugins = ['prettier-plugin-hermes-parser'];
 }


### PR DESCRIPTION
Summary:
Restore the use of an `.fb.js` shim to resolve prettier plugins now that it won't be synced to GitHub, so OSS will correctly fall back to local prettier.

Changelog: Internal

Differential Revision: D80087364


