### PR TITLE
Fix TypeScript CI lint errors

### DIFF
--- a/packages/metro-source-map/src/generateFunctionMap.js
+++ b/packages/metro-source-map/src/generateFunctionMap.js
@@ -12,7 +12,7 @@
 import type {FBSourceFunctionMap} from './source-map';
 import type {PluginObj} from '@babel/core';
 import type {NodePath} from '@babel/traverse';
-import type {Node} from '@babel/types';
+import type {Node as BabelNode} from '@babel/types';
 import type {MetroBabelFileMetadata} from 'metro-babel-transformer';
 
 import B64Builder from './B64Builder';
@@ -363,7 +363,7 @@ function getNameForPath(path: NodePath<>): string {
 }
 
 function isAnyCallExpression(
-  node: Node,
+  node: BabelNode,
 ): node is
   | BabelNodeNewExpression
   | BabelNodeCallExpression
@@ -376,7 +376,7 @@ function isAnyCallExpression(
 }
 
 function isAnyMemberExpression(
-  node: Node,
+  node: BabelNode,
 ): node is
   | BabelNodeMemberExpression
   | BabelNodeJSXMemberExpression
@@ -389,12 +389,12 @@ function isAnyMemberExpression(
 }
 
 function isAnyIdentifier(
-  node: Node,
+  node: BabelNode,
 ): node is BabelNodeIdentifier | BabelNodeJSXIdentifier {
   return isIdentifier(node) || isJSXIdentifier(node);
 }
 
-function getNameFromId(id: Node): ?string {
+function getNameFromId(id: BabelNode): ?string {
   const parts = getNamePartsFromId(id);
 
   if (!parts.length) {
@@ -414,7 +414,7 @@ function getNameFromId(id: Node): ?string {
   return parts.join('.');
 }
 
-function getNamePartsFromId(id: Node): $ReadOnlyArray<string> {
+function getNamePartsFromId(id: BabelNode): $ReadOnlyArray<string> {
   if (!id) {
     return [];
   }

--- a/packages/metro-source-map/src/source-map.js
+++ b/packages/metro-source-map/src/source-map.js
@@ -10,7 +10,6 @@
  */
 
 import type {IConsumer} from './Consumer/types';
-import type {BabelSourceMapSegment} from '@babel/generator';
 
 import {BundleBuilder, createIndexMap} from './BundleBuilder';
 import composeSourceMaps from './composeSourceMaps';
@@ -44,6 +43,14 @@ export type FBSourceFunctionMap = {
   +names: $ReadOnlyArray<string>,
   +mappings: string,
 };
+
+export type BabelSourceMapSegment = $ReadOnly<{
+  generated: $ReadOnly<{column: number, line: number, ...}>,
+  original?: $ReadOnly<{column: number, line: number, ...}>,
+  source?: ?string,
+  name?: ?string,
+  ...
+}>;
 
 export type FBSegmentMap = {[id: string]: MixedSourceMap, ...};
 

--- a/packages/metro-source-map/types/generateFunctionMap.d.ts
+++ b/packages/metro-source-map/types/generateFunctionMap.d.ts
@@ -10,6 +10,7 @@
 
 import type {FBSourceFunctionMap} from './source-map';
 import type {PluginObj} from '@babel/core';
+import type {Node as BabelNode} from '@babel/types';
 
 type Position = {line: number; column: number};
 type RangeMapping = {name: string; start: Position};

--- a/packages/metro-source-map/types/source-map.d.ts
+++ b/packages/metro-source-map/types/source-map.d.ts
@@ -9,7 +9,6 @@
  */
 
 import type {IConsumer} from './Consumer/types';
-import type {BabelSourceMapSegment} from '@babel/generator';
 
 import {BundleBuilder, createIndexMap} from './BundleBuilder';
 import composeSourceMaps from './composeSourceMaps';
@@ -38,6 +37,12 @@ export type FBSourceFunctionMap = {
   readonly names: ReadonlyArray<string>;
   readonly mappings: string;
 };
+export type BabelSourceMapSegment = Readonly<{
+  generated: Readonly<{column: number; line: number}>;
+  original?: Readonly<{column: number; line: number}>;
+  source?: null | undefined | string;
+  name?: null | undefined | string;
+}>;
 export type FBSegmentMap = {[id: string]: MixedSourceMap};
 export type BasicSourceMap = {
   readonly file?: string;

--- a/scripts/__tests__/ts-defs-sync-test.js
+++ b/scripts/__tests__/ts-defs-sync-test.js
@@ -28,4 +28,4 @@ test('TypeScript defs are in sync (yarn run build-ts-defs produces no changes)',
     expect(error.errors).toEqual([]);
   }
   expect(error).toBeUndefined();
-}, 10000);
+}, 30000);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
       // only for this tsconfig - external consumers will read the "main" field
       // and find the adjacent typedef file.
       "metro-source-map": ["./packages/metro-source-map/types/source-map.d.ts"],
-      "ob1": ["./packages/ob1/types"]
+      "ob1": ["./packages/ob1/types/ob1.d.ts"]
     }
   }
 }


### PR DESCRIPTION
Summary:
TS lints are currently failing in OSS CI due to three issues:
 - Verifying generated types are in sync sometimes takes slightly longer than 10s, allow 30s.
 - Use of Babel ambient types that exist in Flow but not TS - switch to an explicitly imported type instead.
 - Incorrect mapping of the `ob1` package because its main file is not `index.js` but `ob1.js`

https://github.com/facebook/metro/actions/runs/17679616928/job/50250418546?pr=1580

Differential Revision: D82316554


