### PR TITLE
fix potential "invalid content type" error on /symbolicate #1629

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -1382,7 +1382,7 @@ export default class Server {
         const body = await req.rawBody;
         parsedBody = JSON.parse(body);
       } else {
-        parsedBody = (await parseJsonBody(req)) as {
+        parsedBody = (await parseJsonBody(req, {strict: false})) as {
           stack: $ReadOnlyArray<StackFrameInput>,
           extraData: {[string]: mixed},
         };


### PR DESCRIPTION
**It's my first PR, I have completed the CLA**

## Summary
Fix: https://github.com/facebook/metro/issues/1629

In my case with RN0.80, /symbolicate receives request with `req.headers["content-type"]` containing `text/plain` instead of `application/json` but the content is indeed a JSON. 
This causes this error message in the console : 
```
Error: Invalid content type, expected application/json
    at .../node_modules/metro/src/lib/parseJsonBody.js:11:16
   ...
```
Calling jsonParseBody with `strict: false` disable the header validation and the request is processed correctly and I no longer get an error message.
So we can propably consider making this header check more flexible and reintroduce it later as a breaking change if necessary (the original change was not introduced as a breaking change)

Changelog: [Fix] potential "invalid content type" error on /symbolicate #1629 

