### PR TITLE
Restore publishing of `.d.ts` files

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -72,8 +72,10 @@ function buildPackage(p /*: string */) {
   const typesDir = path.resolve(p, TYPES_DIR);
   const buildDir = path.resolve(p, BUILD_DIR);
   const pattern = path.resolve(srcDir, '**/*');
-  const files = globSync(pattern, {onlyFiles: true});
-  const typescriptDefs = globSync(path.join(typesDir, '**/*.d.ts'));
+  const files = globSync(pattern, {absolute: true, onlyFiles: true});
+  const typescriptDefs = globSync(path.join(typesDir, '**/*.d.ts'), {
+    absolute: true,
+  });
 
   process.stdout.write(fixedWidth(`${path.basename(p)}\n`));
 


### PR DESCRIPTION
Summary:
https://github.com/facebook/metro/pull/1627 inadvertently broke publishing of `.d.ts` files, which are meant to be copied to the build directory alongside `.js` files prior to publishing, because `tinyglobby`, unlike `glob`, defaults to producing relative paths, breaking a `filePath.replace()`.

This affected 0.83.4, 0.84.0 and 0.84.1.

This restores it, we'll backport to 0.83.

Changelog:
```
 - **[Fix]**: Restore accidentally removed publication of TypeScript types
```

Differential Revision: D94666464


