### PR TITLE
metro-config: Accept functions as arguments to mergeConfig

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -726,9 +726,13 @@ The default value is `['hg.update']`.
 
 Using the `metro-config` package it is possible to merge multiple configurations together.
 
-| Method                                  | Description                                                            |
-| --------------------------------------- | ---------------------------------------------------------------------- |
-| `mergeConfig(...configs): MergedConfig` | Returns the merged configuration of two or more configuration objects. |
+| Method                                  | Description                                                                         |
+| --------------------------------------- | ----------------------------------------------------------------------------------- |
+| `mergeConfig(...configs): MergedConfig` | Returns the merged configuration of two or more configuration objects or functions. |
+
+`configs` may be any combination of configuration objects or functions (from Metro 0.83.2). Functions are called with the merged config of all configs to the left, which may be useful for complex merges with the previous config.
+
+If any arguments are async functions, `mergeConfig` will return a `Promise`, otherwise it will return the merged config synchronously.
 
 :::note
 
@@ -777,5 +781,12 @@ const configB = {
   }
 };
 
-module.exports = mergeConfig(configA, configB);
+// Function forms may be used to access the previous configuration
+configCFn = (previousConfig /* result of mergeConfig(configA, configB) */) => {
+  return {
+    watchFolders: [...previousConfig.watchFolders, 'my-watch-folder'],
+  }
+}
+
+module.exports = mergeConfig(configA, configB, configCFn);
 ```

--- a/packages/metro-config/src/__fixtures__/merged.metro.config.js
+++ b/packages/metro-config/src/__fixtures__/merged.metro.config.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+/*::
+import type {ConfigT, InputConfigT} from '../types';
+
+type ConfigFn = (previous: ConfigT) => InputConfigT
+*/
+
+const {mergeConfig} = require('../loadConfig');
+
+const secondConfig /*:ConfigFn */ = previous => ({
+  resolver: {
+    sourceExts: ['before', ...previous.resolver.sourceExts],
+  },
+});
+
+const thirdConfig /*:ConfigFn */ = previous => ({
+  resolver: {
+    sourceExts: [...previous.resolver.sourceExts, 'after'],
+  },
+});
+
+module.exports = (metroDefaults /*:ConfigT*/): ConfigT =>
+  mergeConfig(metroDefaults, secondConfig, thirdConfig);

--- a/packages/metro-config/src/__flowtests__/types-flowtest.js
+++ b/packages/metro-config/src/__flowtests__/types-flowtest.js
@@ -11,6 +11,8 @@
 
 import type {ConfigT, InputConfigT} from 'metro-config';
 
+import {mergeConfig} from '../loadConfig';
+
 declare var config: ConfigT;
 declare var inputConfig: InputConfigT;
 
@@ -44,3 +46,24 @@ if (
 // ConfigT is completely hydrated (no errors accessing deep props)
 config.resolver.unstable_conditionsByPlatform['foo'];
 config.transformer.assetPlugins[0];
+
+// A mergeConfig returns a full config only if the base is a full config
+mergeConfig(config, {}) as ConfigT;
+// $FlowExpectedError[incompatible-type]
+mergeConfig(inputConfig, {}) as ConfigT;
+
+// And is synchronous with any number of sync arguments
+mergeConfig(
+  config,
+  () => ({}),
+  {},
+  () => ({}),
+) as ConfigT;
+
+// But async if any function returns a promise
+mergeConfig(
+  config,
+  () => ({}),
+  {},
+  async () => ({}),
+).catch(() => {});

--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -66,6 +66,23 @@ describe('loadConfig', () => {
     });
   });
 
+  test('mergeConfig chains config functions', async () => {
+    const defaultConfigOverrides = {
+      resolver: {
+        sourceExts: ['override'],
+      },
+    };
+    const config = path.resolve(
+      __dirname,
+      '../__fixtures__/merged.metro.config.js',
+    );
+    const result = await loadConfig({config}, defaultConfigOverrides);
+    expect(result.projectRoot).toEqual(path.dirname(config));
+    expect(result.resolver).toMatchObject({
+      sourceExts: ['before', 'override', 'after'],
+    });
+  });
+
   test('can load the config from a path pointing to a directory', async () => {
     // We don't actually use the specified file in this test but it needs to
     // resolve to a real file on the file system.

--- a/packages/metro-config/types/loadConfig.d.ts
+++ b/packages/metro-config/types/loadConfig.d.ts
@@ -22,10 +22,29 @@ declare function resolveConfig(
   filePath?: string,
   cwd?: string,
 ): Promise<ResolveConfigResult>;
-declare function mergeConfig<T extends Readonly<InputConfigT>>(
-  defaultConfig: T,
-  ...configs: Array<InputConfigT>
-): T;
+/**
+ * Merge two or more partial config objects (or functions returning partial
+ * configs) together, with arguments to the right overriding the left.
+ *
+ * Functions will be parsed the current config (the merge of all configs to the
+ * left).
+ *
+ * Functions may be async, in which case this function will return a promise.
+ * Otherwise it will return synchronously.
+ */
+declare function mergeConfig<
+  T extends InputConfigT,
+  R extends ReadonlyArray<
+    | InputConfigT
+    | ((baseConfig: T) => InputConfigT)
+    | ((baseConfig: T) => Promise<InputConfigT>)
+  >,
+>(
+  base: T | (() => T),
+  ...configs: R
+): R extends ReadonlyArray<InputConfigT | ((baseConfig: T) => InputConfigT)>
+  ? T
+  : Promise<T>;
 /**
  * Load the metro configuration from disk
  * @param  {object} argv                    Arguments coming from the CLI, can be empty

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -17,6 +17,7 @@ import type {
   ReadOnlyGraph,
   TransformResultDependency,
 } from '../../DeltaBundler/types';
+import type {InputConfigT} from 'metro-config';
 
 import ResourceNotFoundError from '../../IncrementalBundler/ResourceNotFoundError';
 import CountingSet from '../../lib/CountingSet';
@@ -160,7 +161,7 @@ describe('processRequest', () => {
         });
       },
     },
-  });
+  } as InputConfigT);
 
   const makeRequest = (
     requrl: string,

--- a/packages/metro/src/__tests__/HmrServer-test.js
+++ b/packages/metro/src/__tests__/HmrServer-test.js
@@ -11,6 +11,7 @@
 
 import type {TransformResultDependency} from '../DeltaBundler/types';
 import type {Client} from '../HmrServer';
+import type {InputConfigT} from 'metro-config';
 import type {HmrClientMessage} from 'metro-runtime/src/modules/types';
 
 import DeltaBundler from '../DeltaBundler';
@@ -141,7 +142,7 @@ describe('HmrServer', () => {
           return requrl;
         },
       },
-    });
+    } as InputConfigT);
 
     incrementalBundlerMock = new IncrementalBundler(config);
     jest


### PR DESCRIPTION
Extend the existing `mergeConfig` API so that it accepts functions as well as config objects.

These functions are provided with the leftward merged config as an argument, so that they may re-use or extend it in ways not covered by `mergeConfig`'s simple spread. For example:

# Example

Suppose `awesome-lib` exports `addThirdPartyMagic` for configuring Metro for some nice functionality, and it wants to merge intelligently with previous config:

```js
export function addThirdPartyMagic(baseConfig) {
  return {
    resolver: {
      assetExts: [...baseConfig.resolver.assetExts, 'magic'],
    },
  };
}
```

## Currently

This would require a nest or sequence of `mergeConfig` calls with previous configs explicitly passed to `addThirdPartyMagic`, e.g:

```js
const {mergeConfig} = require('metro-config');
const {getDefaultValues} = require('@react-native/metro-config');
const {addThirdPartyMagic} = require('awesome-lib');

const defaults = getDefaultValues(__dirname);
const myConfig = mergeConfig(defaults, {
   resolver: {
     assetExts: ['gif', ...defaults.resolver.assetExts],
   },
})
module.exports = mergeConfig(myConfig, addThirdPartyMagic(myConfig));
```

There's a lot of boilerplate here, it's easy to get wrong and it doesn't get any nicer when you introduce a second and third library that wants to customise config.

## Proposed
Instead, by allowing functions that supply the the previous config, users can do:

```js
const {mergeConfig} = require('metro-config');
const {getDefaultValues} = require('@react-native/metro-config');
const {addThirdPartyMagic} = require('awesome-lib');

module.exports = mergeConfig(getDefaultValues(__dirname), (baseConfig) => {
   resolver: {
     assetExts: ['gif', ...baseConfig.resolver.assetExts],
   },
}, addThirdPartyMagic);
```

And this scales - every additional library is just another argument to `mergeConfig`.

### Future?
Out of scope for just now, but we *could* consider an array exported from `metro.config.js` to mean arguments to `mergeConfig`, and libraries like `@react-native/metro-config` could export a (maybe async) function as a default export, so the future could look like this:

```ts
// metro.config.ts
import type {MetroConfig} from 'metro-config';

export default = [
  import('@react-native/metro-config'),
  (defaults) => ({
    resolver: {
      sourceExts: [...defaults.resolver.sourceExts, 'custom']
    }
  }),
  import('awesome-lib/metro-config'),
] satisfies MetroConfig[];
```

Differential Revision: D82221532