### PR TITLE
feat: add custom event handlers for HMRClient

### DIFF
--- a/packages/metro-runtime/src/modules/HMRClient.js
+++ b/packages/metro-runtime/src/modules/HMRClient.js
@@ -28,9 +28,15 @@ const inject = ({module: [id, code], sourceURL}: HmrModule) => {
   }
 };
 
+const HMRClientOnUpdate = global.HMRClientOnUpdate as Array<
+  (update: HmrModule) => void,
+>;
+
 const injectUpdate = (update: HmrUpdate) => {
-  update.added.forEach(inject);
-  update.modified.forEach(inject);
+  HMRClientOnUpdate.forEach(callback => {
+    update.added.forEach(callback);
+    update.modified.forEach(callback);
+  });
 };
 
 class HMRClient extends EventEmitter {
@@ -42,6 +48,8 @@ class HMRClient extends EventEmitter {
 
   constructor(url: string) {
     super();
+
+    HMRClientOnUpdate.push(inject);
 
     // Access the global WebSocket object only after enabling the client,
     // since some polyfills do the initialization lazily.

--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -94,6 +94,7 @@ const CYCLE_DETECTED = {};
 const {hasOwnProperty} = {};
 
 if (__DEV__) {
+  global.HMRClientOnUpdate = [];
   global.$RefreshReg$ = global.$RefreshReg$ ?? (() => {});
   global.$RefreshSig$ = global.$RefreshSig$ ?? (() => type => type);
 }


### PR DESCRIPTION
## Summary

Currently there's no API in JavaScript to listen to HMRClient updates. This is problematic if a library wants to replace modules used on JavaScript runtime different than the one created by React Native.

This PR adds a global array of event handlers, `HMRClientOnUpdate`, which is available very early and which every library can access to obtain HMR updates.

Changelog: [Feature] add custom event handlers for HMRClient

## Test plan

I don't know how you'd test this change in the repo. I applied these changes in [Reanimated monorepo](https://github.com/software-mansion/react-native-reanimated) and everything worked well.
