### PR TITLE
Fix: walk around uv_os_gethostname returned ENOSYS on Windows 7 node v18

### DIFF
--- a/packages/metro-core/src/Logger.js
+++ b/packages/metro-core/src/Logger.js
@@ -52,6 +52,13 @@ export type LogEntry = {
   ...
 };
 
+try {
+  os.hostname();
+} catch (err) {
+  console.warn(err)
+  os.hostname = () => "localhost";
+}
+
 const log_session = `${os.hostname()}-${Date.now()}`;
 const eventEmitter = new EventEmitter();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Call os.hostname on Windows 7 node v18 got error uv_os_gethostname returned ENOSYS (function not implemented),
I ​​am​​ aware that Microsoft has ended support ​​for​​ Windows 7; however, ​​numerous​​ clients and legacy projects ​​require us to​​ continue using it. ​​A workaround is straightforward​​, and I would like to submit a PR.

See also
https://github.com/facebook/metro/issues/1555

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog:

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I have confirmed my changes both work on Windows 7 and macOS 15.
