### PR TITLE
refactor: Tweak metro-resolver's Node module resolution hot-path

### DIFF
--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -166,26 +166,6 @@ export default function resolve(
 
   const {disableHierarchicalLookup} = context;
 
-  const buildNodeModulePaths = () => {
-    const nodeModulesPaths: string[] = [];
-
-    if (!disableHierarchicalLookup) {
-      let next = path.dirname(originModulePath);
-      let candidate;
-      do {
-        candidate = next;
-        const nodeModulesPath = candidate.endsWith(path.sep)
-          ? candidate + 'node_modules'
-          : candidate + path.sep + 'node_modules';
-        nodeModulesPaths.push(nodeModulesPath);
-        next = path.dirname(candidate);
-      } while (candidate !== next);
-    }
-
-    nodeModulesPaths.push(...context.nodeModulesPaths);
-    return nodeModulesPaths;
-  };
-
   const resolveModuleFromTargetPath = (
     targetPath: string,
   ): Resolution | null => {
@@ -287,10 +267,33 @@ export default function resolve(
     }
   }
 
-  throw new FailedToResolveNameError(
-    buildNodeModulePaths(),
+  throw buildFailedToResolveNameError(
+    context,
     extraNodeModulePath != null ? [extraNodeModulePath] : [],
   );
+}
+
+function buildFailedToResolveNameError(
+  context: ResolutionContext,
+  extraPaths: ReadonlyArray<string>,
+): FailedToResolveNameError {
+  const nodeModulesPaths: string[] = [];
+
+  if (!context.disableHierarchicalLookup) {
+    let next = path.dirname(context.originModulePath);
+    let candidate;
+    do {
+      candidate = next;
+      const nodeModulesPath = candidate.endsWith(path.sep)
+        ? candidate + 'node_modules'
+        : candidate + path.sep + 'node_modules';
+      nodeModulesPaths.push(nodeModulesPath);
+      next = path.dirname(candidate);
+    } while (candidate !== next);
+  }
+
+  nodeModulesPaths.push(...context.nodeModulesPaths);
+  return new FailedToResolveNameError(nodeModulesPaths, extraPaths);
 }
 
 function parseBareSpecifier(specifier: string): ParsedBareSpecifier {

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -166,57 +166,30 @@ export default function resolve(
 
   const {disableHierarchicalLookup} = context;
 
-  const nodeModulesPaths = [];
-  let next = path.dirname(originModulePath);
+  const buildNodeModulePaths = () => {
+    const nodeModulesPaths: string[] = [];
 
-  if (!disableHierarchicalLookup) {
-    let candidate;
-    do {
-      candidate = next;
-      const nodeModulesPath = candidate.endsWith(path.sep)
-        ? candidate + 'node_modules'
-        : candidate + path.sep + 'node_modules';
-      nodeModulesPaths.push(nodeModulesPath);
-      next = path.dirname(candidate);
-    } while (candidate !== next);
-  }
+    if (!disableHierarchicalLookup) {
+      let next = path.dirname(originModulePath);
+      let candidate;
+      do {
+        candidate = next;
+        const nodeModulesPath = candidate.endsWith(path.sep)
+          ? candidate + 'node_modules'
+          : candidate + path.sep + 'node_modules';
+        nodeModulesPaths.push(nodeModulesPath);
+        next = path.dirname(candidate);
+      } while (candidate !== next);
+    }
 
-  // Fall back to `nodeModulesPaths` after hierarchical lookup, similar to $NODE_PATH
-  nodeModulesPaths.push(...context.nodeModulesPaths);
+    nodeModulesPaths.push(...context.nodeModulesPaths);
+    return nodeModulesPaths;
+  };
 
-  const extraPaths = [];
-
-  const {extraNodeModules} = context;
-  if (extraNodeModules && extraNodeModules[parsedSpecifier.packageName]) {
-    const newPackageName = extraNodeModules[parsedSpecifier.packageName];
-    extraPaths.push(path.join(newPackageName, parsedSpecifier.posixSubpath));
-  }
-
-  const allDirPaths = nodeModulesPaths
-    .map(nodeModulePath => {
-      let lookupResult = null;
-      // Insight: The module can only exist if there is a `node_modules` at
-      // this path. Redirections cannot succeed, because we will never look
-      // beyond a node_modules path segment for finding the closest
-      // package.json. Moreover, if the specifier contains a '/' separator,
-      // the first part *must* be a real directory, because it is the
-      // shallowest path that can possibly contain a redirecting package.json.
-      const mustBeDirectory =
-        parsedSpecifier.posixSubpath !== '.' ||
-        parsedSpecifier.packageName.length > parsedSpecifier.firstPart.length
-          ? nodeModulePath + path.sep + parsedSpecifier.firstPart
-          : nodeModulePath;
-      lookupResult = context.fileSystemLookup(mustBeDirectory);
-      if (!lookupResult.exists || lookupResult.type !== 'd') {
-        return null;
-      }
-      return path.join(nodeModulePath, realModuleName);
-    })
-    .filter(Boolean)
-    .concat(extraPaths);
-  for (let i = 0; i < allDirPaths.length; ++i) {
-    const candidate = redirectModulePath(context, allDirPaths[i]);
-
+  const resolveModuleFromTargetPath = (
+    targetPath: string,
+  ): Resolution | null => {
+    const candidate = redirectModulePath(context, targetPath);
     if (candidate === false) {
       return {type: 'empty'};
     }
@@ -227,9 +200,97 @@ export default function resolve(
     if (result.type === 'resolved') {
       return result.resolution;
     }
+
+    return null;
+  };
+
+  const resolveModulePathFromNodeModulePath = (
+    nodeModulePath: string,
+  ): Resolution | null => {
+    // Insight: The module can only exist if there is a `node_modules` at
+    // this path. Redirections cannot succeed, because we will never look
+    // beyond a node_modules path segment for finding the closest
+    // package.json. Moreover, if the specifier contains a '/' separator,
+    // the first part *must* be a real directory, because it is the
+    // shallowest path that can possibly contain a redirecting package.json.
+    const mustBeDirectory =
+      parsedSpecifier.posixSubpath !== '.' ||
+      parsedSpecifier.packageName.length > parsedSpecifier.firstPart.length
+        ? nodeModulePath + path.sep + parsedSpecifier.firstPart
+        : nodeModulePath;
+    const lookupResult = context.fileSystemLookup(mustBeDirectory);
+    if (!lookupResult.exists || lookupResult.type !== 'd') {
+      return null;
+    } else {
+      return resolveModuleFromTargetPath(
+        path.join(nodeModulePath, realModuleName),
+      );
+    }
+  };
+
+  if (!disableHierarchicalLookup) {
+    const visited: {[string]: ?true, __proto__: null} = Object.create(null);
+    let next = path.dirname(originModulePath);
+    let candidate;
+    do {
+      candidate = next;
+      const nodeModulesPath = candidate.endsWith(path.sep)
+        ? candidate + 'node_modules'
+        : candidate + path.sep + 'node_modules';
+
+      const resolution = resolveModulePathFromNodeModulePath(nodeModulesPath);
+      if (resolution != null) {
+        return resolution;
+      }
+
+      visited[nodeModulesPath] = true;
+      next = path.dirname(candidate);
+    } while (candidate !== next);
+
+    // Fall back to `nodeModulesPaths` after hierarchical lookup, similar to $NODE_PATH
+    // This is done separately from the else branch below to save an allocation and check `visited`
+    for (let i = 0; i < context.nodeModulesPaths.length; i++) {
+      // Skip already checked paths, since this could contain duplicates that we already checked
+      if (visited[context.nodeModulesPaths[i]]) {
+        continue;
+      }
+      const resolution = resolveModulePathFromNodeModulePath(
+        context.nodeModulesPaths[i],
+      );
+      if (resolution != null) {
+        return resolution;
+      }
+    }
+  } else {
+    // Only visit `nodeModulesPaths` when hierarchical lookup is disabled
+    for (let i = 0; i < context.nodeModulesPaths.length; i++) {
+      const resolution = resolveModulePathFromNodeModulePath(
+        context.nodeModulesPaths[i],
+      );
+      if (resolution != null) {
+        return resolution;
+      }
+    }
   }
 
-  throw new FailedToResolveNameError(nodeModulesPaths, extraPaths);
+  const {extraNodeModules} = context;
+  let extraNodeModulePath: string | void;
+  if (extraNodeModules && extraNodeModules[parsedSpecifier.packageName]) {
+    const newPackageName = extraNodeModules[parsedSpecifier.packageName];
+    extraNodeModulePath = path.join(
+      newPackageName,
+      parsedSpecifier.posixSubpath,
+    );
+    const resolution = resolveModuleFromTargetPath(extraNodeModulePath);
+    if (resolution != null) {
+      return resolution;
+    }
+  }
+
+  throw new FailedToResolveNameError(
+    buildNodeModulePaths(),
+    extraNodeModulePath != null ? [extraNodeModulePath] : [],
+  );
 }
 
 function parseBareSpecifier(specifier: string): ParsedBareSpecifier {

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -166,25 +166,7 @@ export default function resolve(
 
   const {disableHierarchicalLookup} = context;
 
-  const resolveModuleFromTargetPath = (
-    targetPath: string,
-  ): Resolution | null => {
-    const candidate = redirectModulePath(context, targetPath);
-    if (candidate === false) {
-      return {type: 'empty'};
-    }
-
-    // candidate should be absolute here - we assume that redirectModulePath
-    // always returns an absolute path when given an absolute path.
-    const result = resolvePackage(context, candidate, platform);
-    if (result.type === 'resolved') {
-      return result.resolution;
-    }
-
-    return null;
-  };
-
-  const resolveModulePathFromNodeModulePath = (
+  const resolveFromNodeModulesPath = (
     nodeModulePath: string,
   ): Resolution | null => {
     // Insight: The module can only exist if there is a `node_modules` at
@@ -201,11 +183,12 @@ export default function resolve(
     const lookupResult = context.fileSystemLookup(mustBeDirectory);
     if (!lookupResult.exists || lookupResult.type !== 'd') {
       return null;
-    } else {
-      return resolveModuleFromTargetPath(
-        path.join(nodeModulePath, realModuleName),
-      );
     }
+    return resolveModuleFromTargetPath(
+      context,
+      platform,
+      path.join(nodeModulePath, realModuleName),
+    );
   };
 
   if (!disableHierarchicalLookup) {
@@ -218,7 +201,7 @@ export default function resolve(
         ? candidate + 'node_modules'
         : candidate + path.sep + 'node_modules';
 
-      const resolution = resolveModulePathFromNodeModulePath(nodeModulesPath);
+      const resolution = resolveFromNodeModulesPath(nodeModulesPath);
       if (resolution != null) {
         return resolution;
       }
@@ -234,7 +217,7 @@ export default function resolve(
       if (visited[context.nodeModulesPaths[i]]) {
         continue;
       }
-      const resolution = resolveModulePathFromNodeModulePath(
+      const resolution = resolveFromNodeModulesPath(
         context.nodeModulesPaths[i],
       );
       if (resolution != null) {
@@ -244,7 +227,7 @@ export default function resolve(
   } else {
     // Only visit `nodeModulesPaths` when hierarchical lookup is disabled
     for (let i = 0; i < context.nodeModulesPaths.length; i++) {
-      const resolution = resolveModulePathFromNodeModulePath(
+      const resolution = resolveFromNodeModulesPath(
         context.nodeModulesPaths[i],
       );
       if (resolution != null) {
@@ -261,7 +244,11 @@ export default function resolve(
       newPackageName,
       parsedSpecifier.posixSubpath,
     );
-    const resolution = resolveModuleFromTargetPath(extraNodeModulePath);
+    const resolution = resolveModuleFromTargetPath(
+      context,
+      platform,
+      extraNodeModulePath,
+    );
     if (resolution != null) {
       return resolution;
     }
@@ -271,6 +258,26 @@ export default function resolve(
     context,
     extraNodeModulePath != null ? [extraNodeModulePath] : [],
   );
+}
+
+function resolveModuleFromTargetPath(
+  context: ResolutionContext,
+  platform: string | null,
+  targetPath: string,
+): Resolution | null {
+  const candidate = redirectModulePath(context, targetPath);
+  if (candidate === false) {
+    return {type: 'empty'};
+  }
+
+  // candidate should be absolute here - we assume that redirectModulePath
+  // always returns an absolute path when given an absolute path.
+  const result = resolvePackage(context, candidate, platform);
+  if (result.type === 'resolved') {
+    return result.resolution;
+  }
+
+  return null;
 }
 
 function buildFailedToResolveNameError(

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -187,7 +187,7 @@ export default function resolve(
     return resolveModuleFromTargetPath(
       context,
       platform,
-      path.join(nodeModulePath, realModuleName),
+      nodeModulePath + path.sep + realModuleName,
     );
   };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The current implementation in `resolve.js` seems slightly optimised for readability over performance, but is a hot-path that is highly impactful for bundling performance. This is slightly amplified depending on the depth of folders.

This branch aims to:
- eliminate redundant `fileSystem.lookup` and instead resolve immediately and return the earliest result
- avoid redundant array allocations and instead iterate target paths directly
- delay building a full array of target `nodeModulesPaths` when a `FailedToResolveNameError` is constructed

While this interleaves the actual resolution, avoiding redundant work and allocations makes up for this.

A very primitive (LLM-authored) benchmark can be found here, which shows an up to 10% benefit or neutral results for resolution: https://github.com/kitten/metro/commit/a36d55825cb0d492d9ea5b7ac5f42b0b8e7b0a77

Changelog: [Internal] Refactor performance sensitive metro-resolver Node module resolution hot path

## Test plan

- CI tests should pass unchanged
