### PR TITLE
Re-enable CI on Node v25 (latest)

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -52,7 +52,7 @@ jobs:
           '20.19.4', # minimum supported
           'lts/-1',  # previous lts
           'lts/*',   # latest lts
-          # 'latest'   # latest node version
+          'latest'   # latest node version
         ]
     uses: ./.github/workflows/test.yml
     with:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -24,7 +24,7 @@ jobs:
           '20.19.4', # minimum supported
           'lts/-1',  # previous lts
           'lts/*',   # latest lts
-          # 'latest'   # latest node version
+          'latest'   # latest node version
         ]
         no-lockfile: ['false', 'true']
     uses: ./.github/workflows/test.yml


### PR DESCRIPTION
## Summary

Revert the temporary change in D86973545 now that the fix has landed upstream in Node v25.2.1: https://github.com/nodejs/node/issues/60704#issuecomment-3540961142

## Test plan

CI on this PR
