### PR TITLE
only re-write origin and add proxy hints if proxy is actually used

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -615,6 +615,13 @@ export default class Server {
       debug('Rewritten to:    %s', req.url);
     }
     const reqHost = req.headers['x-forwarded-host'] || req.headers['host'];
+    debug('Request host is:    %s', req.headers['host']);
+    if (req.headers['x-forwarded-host']) {
+      debug(
+        'Request x-forwarded-host is:    %s',
+        req.headers['x-forwarded-host'],
+      );
+    }
     if (!reqHost) {
       throw new Error('No host header was found.');
     }


### PR DESCRIPTION
Summary:
Rewriting of the header `host` (say from `localhost:8081` to `10523.od.fbinfra.net`) and adding the original host from which the request was made via the `x-forwarded-host` header, is only needed if the proxy request runs through a proxy at the moment. Otherwise proxying through 
```
const X2PAGENT_LOCAL_PROXY_URL = 'http://localhost:10054/';
```
fails.

In the usual use-case, we just keep the request pointing to `localhost:8081`.

Reviewed By: motiz88

Differential Revision: D86323364


