### PR TITLE
Fix Windows vs posix build inconsistency in module path hints on dev

### DIFF
--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -11,6 +11,7 @@
 
 import type {AssetPath} from './node-haste/lib/AssetPaths';
 
+import {normalizePathSeparatorsToPosix} from './lib/pathUtils';
 import * as AssetPaths from './node-haste/lib/AssetPaths';
 import crypto from 'crypto';
 import fs from 'fs';
@@ -211,9 +212,7 @@ export async function getAssetData(
     : path.join(publicPath, path.dirname(localPath));
 
   // On Windows, change backslashes to slashes to get proper URL path from file path.
-  if (path.sep === '\\') {
-    assetUrlPath = assetUrlPath.replaceAll('\\', '/');
-  }
+  assetUrlPath = normalizePathSeparatorsToPosix(assetUrlPath);
 
   const isImage = isAssetTypeAnImage(path.extname(assetPath).slice(1));
   const assetInfo = await getAbsoluteAssetInfo(assetPath, platform);

--- a/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
+++ b/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
@@ -13,6 +13,7 @@ import type {MixedOutput, Module} from '../../types';
 import type {JsOutput} from 'metro-transform-worker';
 
 import {isResolvedDependency} from '../../../lib/isResolvedDependency';
+import {normalizePathSeparatorsToPosix} from '../../../lib/pathUtils';
 import invariant from 'invariant';
 import * as jscSafeUrl from 'jsc-safe-url';
 import {addParamsToDefineCall} from 'metro-transform-plugins';
@@ -80,6 +81,7 @@ export function getModuleParams(
         paths[id] =
           '/' +
           path.join(
+            // TODO: This is not the proper Metro URL encoding of a file path
             path.dirname(bundlePath),
             // Strip the file extension
             path.basename(bundlePath, path.extname(bundlePath)),
@@ -105,7 +107,11 @@ export function getModuleParams(
   if (options.dev) {
     // Add the relative path of the module to make debugging easier.
     // This is mapped to `module.verboseName` in `require.js`.
-    params.push(path.relative(options.projectRoot, module.path));
+    params.push(
+      normalizePathSeparatorsToPosix(
+        path.relative(options.projectRoot, module.path),
+      ),
+    );
   }
 
   return params;

--- a/packages/metro/src/DeltaBundler/Transformer.js
+++ b/packages/metro/src/DeltaBundler/Transformer.js
@@ -13,6 +13,7 @@ import type {TransformResult, TransformResultWithSource} from '../DeltaBundler';
 import type {TransformerConfig, TransformOptions} from './Worker';
 import type {ConfigT} from 'metro-config';
 
+import {normalizePathSeparatorsToPosix} from '../lib/pathUtils';
 import getTransformCacheKey from './getTransformCacheKey';
 import WorkerFarm from './WorkerFarm';
 import assert from 'assert';
@@ -118,8 +119,7 @@ export default class Transformer {
       // Project-relative, posix-separated path for portability. Necessary in
       // addition to content hash because transformers receive path as an
       // input, and may apply e.g. extension-based logic.
-      path.sep === '/' ? localPath : localPath.replaceAll(path.sep, '/'),
-
+      normalizePathSeparatorsToPosix(localPath),
       customTransformOptions,
       dev,
       experimentalImportSupport,

--- a/packages/metro/src/lib/pathUtils.js
+++ b/packages/metro/src/lib/pathUtils.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+import * as path from 'path';
+
+export const normalizePathSeparatorsToPosix: string => string =
+  path.sep === '/'
+    ? filePath => filePath
+    : filePath => filePath.replaceAll('\\', '/');


### PR DESCRIPTION
Summary:
When building bundles with `dev=true`, Metro adds project-relative module paths to module define call params, which populate `module.verboseName`.

Currently, this wrongly varies if the bundle happens to have been built on a Windows machine, due to using system path separators. Metro's output should not depend on where Metro is running.

This normalises to posix separators, adding a utility function we also make use of elsewhere.

```
 - **[Fix]** `module.verboseName` (dev builds only) now uses posix separators regardless of the OS the bundle is built on
```

Differential Revision: D81675832


