### PR TITLE
make metro accept tls server config

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -657,6 +657,25 @@ Type: `boolean`
 
 Enable forwarding of `client_log` events (when client logs are [configured](https://github.com/facebook/metro/blob/614ad14a85b22958129ee94e04376b096f03ccb1/packages/metro/src/lib/createWebsocketServer.js#L20)) to the reporter. Defaults to `true`.
 
+#### `tls`
+
+Type: `false | object`
+
+If not provided or is `false` Metro will start an HTTP server with WS WebSocket endpoints.
+
+If an object, Metro will start an HTTPS server with WSS WebSocket endpoints using the passed TLS options:
+
+```ts
+ca?: string | Buffer,      // Certificate authority (contents, not path)
+cert?: string | Buffer,    // Server certificate (contents, not path)
+key?: string | Buffer,     // Private key (contents, not path)
+requestCert?: boolean,     // Whether to authenticate the remote peer by requesting a certificate
+```
+
+Notice that when overriding the base config, object tls configs extend the base tls config, false overrides the base tls configs, and `null` and `undefined` are ignored.
+
+When running Metro with `Metro.runServer` with the `secureServerOptions` property Metro will likewise start an HTTPS server merging with the `config.server.tls` object if provided, overriding it.
+
 ---
 
 ### Watcher Options

--- a/packages/metro-config/src/__tests__/mergeConfig-test.js
+++ b/packages/metro-config/src/__tests__/mergeConfig-test.js
@@ -4,10 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow
  * @format
  * @oncall react_native
  */
+
+import type {InputConfigT} from '../types';
 
 import {mergeConfig} from '../loadConfig';
 
@@ -24,6 +26,170 @@ describe('mergeConfig', () => {
         unstable_autoSaveCache: {},
         watchman: {},
       },
+    });
+  });
+
+  describe('server.tls merging', () => {
+    describe('override IS applied when tls is false or object', () => {
+      test('override tls: object replaces base tls: false', () => {
+        const base: InputConfigT = {server: {tls: false}};
+        const override: InputConfigT = {
+          server: {tls: {key: 'key', cert: 'cert'}},
+        };
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toStrictEqual({key: 'key', cert: 'cert'});
+      });
+
+      test('override tls: false replaces base tls: object', () => {
+        const base: InputConfigT = {server: {tls: {key: 'key', cert: 'cert'}}};
+        const override: InputConfigT = {server: {tls: false}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toBe(false);
+      });
+
+      test('override tls: false sets tls when base is undefined', () => {
+        const base: InputConfigT = {server: {}};
+        const override: InputConfigT = {server: {tls: false}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toBe(false);
+      });
+
+      test('override tls: object sets tls when base is undefined', () => {
+        const base: InputConfigT = {server: {}};
+        const override: InputConfigT = {
+          server: {tls: {key: 'key', cert: 'cert'}},
+        };
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toStrictEqual({key: 'key', cert: 'cert'});
+      });
+
+      test('override tls: object deep merges with base tls: object', () => {
+        const base: InputConfigT = {
+          server: {tls: {key: 'baseKey', cert: 'baseCert', ca: 'baseCa'}},
+        };
+        const override: InputConfigT = {
+          server: {tls: {key: 'newKey', cert: 'newCert'}},
+        };
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toStrictEqual({
+          key: 'newKey',
+          cert: 'newCert',
+          ca: 'baseCa',
+        });
+      });
+
+      test('override tls: object adds new properties to base tls: object', () => {
+        const base: InputConfigT = {
+          server: {tls: {key: 'baseKey', cert: 'baseCert'}},
+        };
+        const override: InputConfigT = {
+          server: {tls: {ca: 'newCa'}},
+        };
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toStrictEqual({
+          key: 'baseKey',
+          cert: 'baseCert',
+          ca: 'newCa',
+        });
+      });
+
+      test('override tls: object with same properties overrides base values', () => {
+        const base: InputConfigT = {
+          server: {tls: {key: 'baseKey', cert: 'baseCert'}},
+        };
+        const override: InputConfigT = {
+          server: {tls: {key: 'newKey', cert: 'newCert'}},
+        };
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toStrictEqual({
+          key: 'newKey',
+          cert: 'newCert',
+        });
+      });
+
+      test('other server properties are preserved when tls is overridden', () => {
+        const base: InputConfigT = {server: {port: 8081, tls: false}};
+        const override: InputConfigT = {
+          server: {tls: {key: 'key', cert: 'cert'}},
+        };
+        const result = mergeConfig(base, override);
+        expect(result.server).toStrictEqual({
+          port: 8081,
+          tls: {key: 'key', cert: 'cert'},
+        });
+      });
+
+      test('override tls: null replaces base tls: undefined', () => {
+        const base: InputConfigT = {server: {}};
+        // $FlowExpectedError[incompatible-type] - testing untyped runtime behavior
+        const override: InputConfigT = {server: {tls: null}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toBe(null);
+      });
+    });
+
+    describe('override is NOT applied when tls is null or undefined', () => {
+      test('override tls: undefined keeps base tls: object', () => {
+        const base: InputConfigT = {server: {tls: {key: 'key', cert: 'cert'}}};
+        const override: InputConfigT = {server: {}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toStrictEqual({key: 'key', cert: 'cert'});
+      });
+
+      test('override tls: undefined (explicit) keeps base tls: object', () => {
+        const base: InputConfigT = {server: {tls: {key: 'key', cert: 'cert'}}};
+        // $FlowExpectedError[incompatible-type] - testing explicit undefined
+        const override: InputConfigT = {server: {tls: undefined}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toStrictEqual({key: 'key', cert: 'cert'});
+      });
+
+      test('override tls: undefined keeps base tls: false', () => {
+        const base: InputConfigT = {server: {tls: false}};
+        const override: InputConfigT = {server: {}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toBe(false);
+      });
+
+      test('override tls: undefined (explicit) keeps base tls: false', () => {
+        const base: InputConfigT = {server: {tls: false}};
+        // $FlowExpectedError[incompatible-type] - testing untyped runtime behavior
+        const override: InputConfigT = {server: {tls: undefined}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toBe(false);
+      });
+
+      test('override tls: null keeps base tls: object', () => {
+        const base: InputConfigT = {server: {tls: {key: 'key', cert: 'cert'}}};
+        // $FlowExpectedError[incompatible-type] - testing untyped runtime behavior
+        const override: InputConfigT = {server: {tls: null}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toStrictEqual({key: 'key', cert: 'cert'});
+      });
+
+      test('override tls: null keeps base tls: false', () => {
+        const base: InputConfigT = {server: {tls: false}};
+        // $FlowExpectedError[incompatible-type] - testing untyped runtime behavior
+        const override: InputConfigT = {server: {tls: null}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toBe(false);
+      });
+
+      test('both tls undefined results in no tls property', () => {
+        const base: InputConfigT = {server: {}};
+        const override: InputConfigT = {server: {}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toBeUndefined();
+      });
+
+      test('both tls undefined (explicit) results in no tls property', () => {
+        // $FlowExpectedError[incompatible-type] - testing untyped runtime behavior
+        const base: InputConfigT = {server: {tls: undefined}};
+        // $FlowExpectedError[incompatible-type] - testing untyped runtime behavior
+        const override: InputConfigT = {server: {tls: undefined}};
+        const result = mergeConfig(base, override);
+        expect(result.server?.tls).toBeUndefined();
+      });
     });
   });
 });

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -80,6 +80,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     unstable_serverRoot: null,
     useGlobalHotkey: true,
     verifyConnections: false,
+    tls: false,
   },
 
   symbolicator: {

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -152,8 +152,21 @@ function mergeConfigObjects<T: InputConfigT>(
     },
     server: {
       ...base.server,
-      // $FlowFixMe[exponential-spread]
       ...overrides.server,
+      // $FlowFixMe[exponential-spread]
+      ...(base.server?.tls != null ? {tls: base.server?.tls} : null),
+      // only override base tls config with false or an object
+      ...(overrides.server?.tls === false
+        ? {tls: false}
+        : overrides.server?.tls != null &&
+            typeof overrides.server?.tls === 'object'
+          ? {
+              tls: {
+                ...(base.server?.tls || {}),
+                ...overrides.server?.tls,
+              },
+            }
+          : null),
     },
     symbolicator: {
       ...base.symbolicator,

--- a/packages/metro-config/src/types.js
+++ b/packages/metro-config/src/types.js
@@ -184,6 +184,14 @@ type ServerConfigT = {
   unstable_serverRoot: ?string,
   useGlobalHotkey: boolean,
   verifyConnections: boolean,
+  tls:
+    | false
+    | {
+        ca?: string | Buffer,
+        cert?: string | Buffer,
+        key?: string | Buffer,
+        requestCert?: boolean,
+      },
 };
 
 type SymbolicatorConfigT = {

--- a/packages/metro-config/types/types.d.ts
+++ b/packages/metro-config/types/types.d.ts
@@ -179,6 +179,14 @@ type ServerConfigT = {
   unstable_serverRoot: null | undefined | string;
   useGlobalHotkey: boolean;
   verifyConnections: boolean;
+  tls:
+    | false
+    | {
+        ca?: string | Buffer;
+        cert?: string | Buffer;
+        key?: string | Buffer;
+        requestCert?: boolean;
+      };
 };
 type SymbolicatorConfigT = {
   customizeFrame: ($$PARAM_0$$: {

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -76,6 +76,7 @@
     "metro-memory-fs": "*",
     "mock-req": "^0.2.0",
     "mock-res": "^0.6.0",
+    "selfsigned": "^5.5.0",
     "stack-trace": "^0.0.10"
   },
   "license": "MIT",

--- a/packages/metro/src/integration_tests/__tests__/server-endpoints-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-endpoints-test.js
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+'use strict';
+
+const Metro = require('../../..');
+const http = require('http');
+const https = require('https');
+const selfsigned = require('selfsigned');
+const WebSocket = require('ws');
+
+jest.useRealTimers();
+jest.setTimeout(60 * 1000);
+
+function checkHttpEndpoint(
+  port: number,
+  secure: boolean,
+): Promise<{
+  success: boolean,
+  status: number,
+  url: string,
+}> {
+  const protocol = secure ? 'https' : 'http';
+  const url = `${protocol}://localhost:${port}/TestBundle.bundle?platform=ios&dev=true&minify=false`;
+  const client = secure ? https : http;
+  const options = secure ? {rejectUnauthorized: false} : {};
+
+  return new Promise((resolve, reject) => {
+    const req = client.get(url, options, res => {
+      // Consume the response body to properly close the connection
+      res.on('data', () => {});
+      res.on('end', () => {
+        if (res.statusCode === 200) {
+          resolve({success: true, status: res.statusCode, url});
+        } else {
+          reject(new Error(`Metro returned status ${res.statusCode}`));
+        }
+      });
+    });
+
+    req.on('error', err => {
+      reject(new Error(`Failed to connect to ${url}: ${err.message}`));
+    });
+
+    req.setTimeout(30000, () => {
+      req.destroy();
+      reject(new Error(`Request to ${url} timed out`));
+    });
+  });
+}
+
+function checkWebSocket(
+  port: number,
+  secure: boolean,
+): Promise<{
+  success: boolean,
+  message: string,
+  url: string,
+}> {
+  const protocol = secure ? 'wss' : 'ws';
+  const url = `${protocol}://localhost:${port}/hot`;
+
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, {
+      rejectUnauthorized: false,
+    });
+
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`WebSocket connection to ${url} timed out`));
+    }, 5000);
+
+    ws.on('open', () => {
+      clearTimeout(timeout);
+      ws.close();
+      resolve({
+        success: true,
+        message: 'WebSocket connection established',
+        url,
+      });
+    });
+
+    ws.on('error', err => {
+      clearTimeout(timeout);
+      reject(
+        new Error(`WebSocket connection to ${url} failed: ${err.message}`),
+      );
+    });
+  });
+}
+
+describe('Metro development server endpoints', () => {
+  let httpServer;
+  let serverClosedPromise;
+  let port;
+
+  afterEach(async () => {
+    if (httpServer) {
+      httpServer.close();
+      await serverClosedPromise;
+      httpServer = null;
+    }
+  });
+
+  describe('HTTP server (no TLS)', () => {
+    beforeEach(async () => {
+      const config = await Metro.loadConfig({
+        config: require.resolve('../metro.config.js'),
+      });
+
+      let onCloseResolve;
+      serverClosedPromise = new Promise(resolve => (onCloseResolve = resolve));
+
+      ({httpServer} = await Metro.runServer(config, {
+        reporter: {update() {}},
+        onClose: () => {
+          onCloseResolve();
+        },
+      }));
+
+      port = httpServer.address().port;
+    });
+
+    test('HTTP endpoint is reachable', async () => {
+      const result = await checkHttpEndpoint(port, false);
+      expect(result.success).toBe(true);
+      expect(result.status).toBe(200);
+    });
+
+    test('WS /hot endpoint is reachable', async () => {
+      const result = await checkWebSocket(port, false);
+      expect(result.success).toBe(true);
+    });
+
+    test('HTTPS endpoint is not reachable on HTTP server', async () => {
+      await expect(checkHttpEndpoint(port, true)).rejects.toThrow();
+    });
+
+    test('WSS /hot endpoint is not reachable on HTTP server', async () => {
+      await expect(checkWebSocket(port, true)).rejects.toThrow();
+    });
+  });
+
+  describe('HTTPS server (with TLS)', () => {
+    beforeEach(async () => {
+      const config = await Metro.loadConfig({
+        config: require.resolve('../metro.config.js'),
+      });
+
+      const selfSignedPems = await selfsigned.generate(
+        [{name: 'commonName', value: 'localhost'}],
+        {days: 1},
+      );
+      config.server.tls = {
+        key: selfSignedPems.private,
+        cert: selfSignedPems.cert,
+      };
+
+      let onCloseResolve;
+      serverClosedPromise = new Promise(resolve => (onCloseResolve = resolve));
+
+      ({httpServer} = await Metro.runServer(config, {
+        reporter: {update() {}},
+        onClose: () => {
+          onCloseResolve();
+        },
+      }));
+
+      port = httpServer.address().port;
+    });
+
+    test('HTTPS endpoint is reachable', async () => {
+      const result = await checkHttpEndpoint(port, true);
+      expect(result.success).toBe(true);
+      expect(result.status).toBe(200);
+    });
+
+    test('WSS /hot endpoint is reachable', async () => {
+      const result = await checkWebSocket(port, true);
+      expect(result.success).toBe(true);
+    });
+
+    test('HTTP endpoint is not reachable on HTTPS server', async () => {
+      await expect(checkHttpEndpoint(port, false)).rejects.toThrow();
+    });
+
+    test('WS /hot endpoint is not reachable on HTTPS server', async () => {
+      await expect(checkWebSocket(port, false)).rejects.toThrow();
+    });
+  });
+});

--- a/packages/metro/src/integration_tests/__tests__/server-tls-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-tls-test.js
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+'use strict';
+
+const Metro = require('../../..');
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+const os = require('os');
+const path = require('path');
+const selfsigned = require('selfsigned');
+
+jest.useRealTimers();
+jest.setTimeout(60 * 1000);
+
+describe('Metro development server with TLS configuration', () => {
+  let httpServer;
+  let serverClosedPromise;
+  let tempDir;
+  let keyFile;
+  let certFile;
+  let keyContent;
+  let certContent;
+
+  beforeAll(async () => {
+    // Create temp directory for cert files
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metro-tls-test-'));
+    keyFile = path.join(tempDir, 'key.pem');
+    certFile = path.join(tempDir, 'cert.pem');
+
+    const selfSignedPems = await selfsigned.generate(
+      [{name: 'commonName', value: 'localhost'}],
+      {days: 1},
+    );
+
+    keyContent = selfSignedPems.private;
+    certContent = selfSignedPems.cert;
+
+    fs.writeFileSync(keyFile, keyContent, 'utf8');
+    fs.writeFileSync(certFile, selfSignedPems.cert, 'utf8');
+  });
+
+  afterAll(() => {
+    // Cleanup temp files
+    if (tempDir) {
+      fs.rmSync(tempDir, {recursive: true, force: true});
+    }
+  });
+
+  afterEach(async () => {
+    if (httpServer) {
+      httpServer.close();
+      await serverClosedPromise;
+      httpServer = null;
+    }
+  });
+
+  test('should create HTTP server when no TLS config is provided', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    let onCloseResolve;
+    serverClosedPromise = new Promise(resolve => (onCloseResolve = resolve));
+
+    ({httpServer} = await Metro.runServer(config, {
+      reporter: {update() {}},
+      onClose: () => {
+        onCloseResolve();
+      },
+    }));
+
+    expect(httpServer).toBeInstanceOf(http.Server);
+    expect(httpServer).not.toBeInstanceOf(https.Server);
+  });
+
+  test('should create HTTPS server when tls config with key/cert strings is provided', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    config.server.tls = {key: keyContent, cert: certContent};
+
+    let onCloseResolve;
+    serverClosedPromise = new Promise(resolve => (onCloseResolve = resolve));
+
+    ({httpServer} = await Metro.runServer(config, {
+      reporter: {update() {}},
+      onClose: () => {
+        onCloseResolve();
+      },
+    }));
+
+    expect(httpServer).toBeInstanceOf(https.Server);
+  });
+
+  test('should create HTTPS server with secureServerOptions', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    let onCloseResolve;
+    serverClosedPromise = new Promise(resolve => (onCloseResolve = resolve));
+
+    ({httpServer} = await Metro.runServer(config, {
+      reporter: {update() {}},
+      secureServerOptions: {key: keyContent, cert: certContent},
+      onClose: () => {
+        onCloseResolve();
+      },
+    }));
+
+    expect(httpServer).toBeInstanceOf(https.Server);
+  });
+
+  test('should create HTTPS server with deprecated secureKey/secureCert file paths', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    let onCloseResolve;
+    serverClosedPromise = new Promise(resolve => (onCloseResolve = resolve));
+
+    // Suppress deprecation warning for test
+    const originalWarn = console.warn;
+    console.warn = jest.fn();
+
+    try {
+      ({httpServer} = await Metro.runServer(config, {
+        reporter: {update() {}},
+        secure: true,
+        secureKey: keyFile,
+        secureCert: certFile,
+        onClose: () => {
+          onCloseResolve();
+        },
+      }));
+
+      expect(httpServer).toBeInstanceOf(https.Server);
+      expect(console.warn).toHaveBeenCalled();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test('tls config should take precedence over secureKey/secureCert', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    // Set tls config with valid certs
+    config.server.tls = {key: keyContent, cert: certContent};
+
+    let onCloseResolve;
+    serverClosedPromise = new Promise(resolve => (onCloseResolve = resolve));
+
+    // Suppress deprecation warning for test
+    const originalWarn = console.warn;
+    console.warn = jest.fn();
+
+    try {
+      // Pass invalid file paths - if tls config takes precedence, these won't be read
+      ({httpServer} = await Metro.runServer(config, {
+        reporter: {update() {}},
+        secure: true,
+        secureKey: '/nonexistent/key.pem',
+        secureCert: '/nonexistent/cert.pem',
+        onClose: () => {
+          onCloseResolve();
+        },
+      }));
+
+      // Server should start successfully using tls config
+      expect(httpServer).toBeInstanceOf(https.Server);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test('secureServerOptions should merge with tls config', async () => {
+    const config = await Metro.loadConfig({
+      config: require.resolve('../metro.config.js'),
+    });
+
+    // Set tls config with key/cert
+    config.server.tls = {key: keyContent, cert: certContent};
+
+    let onCloseResolve;
+    serverClosedPromise = new Promise(resolve => (onCloseResolve = resolve));
+
+    ({httpServer} = await Metro.runServer(config, {
+      reporter: {update() {}},
+      // secureServerOptions should be spread into the options
+      secureServerOptions: {
+        // This option should be merged in
+        rejectUnauthorized: false,
+      },
+      onClose: () => {
+        onCloseResolve();
+      },
+    }));
+
+    expect(httpServer).toBeInstanceOf(https.Server);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,6 +1097,11 @@
     "@jsonjoy.com/buffers" "^1.0.0"
     "@jsonjoy.com/codegen" "^1.0.0"
 
+"@noble/hashes@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1117,6 +1122,129 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@peculiar/asn1-cms@^2.6.0", "@peculiar/asn1-cms@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz#cb5445c1bad9197d176073bf142a5c035b460640"
+  integrity sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.1"
+    "@peculiar/asn1-x509-attr" "^2.6.1"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-csr@^2.6.0":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz#9629d403bc5a61254f28ed0b90e99cee61c0e8be"
+  integrity sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.1"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-ecc@^2.6.0":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz#d29c4af671508a9934edc78e7c9419fbf7bc9870"
+  integrity sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.1"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pfx@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz#75cddd14d43ef875109e91ea150377d679c8fbc1"
+  integrity sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.6.1"
+    "@peculiar/asn1-pkcs8" "^2.6.1"
+    "@peculiar/asn1-rsa" "^2.6.1"
+    "@peculiar/asn1-schema" "^2.6.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pkcs8@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz#bd56b4bb9e8a3702369049713a89134c87c6931a"
+  integrity sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.1"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pkcs9@^2.6.0":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz#ddc5222952f25b59a0562a6f8cabdb72f586a496"
+  integrity sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.6.1"
+    "@peculiar/asn1-pfx" "^2.6.1"
+    "@peculiar/asn1-pkcs8" "^2.6.1"
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.1"
+    "@peculiar/asn1-x509-attr" "^2.6.1"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-rsa@^2.6.0", "@peculiar/asn1-rsa@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz#2cdf9f9ea6d6fdbaae214b9fed6de0534b654437"
+  integrity sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.1"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-schema@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz#0dca1601d5b0fed2a72fed7a5f1d0d7dbe3a6f82"
+  integrity sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==
+  dependencies:
+    asn1js "^3.0.6"
+    pvtsutils "^1.3.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-x509-attr@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz#6425008b8099476010aace5b8ae9f9cbc41db0ab"
+  integrity sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.1"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-x509@^2.6.0", "@peculiar/asn1-x509@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz#4e8995659e16178e0e90fe90519aa269045af262"
+  integrity sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.6.0"
+    asn1js "^3.0.6"
+    pvtsutils "^1.3.6"
+    tslib "^2.8.1"
+
+"@peculiar/x509@^1.14.2":
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/@peculiar/x509/-/x509-1.14.3.tgz#2c44c2b89474346afec38a0c2803ec4fb8ce959e"
+  integrity sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.6.0"
+    "@peculiar/asn1-csr" "^2.6.0"
+    "@peculiar/asn1-ecc" "^2.6.0"
+    "@peculiar/asn1-pkcs9" "^2.6.0"
+    "@peculiar/asn1-rsa" "^2.6.0"
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.0"
+    pvtsutils "^1.3.6"
+    reflect-metadata "^0.2.2"
+    tslib "^2.8.1"
+    tsyringe "^4.10.0"
 
 "@react-native/babel-plugin-codegen@0.78.0":
   version "0.78.0"
@@ -1755,6 +1883,15 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
+asn1js@^3.0.6:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.7.tgz#15f1f2f59e60f80d5b43ef14047a294a969f824f"
+  integrity sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==
+  dependencies:
+    pvtsutils "^1.3.6"
+    pvutils "^1.1.3"
+    tslib "^2.8.1"
+
 ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
@@ -1965,6 +2102,11 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+bytestreamjs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/bytestreamjs/-/bytestreamjs-2.0.1.tgz#a32947c7ce389a6fa11a09a9a563d0a45889535e"
+  integrity sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==
 
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -4643,6 +4785,18 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkijs@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/pkijs/-/pkijs-3.3.3.tgz#b3f04d7b2eaacb05c81675f882be374e591626ec"
+  integrity sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+    asn1js "^3.0.6"
+    bytestreamjs "^2.0.1"
+    pvtsutils "^1.3.6"
+    pvutils "^1.1.3"
+    tslib "^2.8.1"
+
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
@@ -4704,6 +4858,18 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
   integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
 
+pvtsutils@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.6.tgz#ec46e34db7422b9e4fdc5490578c1883657d6001"
+  integrity sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==
+  dependencies:
+    tslib "^2.8.1"
+
+pvutils@^1.1.3:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.5.tgz#84b0dea4a5d670249aa9800511804ee0b7c2809c"
+  integrity sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -4759,6 +4925,11 @@ recast@^0.23.9:
     source-map "~0.6.1"
     tiny-invariant "^1.3.3"
     tslib "^2.0.1"
+
+reflect-metadata@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -4942,6 +5113,14 @@ scheduler@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
+
+selfsigned@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-5.5.0.tgz#4c9ab7c7c9f35f18fb6a9882c253eb0e6bd6557b"
+  integrity sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==
+  dependencies:
+    "@peculiar/x509" "^1.14.2"
+    pkijs "^3.3.3"
 
 semver@^5.6.0:
   version "5.7.2"
@@ -5382,10 +5561,22 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.1:
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tsyringe@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/tsyringe/-/tsyringe-4.10.0.tgz#d0c95815d584464214060285eaaadd94aa03299c"
+  integrity sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==
+  dependencies:
+    tslib "^1.9.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Summary: [Feature] `config.server.tls` now sets Metro to be exposed as an https server

Differential Revision: D93857257


