### PR TITLE
Support loading config from `.config` directory

### DIFF
--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -161,19 +161,27 @@ describe('loadConfig', () => {
           'project/metro.config.cjs',
           'project/metro.config.mjs',
           'project/metro.config.json',
+          'project/.config/metro.js',
+          'project/.config/metro.cjs',
+          'project/.config/metro.mjs',
+          'project/.config/metro.json',
           'project/package.json',
           'metro.config.js',
           'metro.config.cjs',
           'metro.config.mjs',
           'metro.config.json',
+          '.config/metro.js',
+          '.config/metro.cjs',
+          '.config/metro.mjs',
+          '.config/metro.json',
           'package.json',
         ].map(relativePath => path.resolve(HOME, relativePath)),
       );
     });
 
     test('returns defaults when no config is present', async () => {
-      const result = await loadConfig({cwd: HOME});
-      let defaultConfig = await getDefaultConfig(HOME);
+      const result = await loadConfig({cwd: path.resolve(HOME, 'project')});
+      let defaultConfig = await getDefaultConfig(path.resolve(HOME, 'project'));
       defaultConfig = {
         ...defaultConfig,
         watchFolders: [


### PR DESCRIPTION
Summary:
One for folks who like to keep their top-level folders tidy - Metro will now look for config in `<project>/.config/metro.js`, as well as the existing `<project>/metro.config.js` (and, as before, will search up from cwd to the home dir).

This is in line with "newer" (from [7.10.0](https://github.com/cosmiconfig/cosmiconfig/blob/main/CHANGELOG.md#710)) versions of `cosmiconfig` (Metro previously used v5), and is a popular user ask, eg:  [https://x.com/jamonholmgren/status/1749492293617508776](https://x.com/jamonholmgren/status/1749492293617508776) .

Changelog:
```
 - **[Feature]**: Support Metro config at `.config/metro.js` (etc.), as well as `metro.config.js`
```

Differential Revision: D80272839
