### PR TITLE
fix: Add ESM unwrapping to all CommonJS require calls

### DIFF
--- a/packages/metro-file-map/src/plugins/DependencyPlugin.js
+++ b/packages/metro-file-map/src/plugins/DependencyPlugin.js
@@ -76,7 +76,9 @@ export default class DependencyPlugin
     if (this.#dependencyExtractor != null) {
       // Dynamic require to get extractor's cache key
       // $FlowFixMe[unsupported-syntax] - dynamic require
-      const extractor = require(this.#dependencyExtractor);
+      const mod = require(this.#dependencyExtractor);
+      const extractor =
+        mod.__esModule === true && 'default' in mod ? mod.default : mod;
       return JSON.stringify({
         extractorKey: extractor.getCacheKey?.() ?? null,
         extractorPath: this.#dependencyExtractor,

--- a/packages/metro-file-map/src/plugins/dependencies/worker.js
+++ b/packages/metro-file-map/src/plugins/dependencies/worker.js
@@ -27,7 +27,9 @@ module.exports = class DependencyExtractorWorker /*:: implements MetadataWorker 
   ) {
     if (dependencyExtractor != null) {
       // $FlowFixMe[unsupported-syntax] - dynamic require
-      this.#dependencyExtractor = require(dependencyExtractor);
+      const mod = require(dependencyExtractor);
+      this.#dependencyExtractor =
+        mod.__esModule === true && 'default' in mod ? mod.default : mod;
     }
   }
 

--- a/packages/metro-file-map/src/plugins/haste/worker.js
+++ b/packages/metro-file-map/src/plugins/haste/worker.js
@@ -30,7 +30,9 @@ module.exports = class Worker /*:: implements MetadataWorker */ {
   ) {
     if (hasteImplModulePath != null) {
       // $FlowFixMe[unsupported-syntax] - dynamic require
-      this.#hasteImpl = require(hasteImplModulePath);
+      const mod = require(hasteImplModulePath);
+      this.#hasteImpl =
+        mod.__esModule === true && 'default' in mod ? mod.default : mod;
     }
   }
 

--- a/packages/metro-file-map/src/worker.js
+++ b/packages/metro-file-map/src/worker.js
@@ -36,7 +36,9 @@ class Worker {
   constructor({plugins = []} /*: WorkerSetupArgs */) {
     this.#plugins = plugins.map(({modulePath, setupArgs}) => {
       // $FlowFixMe[unsupported-syntax] - dynamic require
-      const PluginWorker = require(modulePath);
+      const mod = require(modulePath);
+      const PluginWorker =
+        mod.__esModule === true && 'default' in mod ? mod.default : mod;
       return new PluginWorker(setupArgs);
     });
   }

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -542,7 +542,9 @@ async function transformJSWithBabel(
 ): Promise<TransformResponse> {
   const {babelTransformerPath} = context.config;
   // $FlowFixMe[unsupported-syntax] dynamic require
-  const transformer: BabelTransformer = require(babelTransformerPath);
+  const mod = require(babelTransformerPath);
+  const transformer: BabelTransformer =
+    mod.__esModule === true && 'default' in mod ? mod.default : mod;
 
   const transformResult = await transformer.transform(
     getBabelTransformArgs(file, context, [

--- a/packages/metro-transform-worker/src/utils/getMinifier.js
+++ b/packages/metro-transform-worker/src/utils/getMinifier.js
@@ -17,7 +17,8 @@ export default function getMinifier(minifierPath: string): Minifier {
   // any entry point that accepts them...
   try {
     // $FlowFixMe[unsupported-syntax] TODO t0 cannot do require with literal
-    return require(minifierPath);
+    const mod = require(minifierPath);
+    return mod.__esModule === true && 'default' in mod ? mod.default : mod;
   } catch (e) {
     throw new Error(
       'A problem occurred while trying to fetch the minifier. Path: "' +

--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -249,7 +249,10 @@ async function applyAssetDataPlugins(
 
   const [currentAssetPlugin, ...remainingAssetPlugins] = assetDataPlugins;
   // $FlowFixMe[unsupported-syntax]: impossible to type a dynamic require.
-  const assetPluginFunction: AssetDataPlugin = require(currentAssetPlugin);
+  const mod = require(currentAssetPlugin);
+  const assetPluginFunction: AssetDataPlugin =
+    mod.__esModule === true && 'default' in mod ? mod.default : mod;
+
   const resultAssetData = await assetPluginFunction(assetData);
   return await applyAssetDataPlugins(remainingAssetPlugins, resultAssetData);
 }


### PR DESCRIPTION
## Summary

This was added to `loadConfig.js` but is missing in other places. While it's arguably not useful in many cases in a "standard" Metro setup with Metro's own packages, it'd be nice to have this behave consistently even with transpiled ESM output (or with require-ESM in Node).

Specifically this affects:
- metro-file-map plugin workers that are loaded with `require`
- metro-file-map's main worker loading
- metro's asset plugins
- metro-transform-worker's `getMinifier` implementation
- metro-transform-worker's `babelTransformerPath` loading

This is probably specifically interesting for `babelTransformerPath` which is often overridden by third-party setups.

Changelog: [Fix] Unwrap ES modules when requiring metro-file-map workers, asset plugins, the minifier, or the babel transformer

## Test plan

- n/a: This will likely be best left untested, but is a consistent implementation that matches ESM->CJS semantics, also used in `loadConfig.js`
