### PR TITLE
feat: expose modules in runtime both in development and production

### DIFF
--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -547,15 +547,16 @@ function unknownModuleError(id: ModuleID): Error {
   return Error(message);
 }
 
+// $FlowFixMe[prop-missing]
+metroRequire.getModules = (): ModuleList => {
+  return modules;
+};
+
 if (__DEV__) {
   // $FlowFixMe[prop-missing]
   metroRequire.Systrace = {
     beginEvent: (): void => {},
     endEvent: (): void => {},
-  };
-  // $FlowFixMe[prop-missing]
-  metroRequire.getModules = (): ModuleList => {
-    return modules;
   };
 
   // HOT MODULE RELOADING


### PR DESCRIPTION
## Summary

Expose `getModules` function in both development and release environments. This allows the developers to dynamically replace a module in runtime.

I personally use it in `react-native-worklets` to replace `react-native` module on extra JavaScript runtimes. `react-native` module includes side-effects that are fatal on these extra runtimes and replacing it with a mock module improves developer experience significantly, in case they import `react-native` accidentally in runtime.

Changelog: [Feature] Expose modules in runtime both in development and production

## Test plan

Nothing to test really.
