### PR TITLE
Remove deprecated `load` method from Metro's `DependencyGraph`

### DIFF
--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -150,17 +150,6 @@ export default class DependencyGraph extends EventEmitter {
     await this._initializedPromise;
   }
 
-  // Creates the dependency graph and waits for it to become ready.
-  // @deprecated Use the constructor + ready() directly.
-  static async load(
-    config: ConfigT,
-    options?: {+hasReducedPerformance?: boolean, +watch?: boolean},
-  ): Promise<DependencyGraph> {
-    const self = new DependencyGraph(config, options);
-    await self.ready();
-    return self;
-  }
-
   _onHasteChange({eventsQueue}: ChangeEvent) {
     this._resolutionCache = new Map();
     eventsQueue.forEach(({filePath}) =>


### PR DESCRIPTION
Summary: Removing the static factory method, load(), which has been marked deprecated for several years in favour of directly using the constructor with a ready() instance method.

Differential Revision: D87436988


