### PR TITLE
ref: Use slice().reverse() instead of toReversed() for backwards compatibility

### DIFF
--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -221,15 +221,15 @@ function mergeConfig<
   ? T
   : Promise<T> {
   let currentConfig: T = typeof base === 'function' ? base() : base;
-  // Reverse for easy popping
-  const reversedConfigs = configs.toReversed();
+  // Reverse for easy popping - use slice().reverse() for compatibility
+  const reversedConfigs = configs.slice().reverse();
   let next;
   while ((next = reversedConfigs.pop())) {
     const nextConfig: InputConfigT | Promise<InputConfigT> =
       typeof next === 'function' ? next(currentConfig) : next;
     if (nextConfig instanceof Promise) {
       // $FlowFixMe[incompatible-type] Not clear why Flow doesn't like this
-      return mergeConfigAsync(nextConfig, reversedConfigs.toReversed());
+      return mergeConfigAsync(nextConfig, reversedConfigs.slice().reverse());
     }
     currentConfig = mergeConfigObjects(currentConfig, nextConfig) as T;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Minor refactoring to use `slice().reverse()` instead of `toReversed()` for backwards compatibility. 

[toReversed is an ES2023 feature](https://www.w3schools.com/js/js_2023.asp?#mark_array_toreversed) not available in older JS environments, causing runtime errors in React Native projects with older Hermes versions.

This results in errors like the following 
```
TypeError: configs.toReversed is not a function
```

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog:

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
