### PR TITLE
Fix `metro-runtime`'s require system getter checks for ESM live bindings

### DIFF
--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -929,6 +929,19 @@ if (__DEV__) {
     }
   };
 
+  // We skip getters, but only on non ESM output
+  var isSpecifierSafeToCheck = (
+    moduleExports: Exports,
+    key: string,
+  ): boolean => {
+    if (moduleExports && moduleExports.__esModule) {
+      return true;
+    } else {
+      const desc = Object.getOwnPropertyDescriptor(moduleExports, key);
+      return !desc || !desc.get;
+    }
+  };
+
   // Modules that only export components become React Refresh boundaries.
   var isReactRefreshBoundary = function (
     Refresh: any,
@@ -947,9 +960,7 @@ if (__DEV__) {
       hasExports = true;
       if (key === '__esModule') {
         continue;
-      }
-      const desc = Object.getOwnPropertyDescriptor<any>(moduleExports, key);
-      if (desc && desc.get) {
+      } else if (!isSpecifierSafeToCheck(moduleExports, key)) {
         // Don't invoke getters as they may have side effects.
         return false;
       }
@@ -994,9 +1005,7 @@ if (__DEV__) {
     for (const key in moduleExports) {
       if (key === '__esModule') {
         continue;
-      }
-      const desc = Object.getOwnPropertyDescriptor<any>(moduleExports, key);
-      if (desc && desc.get) {
+      } else if (!isSpecifierSafeToCheck(moduleExports, key)) {
         continue;
       }
       const exportValue = moduleExports[key];
@@ -1018,8 +1027,7 @@ if (__DEV__) {
       return;
     }
     for (const key in moduleExports) {
-      const desc = Object.getOwnPropertyDescriptor<any>(moduleExports, key);
-      if (desc && desc.get) {
+      if (!isSpecifierSafeToCheck(moduleExports, key)) {
         // Don't invoke getters as they may have side effects.
         continue;
       }


### PR DESCRIPTION
## Summary

In Expo, we're about to introduce ESM live bindings. We noticed that the `metro-runtime` performs checks for getters to skip over for Fast Refresh checks, likely because of CommonJS modules that may be doing `module.exports = { get() { throw new Error() } }` and the likes.

This check is redundant on ESModule-transpiled modules, since we know that getters that were transpiled in for ESM exports are safe to access.

For example, we may have entries such as:
```js
Object.defineProperty(exports, '__esModule', { value: true });
Object.defineProperty(exports, 'default', {
  enumerable: true,
  get: function() {
    return _default;
  },
});
```

See: https://github.com/expo/expo/pull/39525

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Fix] Fix metro-runtime's fast refresh checks to not skip over getters for ES modules

## Test plan

- This can most easily be reproduced against Expo SDK 54, which has a live-bindings suppoting import-export plugin. For repro, see: https://github.com/expo/expo/issues/39505