### PR TITLE
fix(symbolication): Only print errors in debug

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -1341,7 +1341,7 @@ export default class Server {
             fileName: file,
           };
         } catch (error) {
-          console.error(error);
+          debug('Generating code frame failed on file read.', fileAbsolute, error);
         }
       }
 
@@ -1434,7 +1434,7 @@ export default class Server {
         log(createActionEndEntry(symbolicatingLogEntry));
       });
     } catch (error) {
-      console.error(error.stack || error);
+      debug('Symbolication required failed', error.stack || error);
       res.statusCode = 500;
       res.end(JSON.stringify({error: error.message}));
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Current implementation prints file read errors (when generating code frame) and symbolication bundling error using `console.error`. This clutters the Metro Terminal output and also causes duplicates. 

Bundling and other errors are printer in LogBox and also in Metro Terminal (over the HMRClient/Server bridge). Symbolication should avoid printing further errors as these are the same or resulting from the originally printed. 

These errors don't directly help RN Devs that's why I think they should be printed via `debug`.

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Fix] Print symbolication errors in debug

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
