### PR TITLE
Add missing types to RunBuildOptions and export RunBuildResult

### DIFF
--- a/packages/metro/types/index.d.ts
+++ b/packages/metro/types/index.d.ts
@@ -129,6 +129,13 @@ export interface RunBuildOptions {
   unstable_transformProfile?: TransformProfile;
 }
 
+export interface RunBuildResult {
+  code: string;
+  map: string;
+  assets?: ReadonlyArray<AssetData>;
+  [key: string]: unknown;
+}
+
 interface BuildGraphOptions {
   entries: ReadonlyArray<string>;
   customTransformOptions?: CustomTransformOptions;
@@ -159,7 +166,7 @@ export function runServer(
 export function runBuild(
   config: ConfigT,
   options: RunBuildOptions,
-): Promise<void>;
+): Promise<RunBuildResult>;
 
 export function buildGraph(
   config: ConfigT,


### PR DESCRIPTION
## Summary

[This commit](https://github.com/pafry7/metro/commit/3b4f50333ba0931f6740f2cde30fc5129edb22ab#diff-b76006199b2dadcf45bcf375953a05d30057b0ff34a5542a028cb56012ceebb2) added the `assets` boolean to `RunBuildOptions` as well as `RunBuildResult` type, but `index.d.ts` was not changed, which causes missing type errors.

<img width="882" height="118" alt="Screenshot 2025-11-21 at 08 15 41" src="https://github.com/user-attachments/assets/83364bae-dcec-4f98-9236-838624a05f6c" />

Changelog: [Fix] missing types for `runBuild` command

## Test plan
<img width="219" height="72" alt="Screenshot 2025-11-21 at 08 23 03" src="https://github.com/user-attachments/assets/f3d447d8-bf12-4c9a-83b0-55cef4005fa6" />
<img width="347" height="65" alt="Screenshot 2025-11-21 at 08 23 15" src="https://github.com/user-attachments/assets/c44ef580-a219-4657-b592-754663aec69f" />


