### PR TITLE
Replace glob with tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "eslint-plugin-relay": "^1.8.3",
     "flow-api-translator": "^0.32.0",
     "flow-bin": "^0.291.0",
-    "glob": "^7.1.1",
     "hermes-eslint": "0.32.0",
     "invariant": "^2.2.4",
     "istanbul-api": "3.0.0",
@@ -45,6 +44,7 @@
     "prettier": "3.6.2",
     "prettier-plugin-hermes-parser": "0.32.0",
     "progress": "^2.0.0",
+    "tinyglobby": "^0.2.15",
     "typescript": "5.8.3"
   },
   "scripts": {

--- a/scripts/__tests__/subpackages-test.js
+++ b/scripts/__tests__/subpackages-test.js
@@ -10,13 +10,12 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 // TODO: Replace with fs.globSync once Flow knows about it
 // $FlowFixMe[untyped-import] glob in OSS
-import glob from 'glob';
-import path from 'path';
-import {promisify} from 'util';
+import {glob, globSync} from 'tinyglobby';
 
-const globAsync = promisify(glob);
+const globAsync = glob;
 
 // For promisified glob
 jest.useRealTimers();
@@ -32,7 +31,12 @@ const workspaceRootPackageJson = readJsonSync('package.json');
 const ALL_PACKAGES: ReadonlySet<string> = new Set(
   Array.isArray(workspaceRootPackageJson.workspaces)
     ? workspaceRootPackageJson.workspaces
-        .flatMap(relativeGlob => glob.sync(relativeGlob, {cwd: WORKSPACE_ROOT}))
+        .flatMap(relativeGlob =>
+          globSync(relativeGlob, {
+            cwd: WORKSPACE_ROOT,
+            onlyDirectories: true,
+          }),
+        )
         // Glob returns posix separators, we want system-native
         .map(relativePath => path.normalize(relativePath))
     : [],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -28,10 +28,10 @@ const getPackages = require('./_getPackages');
 const babel = require('@babel/core');
 const chalk = require('chalk');
 const fs = require('fs');
-const glob = require('glob');
 const micromatch = require('micromatch');
 const path = require('path');
 const prettier = require('prettier');
+const {globSync} = require('tinyglobby');
 
 const SRC_DIR = 'src';
 const TYPES_DIR = 'types';
@@ -72,8 +72,8 @@ function buildPackage(p /*: string */) {
   const typesDir = path.resolve(p, TYPES_DIR);
   const buildDir = path.resolve(p, BUILD_DIR);
   const pattern = path.resolve(srcDir, '**/*');
-  const files = glob.sync(pattern, {nodir: true});
-  const typescriptDefs = glob.sync(path.join(typesDir, '**/*.d.ts'));
+  const files = globSync(pattern, {onlyFiles: true});
+  const typescriptDefs = globSync(path.join(typesDir, '**/*.d.ts'));
 
   process.stdout.write(fixedWidth(`${path.basename(p)}\n`));
 

--- a/scripts/generateTypeScriptDefinitions.js
+++ b/scripts/generateTypeScriptDefinitions.js
@@ -16,11 +16,11 @@ import {
   translateFlowToFlowDef,
 } from 'flow-api-translator';
 import fs from 'fs';
-// $FlowFixMe[untyped-import] in OSS only
-import glob from 'glob';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import * as prettier from 'prettier';
+// $FlowFixMe[untyped-import] in OSS only
+import {globSync} from 'tinyglobby';
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '..');
 
@@ -69,7 +69,7 @@ export async function generateTsDefsForJsGlobs(
     Array.from(
       globPatterns
         .flatMap(pattern =>
-          glob.sync(pattern, {
+          globSync(pattern, {
             ignore: IGNORED_PATTERNS,
             cwd: WORKSPACE_ROOT,
           }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,6 +2784,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -4638,6 +4643,11 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+
 pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
@@ -5284,6 +5294,14 @@ tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
+tinyglobby@^0.2.15:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
 
 tmp@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
Summary:
Follows https://github.com/facebook/react-native/pull/54737. Replaces https://github.com/facebook/metro/pull/1442.

Replace `glob@^7.0.0` with the lighter weight `tinyglobby` package to resolve deprecation warnings. This affects only Metro's scripts files.

Changelog:
- **[Security]**: Replace `glob@^7.0.0` with `tinyglobby@^0.2.15`

Reviewed By: vzaidman

Differential Revision: D88146420


