### PR TITLE
feat: add support for including the babel partial config to cache key

### DIFF
--- a/packages/metro-babel-transformer/package.json
+++ b/packages/metro-babel-transformer/package.json
@@ -25,6 +25,7 @@
     "@babel/core": "^7.25.2",
     "flow-enums-runtime": "^0.0.6",
     "hermes-parser": "0.32.0",
+    "metro-cache-key": "*",
     "nullthrows": "^1.1.1"
   },
   "engines": {

--- a/packages/metro-babel-transformer/types/index.d.ts
+++ b/packages/metro-babel-transformer/types/index.d.ts
@@ -37,15 +37,21 @@ export interface BabelTransformerArgs {
   readonly src: string;
 }
 
+export interface BabelTransformerCacheKeyOptions {
+  readonly projectRoot: string;
+  readonly enableBabelRCLookup?: boolean;
+}
+
 export interface BabelTransformer {
   transform: (args: BabelTransformerArgs) => {
     ast: unknown;
     metadata: unknown;
   };
-  getCacheKey?: () => string;
+  getCacheKey?: (options: BabelTransformerCacheKeyOptions) => string;
 }
 
 export const transform: BabelTransformer['transform'];
+export const getCacheKey: (options: BabelTransformerCacheKeyOptions) => string;
 
 /**
  * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
@@ -53,7 +59,10 @@ export const transform: BabelTransformer['transform'];
  *
  * @deprecated Default import from 'metro-babel-transformer' is deprecated, use named exports.
  */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: {transform: typeof transform};
+declare const $$EXPORT_DEFAULT_DECLARATION$$: {
+  transform: typeof transform;
+  getCacheKey: typeof getCacheKey;
+};
 declare type $$EXPORT_DEFAULT_DECLARATION$$ =
   typeof $$EXPORT_DEFAULT_DECLARATION$$;
 export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -718,7 +718,10 @@ export const transform = async (
   return await transformJSWithBabel(file, context);
 };
 
-export const getCacheKey = (config: JsTransformerConfig): string => {
+export const getCacheKey = (
+  config: JsTransformerConfig,
+  projectRoot: string,
+): string => {
   const {babelTransformerPath, minifierPath, ...remainingConfig} = config;
 
   const filesKey = metroGetCacheKey([
@@ -734,10 +737,19 @@ export const getCacheKey = (config: JsTransformerConfig): string => {
 
   // $FlowFixMe[unsupported-syntax]
   const babelTransformer = require(babelTransformerPath);
+
+  // Get cache key from babel transformer, which may include user's babel config files
+  const babelTransformerCacheKey = babelTransformer.getCacheKey
+    ? babelTransformer.getCacheKey({
+        projectRoot,
+        enableBabelRCLookup: config.enableBabelRCLookup,
+      })
+    : '';
+
   return [
     filesKey,
     stableHash(remainingConfig).toString('hex'),
-    babelTransformer.getCacheKey ? babelTransformer.getCacheKey() : '',
+    babelTransformerCacheKey,
   ].join('$');
 };
 

--- a/packages/metro-transform-worker/types/index.d.ts
+++ b/packages/metro-transform-worker/types/index.d.ts
@@ -100,7 +100,10 @@ export declare const transform: (
   options: JsTransformOptions,
 ) => Promise<TransformResponse>;
 export declare type transform = typeof transform;
-export declare const getCacheKey: (config: JsTransformerConfig) => string;
+export declare const getCacheKey: (
+  config: JsTransformerConfig,
+  projectRoot: string,
+) => string;
 export declare type getCacheKey = typeof getCacheKey;
 /**
  * Backwards-compatibility with CommonJS consumers using interopRequireDefault.

--- a/packages/metro/src/DeltaBundler/getTransformCacheKey.js
+++ b/packages/metro/src/DeltaBundler/getTransformCacheKey.js
@@ -19,7 +19,7 @@ import {getCacheKey} from 'metro-cache-key';
 const VERSION = require('../../package.json').version;
 
 type CacheKeyProvider = {
-  getCacheKey?: JsTransformerConfig => string,
+  getCacheKey?: (config: JsTransformerConfig, projectRoot: string) => string,
 };
 
 export default function getTransformCacheKey(opts: {
@@ -32,7 +32,7 @@ export default function getTransformCacheKey(opts: {
   // eslint-disable-next-line no-useless-call
   const Transformer: CacheKeyProvider = require.call(null, transformerPath);
   const transformerKey = Transformer.getCacheKey
-    ? Transformer.getCacheKey(transformerConfig)
+    ? Transformer.getCacheKey(transformerConfig, opts.projectRoot)
     : '';
 
   return crypto


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Update the Metro Babel transformer to generate cache keys that include the contents of user Babel configuration files, ensuring cache invalidation when Babel configs change. This is similar to what Jest does and it seems to work really well for them.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Fix] Include user-defined babel config in transformer cache key to ensure correctness

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
