### PR TITLE
File map: Use worker threads rather than child processes, remove watcher.unstable_workerThreads

### DIFF
--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -145,7 +145,6 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
       timeout: 5000,
     },
     unstable_lazySha1: true,
-    unstable_workerThreads: false,
     unstable_autoSaveCache: {
       enabled: true,
       debounceMs: 5000,

--- a/packages/metro-config/src/types.js
+++ b/packages/metro-config/src/types.js
@@ -212,7 +212,6 @@ type WatcherConfigT = {
     debounceMs?: number,
   }>,
   unstable_lazySha1: boolean,
-  unstable_workerThreads: boolean,
   watchman: Readonly<{
     deferStates: $ReadOnlyArray<string>,
   }>,

--- a/packages/metro-config/types/types.d.ts
+++ b/packages/metro-config/types/types.d.ts
@@ -203,7 +203,6 @@ type WatcherConfigT = {
   }>;
   unstable_autoSaveCache: Readonly<{enabled: boolean; debounceMs?: number}>;
   unstable_lazySha1: boolean;
-  unstable_workerThreads: boolean;
   watchman: Readonly<{deferStates: ReadonlyArray<string>}>;
 };
 export type InputConfigT = Partial<

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -75,7 +75,6 @@ export type InputOptions = Readonly<{
   computeDependencies?: ?boolean,
   computeSha1?: ?boolean,
   enableSymlinks?: ?boolean,
-  enableWorkerThreads?: ?boolean,
   extensions: $ReadOnlyArray<string>,
   forceNodeFilesystemAPI?: ?boolean,
   ignorePattern?: ?RegExp,
@@ -339,7 +338,6 @@ export default class FileMap extends EventEmitter {
 
     this._fileProcessor = new FileProcessor({
       dependencyExtractor: buildParameters.dependencyExtractor,
-      enableWorkerThreads: options.enableWorkerThreads ?? false,
       maxFilesPerWorker: options.maxFilesPerWorker,
       maxWorkers: options.maxWorkers,
       perfLogger: this._startupPerfLogger,

--- a/packages/metro-file-map/src/lib/FileProcessor.js
+++ b/packages/metro-file-map/src/lib/FileProcessor.js
@@ -58,7 +58,6 @@ const MAX_FILES_PER_WORKER = 100;
 
 export class FileProcessor {
   #dependencyExtractor: ?string;
-  #enableWorkerThreads: boolean;
   #maxFilesPerWorker: number;
   #maxWorkers: number;
   #perfLogger: ?PerfLogger;
@@ -69,7 +68,6 @@ export class FileProcessor {
   constructor(
     opts: Readonly<{
       dependencyExtractor: ?string,
-      enableWorkerThreads: boolean,
       maxFilesPerWorker?: ?number,
       maxWorkers: number,
       pluginWorkers: ?$ReadOnlyArray<FileMapPluginWorker>,
@@ -78,7 +76,6 @@ export class FileProcessor {
     }>,
   ) {
     this.#dependencyExtractor = opts.dependencyExtractor;
-    this.#enableWorkerThreads = opts.enableWorkerThreads;
     this.#maxFilesPerWorker = opts.maxFilesPerWorker ?? MAX_FILES_PER_WORKER;
     this.#maxWorkers = opts.maxWorkers;
     this.#pluginWorkers = opts.pluginWorkers ?? [];
@@ -239,11 +236,7 @@ export class FileProcessor {
       };
     }
     const workerPath = require.resolve('../worker');
-    debug(
-      'Creating worker farm of %d worker %s',
-      numWorkers,
-      this.#enableWorkerThreads ? 'threads' : 'processes',
-    );
+    debug('Creating worker farm of %d worker threads', numWorkers);
     this.#perfLogger?.point('initWorkers_start');
     const jestWorker = new JestWorker<{
       processFile: WorkerMessage => Promise<WorkerMetadata>,
@@ -251,7 +244,7 @@ export class FileProcessor {
       exposedMethods: ['processFile'],
       maxRetries: 3,
       numWorkers,
-      enableWorkerThreads: this.#enableWorkerThreads,
+      enableWorkerThreads: true,
       forkOptions: {
         // Don't pass Node arguments down to workers. In particular, avoid
         // unnecessarily registering Babel when we're running Metro from

--- a/packages/metro-file-map/src/lib/__tests__/FileProcessor-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/FileProcessor-test.js
@@ -34,7 +34,6 @@ const p: string => string = filePath =>
 
 const defaultOptions = {
   dependencyExtractor: null,
-  enableWorkerThreads: true,
   maxWorkers: 5,
   perfLogger: null,
   pluginWorkers: [] as $ReadOnlyArray<FileMapPluginWorker>,

--- a/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
+++ b/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
@@ -99,7 +99,6 @@ export default function createFileMap(
     computeSha1: !config.watcher.unstable_lazySha1,
     dependencyExtractor: config.resolver.dependencyExtractor,
     enableSymlinks: true,
-    enableWorkerThreads: config.watcher.unstable_workerThreads,
     extensions: Array.from(
       new Set([
         ...config.resolver.sourceExts,


### PR DESCRIPTION
Summary:
Improve startup performance (especially on Windows) by having the file map use threads rather than child processes to distribute large workloads.

In telemetry for humans running Metro at Meta on Node 22, for cases where there are enough files to process to create a worker pool:

Creating a pool of threads vs child processes is:
 - 1.7x faster on macOS
 -  3.8x faster on Linux
 - **150x** faster on Windows (6.5s -> 43ms)

Processing files on threads vs child processes is:
 - 1.4x faster on macOS
 - 1.5x faster on Linux
 - **3.6x** faster on Windows (18s -> 6s)

NOTE: There is a separate worker threads configuration for *transform* workers which we've also been experimenting with, I'll come to that separately.

Changelog:
```
 - **[Performance]** Use worker threads for processing file changes on startup, significantly faster on Windows
```

Reviewed By: vzaidman

Differential Revision: D90510232


