### PR TITLE
Restore compatibility with interopRequireDefault (`import Things from 'metro-pkg'`) in Metro public Node.js APIs.

### DIFF
--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -140,3 +140,11 @@ function transform({
 */
 
 export {transform};
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-babel-transformer' is deprecated, use named exports.
+ */
+export default {transform};

--- a/packages/metro-babel-transformer/types/index.d.ts
+++ b/packages/metro-babel-transformer/types/index.d.ts
@@ -48,3 +48,14 @@ export interface BabelTransformer {
 }
 
 export const transform: BabelTransformer['transform'];
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-babel-transformer' is deprecated, use named exports.
+ */
+declare const $$EXPORT_DEFAULT_DECLARATION$$: {transform: typeof transform};
+declare type $$EXPORT_DEFAULT_DECLARATION$$ =
+  typeof $$EXPORT_DEFAULT_DECLARATION$$;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-cache/src/index.js
+++ b/packages/metro-cache/src/index.js
@@ -28,3 +28,18 @@ export {
   HttpStore,
   stableHash,
 };
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-cache' is deprecated, use named exports.
+ */
+export default {
+  AutoCleanFileStore,
+  Cache,
+  FileStore,
+  HttpGetStore,
+  HttpStore,
+  stableHash,
+};

--- a/packages/metro-cache/types/index.d.ts
+++ b/packages/metro-cache/types/index.d.ts
@@ -8,8 +8,6 @@
  * @oncall react_native
  */
 
-// <reference types="node" />
-
 import Cache from './Cache';
 import stableHash from './stableHash';
 import AutoCleanFileStore from './stores/AutoCleanFileStore';
@@ -20,6 +18,14 @@ import HttpStore from './stores/HttpStore';
 export type {Options as FileOptions} from './stores/FileStore';
 export type {Options as HttpOptions} from './stores/HttpStore';
 export type {CacheStore} from './types';
+export {
+  AutoCleanFileStore,
+  Cache,
+  FileStore,
+  HttpGetStore,
+  HttpStore,
+  stableHash,
+};
 
 export interface MetroCache {
   AutoCleanFileStore: typeof AutoCleanFileStore;
@@ -30,11 +36,11 @@ export interface MetroCache {
   stableHash: typeof stableHash;
 }
 
-export {
-  AutoCleanFileStore,
-  Cache,
-  FileStore,
-  HttpGetStore,
-  HttpStore,
-  stableHash,
-};
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-cache' is deprecated, use named exports.
+ */
+declare const $$EXPORT_DEFAULT_DECLARATION$$: MetroCache;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -11,5 +11,15 @@
 
 export type * from './types';
 
-export {default as getDefaultConfig} from './defaults';
-export {loadConfig, mergeConfig, resolveConfig} from './loadConfig';
+import getDefaultConfig from './defaults';
+import {loadConfig, mergeConfig, resolveConfig} from './loadConfig';
+
+export {getDefaultConfig, loadConfig, mergeConfig, resolveConfig};
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-config' is deprecated, use named exports.
+ */
+export default {getDefaultConfig, loadConfig, mergeConfig, resolveConfig};

--- a/packages/metro-config/types/defaults/index.d.ts
+++ b/packages/metro-config/types/defaults/index.d.ts
@@ -10,7 +10,10 @@
 
 import type {ConfigT} from '../types';
 
-export default interface getDefaultConfig {
+interface getDefaultConfig {
   (rootPath: string | null): Promise<ConfigT>;
   getDefaultValues: (rootPath: string | null) => ConfigT;
 }
+
+declare const getDefaultConfig: getDefaultConfig;
+export default getDefaultConfig;

--- a/packages/metro-config/types/index.d.ts
+++ b/packages/metro-config/types/index.d.ts
@@ -8,8 +8,24 @@
  * @oncall react_native
  */
 
+export type * from './types';
 import getDefaultConfig from './defaults';
 import {loadConfig, mergeConfig, resolveConfig} from './loadConfig';
 
-export * from './types';
-export {loadConfig, mergeConfig, resolveConfig, getDefaultConfig};
+export {getDefaultConfig, loadConfig, mergeConfig, resolveConfig};
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-config' is deprecated, use named exports.
+ */
+declare const $$EXPORT_DEFAULT_DECLARATION$$: {
+  getDefaultConfig: typeof getDefaultConfig;
+  loadConfig: typeof loadConfig;
+  mergeConfig: typeof mergeConfig;
+  resolveConfig: typeof resolveConfig;
+};
+declare type $$EXPORT_DEFAULT_DECLARATION$$ =
+  typeof $$EXPORT_DEFAULT_DECLARATION$$;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-core/src/index.js
+++ b/packages/metro-core/src/index.js
@@ -20,3 +20,16 @@ export {
   PackageResolutionError,
   Terminal,
 };
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-core' is deprecated, use named exports.
+ */
+export default {
+  AmbiguousModuleResolutionError,
+  Logger,
+  PackageResolutionError,
+  Terminal,
+};

--- a/packages/metro-core/types/index.d.ts
+++ b/packages/metro-core/types/index.d.ts
@@ -8,6 +8,19 @@
  * @oncall react_native
  */
 
-/// <reference types="node" />
+import {Terminal} from './Terminal';
 
-export * from './Terminal';
+export {Terminal};
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-core' is deprecated, use named exports.
+ */
+declare const $$EXPORT_DEFAULT_DECLARATION$$: {
+  Terminal: typeof Terminal;
+};
+declare type $$EXPORT_DEFAULT_DECLARATION$$ =
+  typeof $$EXPORT_DEFAULT_DECLARATION$$;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-resolver/src/index.js
+++ b/packages/metro-resolver/src/index.js
@@ -40,3 +40,18 @@ export {
   InvalidPackageError,
   resolve,
 };
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-resolver' is deprecated, use named exports.
+ */
+export default {
+  FailedToResolveNameError,
+  FailedToResolvePathError,
+  FailedToResolveUnsupportedError,
+  formatFileCandidates,
+  InvalidPackageError,
+  resolve,
+};

--- a/packages/metro-resolver/types/index.d.ts
+++ b/packages/metro-resolver/types/index.d.ts
@@ -17,3 +17,16 @@ export function resolve(
   moduleName: string,
   platform: string | null,
 ): Resolution;
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-resolver' is deprecated, use named exports.
+ */
+declare const $$EXPORT_DEFAULT_DECLARATION$$: {
+  resolve: typeof resolve;
+};
+declare type $$EXPORT_DEFAULT_DECLARATION$$ =
+  typeof $$EXPORT_DEFAULT_DECLARATION$$;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-source-map/src/source-map.js
+++ b/packages/metro-source-map/src/source-map.js
@@ -343,3 +343,23 @@ export {
   toBabelSegments,
   toSegmentTuple,
 };
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-source-map' is deprecated, use named exports.
+ */
+export default {
+  BundleBuilder,
+  composeSourceMaps,
+  Consumer,
+  createIndexMap,
+  generateFunctionMap,
+  fromRawMappings,
+  fromRawMappingsNonBlocking,
+  functionMapBabelPlugin,
+  normalizeSourcePath,
+  toBabelSegments,
+  toSegmentTuple,
+};

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -781,3 +781,14 @@ function countLinesAndTerminateMap(
   }
   return {lineCount, map: [...map]};
 }
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-transform-worker' is deprecated, use named exports.
+ */
+export default {
+  getCacheKey,
+  transform,
+};

--- a/packages/metro-transform-worker/types/index.d.ts
+++ b/packages/metro-transform-worker/types/index.d.ts
@@ -124,3 +124,17 @@ export function transform(
 ): Promise<TransformResponse>;
 
 export function getCacheKey(config: JsTransformerConfig): string;
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro-transform-worker' is deprecated, use named exports.
+ */
+declare const $$EXPORT_DEFAULT_DECLARATION$$: {
+  getCacheKey: typeof getCacheKey;
+  transform: typeof transform;
+};
+declare type $$EXPORT_DEFAULT_DECLARATION$$ =
+  typeof $$EXPORT_DEFAULT_DECLARATION$$;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro/src/index.flow.js
+++ b/packages/metro/src/index.flow.js
@@ -548,6 +548,12 @@ async function earlyPortCheck(host: void | string, port: number) {
   }
 }
 
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro' is deprecated, use named exports.
+ */
 export default {
   attachMetroCli,
   runServer,

--- a/packages/metro/types/index.d.ts
+++ b/packages/metro/types/index.d.ts
@@ -32,14 +32,12 @@ import type {
 import type {Duplex} from 'stream';
 import type Yargs from 'yargs';
 
-export {loadConfig, mergeConfig, resolveConfig} from 'metro-config';
-export {Terminal} from 'metro-core';
-export {
-  TerminalReporter,
-  TerminalReportableEvent,
-} from './lib/TerminalReporter';
+import {TerminalReporter} from './lib/TerminalReporter';
+import {loadConfig, mergeConfig, resolveConfig} from 'metro-config';
+import {Terminal} from 'metro-core';
 
 export {HttpServer, HttpsServer};
+export {loadConfig, mergeConfig, resolveConfig, Terminal, TerminalReporter};
 
 interface MetroMiddleWare {
   attachHmrServer: (httpServer: HttpServer | HttpsServer) => void;
@@ -171,3 +169,25 @@ export function attachMetroCli(
   yargs: Yargs.Argv,
   options?: AttachMetroCLIOptions,
 ): Yargs.Argv;
+
+/**
+ * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
+ * Do not add to this list.
+ *
+ * @deprecated Default import from 'metro' is deprecated, use named exports.
+ */
+declare const $$EXPORT_DEFAULT_DECLARATION$$: {
+  attachMetroCli: typeof attachMetroCli;
+  runServer: typeof runServer;
+  Terminal: typeof Terminal;
+  TerminalReporter: typeof TerminalReporter;
+  loadConfig: typeof loadConfig;
+  mergeConfig: typeof mergeConfig;
+  resolveConfig: typeof resolveConfig;
+  createConnectMiddleware: typeof createConnectMiddleware;
+  runBuild: typeof runBuild;
+  buildGraph: typeof buildGraph;
+};
+declare type $$EXPORT_DEFAULT_DECLARATION$$ =
+  typeof $$EXPORT_DEFAULT_DECLARATION$$;
+export default $$EXPORT_DEFAULT_DECLARATION$$;


### PR DESCRIPTION
Summary:
In https://github.com/facebook/metro/pull/1549 (Migrate Metro to ESM syntax), which was intended to be non-breaking, there was one use case I overlooked.

If your code consuming Metro under Node.js uses ESM-style imports transformed to CommonJS with Babel's default interop mode, you could've written any of:

```
// Import default
import Resolver from 'metro-resolver';
Resolver.resolve('./foo');
```

or,


```
// Import all named as namespace
import * as Resolver from 'metro-resolver';
Resolver.resolve('./foo');
```

or, 


```
// Import named
import {resolve} from 'metro-resolver';
resolve('./foo');
```

However, when we switched from a `module.exports` object to ESM-style named exports, the first case would fail, because Babel marks our index file with `__esModule`, which causes `interopRequireDefault` to select the `default` prop (which is now undefined).

The consumer would be transformed to this, which would throw:

```
var _metroResolver = _interopRequireDefault(require("metro-resolver"));
function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
_metroResolver.default.resolve('./foo'); // TypeError: Cannot access property resolve of undefined
```

This restores compatibility by adding an explicit default export alongside the named exports, for all public package entry points that were not already `__esModule`s. These will be removed in a future breaking change.

Changelog: Internal - fix unreleased breaking change from https://github.com/facebook/metro/pull/1549

Reviewed By: vzaidman

Differential Revision: D81127738


