### PR TITLE
Trusted Publish: Add id-token write permission for OIDC to publish GHA

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -20,6 +20,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+  id-token: write  # Required for OIDC
+
 jobs:
   run-js-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add permission to create an id token, according to the NPM docs:

https://docs.npmjs.com/trusted-publishers#supported-cicd-providers

Unblock "trusted publish", which we'll migrate to in place of current NPM tokens.