### PR TITLE
chore(types): auto-generate types for metro-transform-worker

### DIFF
--- a/packages/metro-transform-worker/types/index.d.ts
+++ b/packages/metro-transform-worker/types/index.d.ts
@@ -8,7 +8,6 @@
  * @oncall react_native
  */
 
-import type {DynamicRequiresBehavior} from 'metro';
 import type {
   CustomTransformOptions,
   TransformProfile,
@@ -20,28 +19,21 @@ import type {
 } from 'metro-source-map';
 import type {TransformResultDependency} from 'metro/private/DeltaBundler';
 import type {AllowOptionalDependencies} from 'metro/private/DeltaBundler/types';
+import type {DynamicRequiresBehavior} from 'metro/private/ModuleGraph/worker/collectDependencies';
 
-export type MinifierConfig = Readonly<Record<string, unknown>>;
-
-export interface MinifierOptions {
+type MinifierConfig = Readonly<{[$$Key$$: string]: unknown}>;
+export type MinifierOptions = {
   code: string;
-  map?: BasicSourceMap;
+  map: null | undefined | BasicSourceMap;
   filename: string;
   reserved: ReadonlyArray<string>;
   config: MinifierConfig;
-}
-
-export interface MinifierResult {
-  code: string;
-  map?: BasicSourceMap;
-}
-
+};
+export type MinifierResult = {code: string; map?: BasicSourceMap};
 export type Minifier = (
-  options: MinifierOptions,
+  $$PARAM_0$$: MinifierOptions,
 ) => MinifierResult | Promise<MinifierResult>;
-
 export type Type = 'script' | 'module' | 'asset';
-
 export type JsTransformerConfig = Readonly<{
   assetPlugins: ReadonlyArray<string>;
   assetRegistryPath: string;
@@ -49,7 +41,7 @@ export type JsTransformerConfig = Readonly<{
   babelTransformerPath: string;
   dynamicDepsInPackages: DynamicRequiresBehavior;
   enableBabelRCLookup: boolean;
-  enableBabelRuntime: boolean;
+  enableBabelRuntime: boolean | string;
   globalPrefix: string;
   hermesParser: boolean;
   minifierConfig: MinifierConfig;
@@ -57,8 +49,7 @@ export type JsTransformerConfig = Readonly<{
   optimizationSizeLimit: number;
   publicPath: string;
   allowOptionalDependencies: AllowOptionalDependencies;
-  unstable_collectDependenciesPath: string;
-  unstable_dependencyMapReservedName?: string;
+  unstable_dependencyMapReservedName: null | undefined | string;
   unstable_disableModuleWrapping: boolean;
   unstable_disableNormalizePseudoGlobals: boolean;
   unstable_compactOutput: boolean;
@@ -71,9 +62,7 @@ export type JsTransformerConfig = Readonly<{
   /** Whether to rename scoped `require` functions to `_$$_REQUIRE`, usually an extraneous operation when serializing to iife (default). */
   unstable_renameRequire?: boolean;
 }>;
-
-export {CustomTransformOptions} from 'metro-babel-transformer';
-
+export type {CustomTransformOptions} from 'metro-babel-transformer';
 export type JsTransformOptions = Readonly<{
   customTransformOptions?: CustomTransformOptions;
   dev: boolean;
@@ -82,47 +71,37 @@ export type JsTransformOptions = Readonly<{
   inlineRequires: boolean;
   minify: boolean;
   nonInlinedRequires?: ReadonlyArray<string>;
-  platform?: string;
-  runtimeBytecodeVersion?: number;
+  platform: null | undefined | string;
   type: Type;
+  unstable_memoizeInlineRequires?: boolean;
+  unstable_nonMemoizedInlineRequires?: ReadonlyArray<string>;
+  unstable_staticHermesOptimizedRequire?: boolean;
   unstable_transformProfile: TransformProfile;
 }>;
-
-export type BytecodeFileType =
-  | 'bytecode/module'
-  | 'bytecode/module/asset'
-  | 'bytecode/script';
-
-export type JSFileType = 'js/script' | 'js/module' | 'js/module/asset';
-
+type JSFileType = 'js/script' | 'js/module' | 'js/module/asset';
 export type JsOutput = Readonly<{
   data: Readonly<{
     code: string;
     lineCount: number;
-    map: MetroSourceMapSegmentTuple[];
-    functionMap: FBSourceFunctionMap | null;
+    map: Array<MetroSourceMapSegmentTuple>;
+    functionMap: null | undefined | FBSourceFunctionMap;
   }>;
   type: JSFileType;
 }>;
-
-// Hermes byte-code output type
-export type BytecodeOutput = unknown;
-
-export type TransformResponse = Readonly<{
+type TransformResponse = Readonly<{
   dependencies: ReadonlyArray<TransformResultDependency>;
-  output: ReadonlyArray<JsOutput | BytecodeOutput>;
+  output: ReadonlyArray<JsOutput>;
 }>;
-
-export function transform(
+export declare const transform: (
   config: JsTransformerConfig,
   projectRoot: string,
   filename: string,
   data: Buffer,
   options: JsTransformOptions,
-): Promise<TransformResponse>;
-
-export function getCacheKey(config: JsTransformerConfig): string;
-
+) => Promise<TransformResponse>;
+export declare type transform = typeof transform;
+export declare const getCacheKey: (config: JsTransformerConfig) => string;
+export declare type getCacheKey = typeof getCacheKey;
 /**
  * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
  * Do not add to this list.

--- a/packages/metro-transform-worker/types/utils/assetTransformer.d.ts
+++ b/packages/metro-transform-worker/types/utils/assetTransformer.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+import type {File} from '@babel/types';
+import type {BabelTransformerArgs} from 'metro-babel-transformer';
+
+export declare function transform(
+  $$PARAM_0$$: BabelTransformerArgs,
+  assetRegistryPath: string,
+  assetDataPlugins: ReadonlyArray<string>,
+): Promise<{ast: File}>;

--- a/packages/metro-transform-worker/types/utils/getMinifier.d.ts
+++ b/packages/metro-transform-worker/types/utils/getMinifier.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+import type {Minifier} from '../index.js';
+
+declare function getMinifier(minifierPath: string): Minifier;
+export default getMinifier;

--- a/scripts/generateTypeScriptDefinitions.js
+++ b/scripts/generateTypeScriptDefinitions.js
@@ -32,6 +32,7 @@ export const AUTO_GENERATED_PATTERNS: $ReadOnlyArray<string> = [
   'packages/metro-core/**',
   'packages/metro-resolver/**',
   'packages/metro-source-map/**',
+  'packages/metro-transform-worker/**',
   'packages/ob1/**',
 ];
 


### PR DESCRIPTION
## Summary

As I began working to hand-fix some types, the formidable @robhogan [pointed me](https://github.com/facebook/metro/pull/1608#issuecomment-3503159420) in the direction of `generateTypeScriptDefinitions.js`, which has been used here to generate types for `metro-transform-worker`

Changelog: [Internal]: Auto generate types for `metro-transform-worker`

## Test plan
Automatically tested in CI, also peformed a good-ol eyeball check.
