### PR TITLE
fix(types): incorrect <void> use in typescript

### DIFF
--- a/packages/metro/types/Bundler.d.ts
+++ b/packages/metro/types/Bundler.d.ts
@@ -33,7 +33,7 @@ export default class Bundler {
     transformOptions: TransformOptions,
     /** Optionally provide the file contents, this can be used to provide virtual contents for a file. */
     fileBuffer?: Buffer,
-  ): Promise<TransformResultWithSource<void>>;
+  ): Promise<TransformResultWithSource>;
 
   ready(): Promise<void>;
 }

--- a/packages/metro/types/DeltaBundler/Worker.d.ts
+++ b/packages/metro/types/DeltaBundler/Worker.d.ts
@@ -34,7 +34,7 @@ export interface TransformerConfig {
 }
 
 interface Data {
-  readonly result: TransformResult<void>;
+  readonly result: TransformResult;
   readonly sha1: string;
   readonly transformFileStartLogEntry: LogEntry;
   readonly transformFileEndLogEntry: LogEntry;

--- a/packages/metro/types/IncrementalBundler.d.ts
+++ b/packages/metro/types/IncrementalBundler.d.ts
@@ -22,10 +22,10 @@ import {ResolverInputOptions} from './shared/types';
 
 export type RevisionId = string;
 
-export type OutputGraph = Graph<void>;
+export type OutputGraph = Graph;
 
 export interface OtherOptions {
-  readonly onProgress: DeltaBundlerOptions<void>['onProgress'];
+  readonly onProgress: DeltaBundlerOptions['onProgress'];
   readonly shallow: boolean;
 }
 
@@ -34,7 +34,7 @@ export interface GraphRevision {
   readonly date: Date;
   readonly graphId: GraphId;
   readonly graph: OutputGraph;
-  readonly prepend: ReadonlyArray<Module<void>>;
+  readonly prepend: ReadonlyArray<Module>;
 }
 
 export interface IncrementalBundlerOptions {
@@ -48,7 +48,7 @@ export default class IncrementalBundler {
 
   end(): void;
   getBundler(): Bundler;
-  getDeltaBundler(): DeltaBundler<void>;
+  getDeltaBundler(): DeltaBundler;
   getRevision(revisionId: RevisionId): Promise<GraphRevision> | null;
   getRevisionByGraphId(graphId: GraphId): Promise<GraphRevision> | null;
 
@@ -64,16 +64,14 @@ export default class IncrementalBundler {
     transformOptions: TransformInputOptions,
     resolverOptions: ResolverInputOptions,
     otherOptions?: OtherOptions,
-  ): Promise<ReadOnlyDependencies<void>>;
+  ): Promise<ReadOnlyDependencies>;
 
   buildGraph(
     entryFile: string,
     transformOptions: TransformInputOptions,
     resolverOptions: ResolverInputOptions,
     otherOptions?: OtherOptions,
-  ): Promise<
-    Readonly<{graph: OutputGraph; prepend: ReadonlyArray<Module<void>>}>
-  >;
+  ): Promise<Readonly<{graph: OutputGraph; prepend: ReadonlyArray<Module>}>>;
 
   initializeGraph(
     entryFile: string,
@@ -81,7 +79,7 @@ export default class IncrementalBundler {
     resolverOptions: ResolverInputOptions,
     otherOptions?: OtherOptions,
   ): Promise<{
-    delta: DeltaResult<void>;
+    delta: DeltaResult;
     revision: GraphRevision;
   }>;
 
@@ -89,7 +87,7 @@ export default class IncrementalBundler {
     revision: GraphRevision,
     reset: boolean,
   ): Promise<{
-    delta: DeltaResult<void>;
+    delta: DeltaResult;
     revision: GraphRevision;
   }>;
 

--- a/packages/metro/types/index.d.ts
+++ b/packages/metro/types/index.d.ts
@@ -154,7 +154,7 @@ export function runBuild(
 export function buildGraph(
   config: ConfigT,
   options: BuildGraphOptions,
-): Promise<ReadOnlyGraph<void>>;
+): Promise<ReadOnlyGraph>;
 
 type BuildCommandOptions = Record<string, unknown> | null;
 type ServeCommandOptions = Record<string, unknown> | null;


### PR DESCRIPTION
## Summary
The use of `void` as a type parameter is semantically different in TS than Flow. Specifically, providing `void` in Flow will result in the use of the default type parameter value, while TS will treat it as an explicit use of `void` for the generic. 

Original Issue: https://github.com/facebook/metro/issues/1491

Changelog:
[Fix] `Bundler` types (`transformFile`)
[Fix] `IncrementalBundler` types (`OutputGraph`, `getDeltaBundler`, `getDependencies`, `buildGraph`, `initializeGraph` and `updateGraph`)
[Fix] `Worker` types (`transform`)
[Fix] `Metro.buildGraph` return type


## Test plan
Oof. This may be a larger discussion as keeping the TS and Flow types in-sync and correct may be a moving target as the project evolves. For now, the verification is "when consuming this code in a TS codebase, types are the same as if I was consuming the flow annotated code"
