### PR TITLE
chore(types): provide ability to define .d.ts as source

### DIFF
--- a/scripts/generateTypeScriptDefinitions.js
+++ b/scripts/generateTypeScriptDefinitions.js
@@ -25,6 +25,7 @@ import * as prettier from 'prettier';
 const WORKSPACE_ROOT = path.resolve(__dirname, '..');
 
 const TYPES_DIR = 'types';
+const SRC_DIR = 'src';
 
 export const AUTO_GENERATED_PATTERNS: $ReadOnlyArray<string> = [
   'packages/metro-cache/**',
@@ -49,6 +50,20 @@ const IGNORED_PATTERNS = [
   'packages/metro/src/integration_tests/**',
 ];
 
+function isSourceTSDeclaration(
+  filePath: string,
+): boolean {
+  const parts = filePath.split(path.sep);
+  return filePath.endsWith('.d.ts') && parts[2] === SRC_DIR;
+}
+
+function isExistingTSDeclaration(
+  filePath: string,
+): boolean {
+  const parts = filePath.split(path.sep);
+  return filePath.endsWith('.d.ts') && parts[2] === TYPES_DIR;
+}
+
 export async function generateTsDefsForJsGlobs(
   globPattern: string | $ReadOnlyArray<string>,
   opts: $ReadOnly<{
@@ -65,6 +80,7 @@ export async function generateTsDefsForJsGlobs(
   const globPatterns = Array.isArray(globPattern) ? globPattern : [globPattern];
 
   const existingDefs = new Set<string>();
+  const sourceDefs = new Set<string>();
   const filesToProcess: Array<[jsFile: string, flowSourceFile: string]> =
     Array.from(
       globPatterns
@@ -83,10 +99,9 @@ export async function generateTsDefsForJsGlobs(
             toProcess.set(filePath.replace(/\.flow\.js$/, '.js'), filePath);
           } else if (filePath.endsWith('.js') && !toProcess.has(filePath)) {
             toProcess.set(filePath, filePath);
-          } else if (
-            filePath.endsWith('.d.ts') &&
-            filePath.split(path.sep)[2] === TYPES_DIR
-          ) {
+          } else if (isSourceTSDeclaration(filePath)) {
+            sourceDefs.add(path.resolve(WORKSPACE_ROOT, filePath));
+          } else if (isExistingTSDeclaration(filePath)) {
             existingDefs.add(path.resolve(WORKSPACE_ROOT, filePath));
           }
           return toProcess;
@@ -95,10 +110,67 @@ export async function generateTsDefsForJsGlobs(
     );
 
   const errors = [];
+
+
+  async function writeOutputFile(
+    sourceContent: string,
+    absoluteTsFile: string,
+    sourceFile: string,
+  ) {
+
+    // Lint and fix the generated output
+    const [lintResult] = await linter.lintText(sourceContent, {
+      filePath: absoluteTsFile,
+    });
+
+    if (lintResult.messages.length > 0) {
+      console.warn(sourceFile, lintResult.messages);
+    }
+
+    const finalOutput = await prettier.format(
+      lintResult.output ?? sourceContent,
+      prettierConfig,
+    );
+
+    existingDefs.delete(absoluteTsFile);
+
+    if (opts.verifyOnly) {
+      let existingFile = null;
+      try {
+        existingFile = await fs.promises.readFile(absoluteTsFile, 'utf-8');
+        if (finalOutput !== existingFile) {
+          errors.push({
+            sourceFile,
+            error: new Error('.d.ts file is out of sync'),
+          });
+        }
+      } catch {
+        errors.push({sourceFile, error: new Error('.d.ts file missing')});
+      }
+    } else {
+      await fs.promises.mkdir(path.dirname(absoluteTsFile), {
+        recursive: true,
+      });
+      await fs.promises.writeFile(absoluteTsFile, finalOutput);
+    }
+  }
+
   await Promise.all(
     filesToProcess.map(async ([jsFile, sourceFile]) => {
       const absoluteTsFile = getTSDeclAbsolutePath(jsFile);
+      const sourceTSDeclationPath = absoluteTsFile.replace(TYPES_DIR, SRC_DIR);
       const absoluteSourceFile = path.resolve(WORKSPACE_ROOT, sourceFile);
+
+      // If a source .d.ts file exists, copy it directly.
+      if (sourceDefs.has(sourceTSDeclationPath)) {
+        const source = await fs.promises.readFile(
+          sourceTSDeclationPath,
+          'utf-8',
+        );
+        await writeOutputFile(source, absoluteTsFile, sourceFile);
+        return;
+      }
+
       const source = await fs.promises.readFile(absoluteSourceFile, 'utf-8');
       if (!source.includes('@flow')) {
         errors.push({
@@ -121,44 +193,7 @@ export async function generateTsDefsForJsGlobs(
 
           // Fix up gap left in license header by removal of atflow
           const beforeLint = tsDef.replace('\n *\n *\n', '\n *\n');
-
-          const [lintResult] = await linter.lintText(beforeLint, {
-            filePath: absoluteTsFile,
-          });
-
-          if (lintResult.messages.length > 0) {
-            console.warn(sourceFile, lintResult.messages);
-          }
-
-          const finalOutput = await prettier.format(
-            lintResult.output ?? beforeLint,
-            prettierConfig,
-          );
-
-          existingDefs.delete(absoluteTsFile);
-
-          if (opts.verifyOnly) {
-            let existingFile = null;
-            try {
-              existingFile = await fs.promises.readFile(
-                absoluteTsFile,
-                'utf-8',
-              );
-              if (finalOutput !== existingFile) {
-                errors.push({
-                  sourceFile,
-                  error: new Error('.d.ts file is out of sync'),
-                });
-              }
-            } catch {
-              errors.push({sourceFile, error: new Error('.d.ts file missing')});
-            }
-          } else {
-            await fs.promises.mkdir(path.dirname(absoluteTsFile), {
-              recursive: true,
-            });
-            await fs.promises.writeFile(absoluteTsFile, finalOutput);
-          }
+          await writeOutputFile(beforeLint, absoluteTsFile, sourceFile);
         }
       } catch (error) {
         errors.push({sourceFile, error});
@@ -182,7 +217,6 @@ export async function generateTsDefsForJsGlobs(
       );
     }
   }
-
   if (errors.length > 0) {
     errors.sort((a, b) => a.sourceFile.localeCompare(b.sourceFile));
     throw new AggregateError(


### PR DESCRIPTION
Provides an escape hatch by allowing users to define .d.ts as sibling files to source, as type generation overwrites files in `types`, and removes orphaned files. This can also be used in the case where flow-api-translator produces incorrect typings, or fails entitely

## Summary

Discussions with @robhogan and other PRs that I hope to land could benefit from being able to bail on type-generation without manually defined .d.ts files being removed as part of generation.

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog:
[Internal] Allow .d.ts files in `src` to allow for manual definitions

## Test plan


https://github.com/user-attachments/assets/9d76b6cb-687f-4ebc-bfd9-40eff27bdd90

