### PR TITLE
Add keepalive "heartbeat" message to Fast Refresh connections

### DIFF
--- a/packages/metro-runtime/src/modules/HMRClient.js
+++ b/packages/metro-runtime/src/modules/HMRClient.js
@@ -15,6 +15,8 @@ import type {HmrMessage, HmrUpdate} from './types';
 
 const EventEmitter = require('./vendor/eventemitter3');
 
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
 type SocketState = 'opening' | 'open' | 'closed';
 
 const inject = ({module: [id, code], sourceURL}: HmrModule) => {
@@ -39,6 +41,7 @@ class HMRClient extends EventEmitter {
   _queue: Array<string> = [];
   _state: SocketState = 'opening';
   _ws: WebSocket;
+  _heartbeatTimer: ?IntervalID = null;
 
   constructor(url: string) {
     super();
@@ -48,6 +51,7 @@ class HMRClient extends EventEmitter {
     this._ws = new global.WebSocket(url);
     this._ws.onopen = () => {
       this._state = 'open';
+      this._startHeartbeat();
       this.emit('open');
       this._flushQueue();
     };
@@ -56,12 +60,17 @@ class HMRClient extends EventEmitter {
     };
     this._ws.onclose = closeEvent => {
       this._state = 'closed';
+      this._stopHeartbeat();
       this.emit('close', closeEvent);
     };
     this._ws.onmessage = message => {
       const data: HmrMessage = JSON.parse(String(message.data));
 
       switch (data.type) {
+        case 'heartbeat':
+          // Not exposed to consumers
+          break;
+
         case 'bundle-registered':
           this.emit('bundle-registered');
           break;
@@ -121,6 +130,22 @@ class HMRClient extends EventEmitter {
   _flushQueue(): void {
     this._queue.forEach(message => this.send(message));
     this._queue.length = 0;
+  }
+
+  _startHeartbeat(): void {
+    this._stopHeartbeat();
+    this._heartbeatTimer = setInterval(() => {
+      if (this._state === 'open') {
+        this._ws.send('{"type":"heartbeat"}');
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  _stopHeartbeat(): void {
+    if (this._heartbeatTimer != null) {
+      clearInterval(this._heartbeatTimer);
+      this._heartbeatTimer = null;
+    }
   }
 
   enable() {

--- a/packages/metro-runtime/src/modules/types.js
+++ b/packages/metro-runtime/src/modules/types.js
@@ -83,6 +83,9 @@ export type HmrClientMessage =
     }
   | {
       +type: 'log-opt-in',
+    }
+  | {
+      +type: 'heartbeat',
     };
 
 export type HmrMessage =
@@ -100,4 +103,7 @@ export type HmrMessage =
       +body?: {+changeId?: string},
     }
   | HmrUpdateMessage
-  | HmrErrorMessage;
+  | HmrErrorMessage
+  | {
+      +type: 'heartbeat',
+    };

--- a/packages/metro-runtime/types/modules/types.d.ts
+++ b/packages/metro-runtime/types/modules/types.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<b7200f697fbdbb3b71cc1049801258af>>
+ * @generated SignedSource<<117ae8d35a498c8c16f22a36d6ee14ef>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-runtime/src/modules/types.js
@@ -87,7 +87,8 @@ export type HmrClientMessage =
         | 'debug';
       readonly data: Array<unknown>;
     }
-  | {readonly type: 'log-opt-in'};
+  | {readonly type: 'log-opt-in'}
+  | {readonly type: 'heartbeat'};
 export type HmrMessage =
   | {readonly type: 'bundle-registered'}
   | {
@@ -99,4 +100,5 @@ export type HmrMessage =
       readonly body?: {readonly changeId?: string};
     }
   | HmrUpdateMessage
-  | HmrErrorMessage;
+  | HmrErrorMessage
+  | {readonly type: 'heartbeat'};

--- a/packages/metro/src/HmrServer.js
+++ b/packages/metro/src/HmrServer.js
@@ -241,6 +241,10 @@ export default class HmrServer<TClient extends Client> {
         case 'log-opt-in':
           client.optedIntoHMR = true;
           break;
+        case 'heartbeat':
+          debug('Heartbeat received');
+          sendFn(String(message));
+          break;
         default:
           break;
       }


### PR DESCRIPTION
Summary:
Add a heartbeat mechanism, initially to prevent idle timeouts in (e.g) HTTP proxy configurations. Later we'll use it to detect broken connections.

The client sends a periodic `{"type":"heartbeat"}` message every 20s; the server echoes it back.

Although server and client versions potentially differ, this is non-breaking:
 - If the server doesn't recognise the `heartbeat` message, it simply ignores it. The client doesn't require a reply (yet).
 - The server never sends `heartbeat` except in reply, so a client doesn't need to support it. The server doesn't care if the client never sends it (yet).

Changelog:
```
 - **[Feature]** Add keepalive "heartbeat" message to Fast Refresh connections
```

Reviewed By: huntie

Differential Revision: D100320458


