### PR TITLE
Support loading config files that export promises (fix regression)

### DIFF
--- a/packages/metro-config/src/__fixtures__/cjs-promise.metro.config.js
+++ b/packages/metro-config/src/__fixtures__/cjs-promise.metro.config.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+/*::
+import type {InputConfigT} from '../types';
+*/
+
+module.exports = Promise.resolve({
+  cacheVersion: 'cjs-promise-config',
+}) /*:: as Promise<InputConfigT> */;

--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -66,6 +66,21 @@ describe('loadConfig', () => {
     });
   });
 
+  test('can load config that exports a promise', async () => {
+    const result = await loadConfig(
+      {
+        config: path.resolve(
+          __dirname,
+          '../__fixtures__/cjs-promise.metro.config.js',
+        ),
+      },
+      {},
+    );
+    expect(result).toMatchObject({
+      cacheVersion: 'cjs-promise-config',
+    });
+  });
+
   test('mergeConfig chains config functions', async () => {
     const defaultConfigOverrides = {
       resolver: {

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -391,7 +391,9 @@ export async function loadConfigFile(
       if (absolutePath.endsWith(PACKAGE_JSON)) {
         config = configModule[PACKAGE_JSON_PROP_NAME];
       } else {
-        config = configModule.__esModule ? configModule.default : configModule;
+        config = await (configModule.__esModule
+          ? configModule.default
+          : configModule);
       }
     } catch (e) {
       try {


### PR DESCRIPTION
Summary:
Fix: https://github.com/facebook/metro/issues/1585

Metro 0.83.2 accidentally regressed handling of config files that are loaded with `require` and export a `Promise<InputConfigT>`. Cosmiconfig would await the promise, whereas we don't.

This restores the previous support.

```
 - **[Changelog]**: Fix regression loading config files that export a promise
```

Differential Revision: D83474562


