### PR TITLE
fix(metro-config): Convert absolute paths to file URL before calling await import

### DIFF
--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -18,6 +18,8 @@ import {validate} from 'jest-validate';
 import * as MetroCache from 'metro-cache';
 import {homedir} from 'os';
 import * as path from 'path';
+// eslint-disable-next-line no-restricted-imports
+import {pathToFileURL} from 'url';
 import {parse as parseYaml} from 'yaml';
 
 type ResolveConfigResult = {
@@ -397,7 +399,11 @@ export async function loadConfigFile(
     } catch (e) {
       try {
         // $FlowExpectedError[unsupported-syntax]
-        const configModule = await import(absolutePath);
+        const configModule = await import(
+          path.isAbsolute(absolutePath)
+            ? pathToFileURL(absolutePath).toString()
+            : absolutePath
+        );
         // The default export is a promise in the case of top-level await
         config = await configModule.default;
       } catch (error) {


### PR DESCRIPTION
## Summary

Errors may be swallowed in `require`, which then cascades the error to `await import`. However, this may then trigger an error on Windows since absolute Windows paths cannot be passed to `await import` and need to be file URLs instead (`C:` or `D:` look like protocols to `import` otherwise)

We could also expose the error from `require` instead if the `code`s match a set of allowed (or not match a set of disallowed) error codes, but it's hard to get a comprehensive list for those without testing across all Node LTS versions.

Changelog: [Fix] Prevent absolute path error on `await import()` for Windows absolute paths

## Test plan

This is admittedly a speculative fix, and I still need to test this, but I've only observed this in Expo CI for now.
