### PR TITLE
[Internal] Export missing TerminalReportableEvent type

### DIFF
--- a/packages/metro/types/index.d.ts
+++ b/packages/metro/types/index.d.ts
@@ -36,7 +36,7 @@ export {loadConfig, mergeConfig, resolveConfig} from 'metro-config';
 export {Terminal} from 'metro-core';
 export {
   TerminalReporter,
-  TerminalReportableEvent
+  TerminalReportableEvent,
 } from './lib/TerminalReporter';
 
 export {HttpServer, HttpsServer};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The `TerminalReportableEvent` type is available but not exported from index.d.ts.

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Internal]

## Test plan

<img width="665" height="173" alt="image" src="https://github.com/user-attachments/assets/37264f2e-b7ea-4333-8a3d-2ed5375c18ea" />

