### PR TITLE
Replace chalk with Node core util.styleText

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -27,7 +27,6 @@
     "@babel/traverse": "^7.29.0",
     "@babel/types": "^7.29.0",
     "accepts": "^2.0.0",
-    "chalk": "^4.0.0",
     "ci-info": "^2.0.0",
     "connect": "^3.6.5",
     "debug": "^4.4.0",

--- a/packages/metro/src/index.flow.js
+++ b/packages/metro/src/index.flow.js
@@ -41,7 +41,6 @@ import JsonReporter from './lib/JsonReporter';
 import TerminalReporter from './lib/TerminalReporter';
 import MetroServer from './Server';
 import * as outputBundle from './shared/output/bundle';
-import chalk from 'chalk';
 import fs from 'fs';
 import http from 'http';
 import https from 'https';
@@ -54,6 +53,7 @@ import {
 import {Terminal} from 'metro-core';
 import net from 'net';
 import nullthrows from 'nullthrows';
+import util from 'util';
 
 const DEFAULTS = MetroServer.DEFAULT_BUNDLE_OPTIONS;
 
@@ -296,7 +296,7 @@ export const runServer = async (
   if (secure != null || secureCert != null || secureKey != null) {
     // eslint-disable-next-line no-console
     console.warn(
-      chalk.inverse.yellow.bold(' DEPRECATED '),
+      util.styleText(['inverse', 'yellow', 'bold'], ' DEPRECATED '),
       'The `secure`, `secureCert`, and `secureKey` options are now deprecated. ' +
         'Please use the `secureServerOptions` object instead to pass options to ' +
         "Metro's https development server, or `config.server.tls` in Metro's configuration",

--- a/packages/metro/src/lib/TerminalReporter.js
+++ b/packages/metro/src/lib/TerminalReporter.js
@@ -12,15 +12,22 @@
 import type {BundleDetails, ReportableEvent} from './reporting';
 import type {Terminal} from 'metro-core';
 import type {HealthCheckResult, WatcherStatus} from 'metro-file-map';
+import type {BackgroundColors, ForegroundColors, Modifiers} from 'util';
 
 import {calculateBundleProgressRatio} from './bundleProgressUtils';
 import logToConsole from './logToConsole';
 import * as reporting from './reporting';
-import chalk from 'chalk';
 // $FlowFixMe[untyped-import] lodash.throttle
 import throttle from 'lodash.throttle';
 import {AmbiguousModuleResolutionError} from 'metro-core';
 import path from 'path';
+import util from 'util';
+
+type StyleFormat = $ReadOnlyArray<
+  ForegroundColors | BackgroundColors | Modifiers,
+>;
+const style = (format: StyleFormat, text: string): string =>
+  util.styleText(format, text);
 
 type BundleProgress = {
   bundleDetails: BundleDetails,
@@ -121,28 +128,30 @@ export default class TerminalReporter {
   ): string {
     const localPath = path.relative('.', entryFile);
     const filledBar = Math.floor(ratio * MAX_PROGRESS_BAR_CHAR_WIDTH);
-    const bundleTypeColor =
+    const bundleTypeColor: StyleFormat =
       phase === 'done'
-        ? chalk.green
+        ? ['green']
         : phase === 'failed'
-          ? chalk.red
-          : chalk.yellow;
+          ? ['red']
+          : ['yellow'];
     const progress =
       phase === 'in_progress'
-        ? chalk.green.bgGreen(DARK_BLOCK_CHAR.repeat(filledBar)) +
-          chalk.bgWhite.white(
+        ? style(['green', 'bgGreen'], DARK_BLOCK_CHAR.repeat(filledBar)) +
+          style(
+            ['bgWhite', 'white'],
             LIGHT_BLOCK_CHAR.repeat(MAX_PROGRESS_BAR_CHAR_WIDTH - filledBar),
           ) +
-          chalk.bold(` ${Math.floor(100 * ratio)}% `) +
-          chalk.dim(`(${transformedFileCount}/${totalFileCount})`)
+          style(['bold'], ` ${Math.floor(100 * ratio)}% `) +
+          style(['dim'], `(${transformedFileCount}/${totalFileCount})`)
         : '';
 
     return (
-      bundleTypeColor.inverse.bold(
+      style(
+        [...bundleTypeColor, 'inverse', 'bold'],
         ` ${isPrefetch === true ? 'PREBUNDLE' : bundleType.toUpperCase()} `,
       ) +
-      chalk.reset.dim(` ${path.dirname(localPath)}/`) +
-      chalk.bold(path.basename(localPath)) +
+      style(['reset', 'dim'], ` ${path.dirname(localPath)}/`) +
+      style(['bold'], path.basename(localPath)) +
       ' ' +
       progress
     );
@@ -191,31 +200,37 @@ export default class TerminalReporter {
       '',
     ];
 
-    const color = hasReducedPerformance ? chalk.red : chalk.blue;
-    this.terminal.log(color(logo.join('\n')));
+    const color: StyleFormat = hasReducedPerformance ? ['red'] : ['blue'];
+    this.terminal.log(style(color, logo.join('\n')));
   }
 
   _logInitializingFailed(port: number, error: SnippetError): void {
     if (error.code === 'EADDRINUSE') {
       this.terminal.log(
-        chalk.bgRed.bold(' ERROR '),
-        chalk.red("Metro can't listen on port", chalk.bold(String(port))),
+        style(['bgRed', 'bold'], ' ERROR '),
+        style(
+          ['red'],
+          `Metro can't listen on port ${style(['bold'], String(port))}`,
+        ),
       );
       this.terminal.log(
         'Most likely another process is already using this port',
       );
       this.terminal.log('Run the following command to find out which process:');
-      this.terminal.log('\n  ', chalk.bold('lsof -i :' + port), '\n');
+      this.terminal.log('\n  ', style(['bold'], 'lsof -i :' + port), '\n');
       this.terminal.log('Then, you can either shut down the other process:');
-      this.terminal.log('\n  ', chalk.bold('kill -9 <PID>'), '\n');
+      this.terminal.log('\n  ', style(['bold'], 'kill -9 <PID>'), '\n');
       this.terminal.log('or run Metro on different port.');
     } else {
-      this.terminal.log(chalk.bgRed.bold(' ERROR '), chalk.red(error.message));
+      this.terminal.log(
+        style(['bgRed', 'bold'], ' ERROR '),
+        style(['red'], error.message),
+      );
       const errorAttributes = JSON.stringify(error);
       if (errorAttributes !== '{}') {
-        this.terminal.log(chalk.red(errorAttributes));
+        this.terminal.log(style(['red'], errorAttributes));
       }
-      this.terminal.log(chalk.red(error.stack));
+      this.terminal.log(style(['red'], String(error.stack)));
     }
   }
 
@@ -271,20 +286,26 @@ export default class TerminalReporter {
         logFn(this.terminal, String(format), ...args);
         break;
       case 'dep_graph_loading':
-        const color = event.hasReducedPerformance ? chalk.red : chalk.blue;
+        const color: StyleFormat = event.hasReducedPerformance
+          ? ['red']
+          : ['blue'];
         // eslint-disable-next-line import/no-commonjs
         // $FlowFixMe[untyped-import] package.json
         const version = 'v' + require('../../package.json').version;
         this.terminal.log(
-          color.bold(
-            ' '.repeat(19 - version.length / 2),
-            'Welcome to Metro ' + chalk.white(version) + '\n',
-          ) + chalk.dim('              Fast - Scalable - Integrated\n\n'),
+          style(
+            [...color, 'bold'],
+            ' '.repeat(19 - version.length / 2) +
+              ' Welcome to Metro ' +
+              style(['white'], version) +
+              '\n',
+          ) + style(['dim'], '              Fast - Scalable - Integrated\n\n'),
         );
 
         if (event.hasReducedPerformance) {
           this.terminal.log(
-            chalk.red(
+            style(
+              ['red'],
               'Metro is operating with reduced performance.\n' +
                 'Please fix the problem above and restart Metro.\n\n',
             ),
@@ -459,7 +480,7 @@ export default class TerminalReporter {
           // Only report success after a prior failure.
           if (this._prevHealthCheckResult) {
             this.terminal.log(
-              chalk.green(`Watcher ${watcherName} is now healthy.`),
+              style(['green'], `Watcher ${watcherName} is now healthy.`),
             );
           }
           break;
@@ -499,7 +520,8 @@ export default class TerminalReporter {
         break;
       case 'watchman_slow_command':
         this.terminal.log(
-          chalk.dim(
+          style(
+            ['dim'],
             `Waiting for Watchman \`${status.command}\` (${Math.round(
               status.timeElapsed / 1000,
             )}s)...`,
@@ -508,7 +530,8 @@ export default class TerminalReporter {
         break;
       case 'watchman_slow_command_complete':
         this.terminal.log(
-          chalk.green(
+          style(
+            ['green'],
             `Watchman \`${status.command}\` finished after ${(
               status.timeElapsed / 1000
             ).toFixed(1)}s.`,

--- a/packages/metro/src/lib/__tests__/logToConsole-test.js
+++ b/packages/metro/src/lib/__tests__/logToConsole-test.js
@@ -12,17 +12,6 @@
 
 'use strict';
 
-jest.mock('chalk', () => {
-  const bold = _ => _;
-  return {
-    inverse: {
-      red: {bold},
-      white: {bold},
-      yellow: {bold},
-    },
-  };
-});
-
 let log;
 
 beforeEach(() => {

--- a/packages/metro/src/lib/logToConsole.js
+++ b/packages/metro/src/lib/logToConsole.js
@@ -11,8 +11,8 @@
 /* eslint-disable no-console */
 
 import type {Terminal} from 'metro-core';
+import type {BackgroundColors, ForegroundColors, Modifiers} from 'util';
 
-import chalk from 'chalk';
 import util from 'util';
 
 const groupStack = [];
@@ -21,12 +21,14 @@ let collapsedGuardTimer;
 export default (terminal: Terminal, level: string, ...data: Array<unknown>) => {
   // $FlowFixMe[invalid-computed-prop]
   const logFunction = console[level] && level !== 'trace' ? level : 'log';
-  const color =
+  const color: $ReadOnlyArray<
+    ForegroundColors | BackgroundColors | Modifiers,
+  > =
     level === 'error'
-      ? chalk.inverse.red
+      ? ['inverse', 'red']
       : level === 'warn'
-        ? chalk.inverse.yellow
-        : chalk.inverse.white;
+        ? ['inverse', 'yellow']
+        : ['inverse', 'white'];
 
   if (level === 'group') {
     groupStack.push(level);
@@ -37,7 +39,7 @@ export default (terminal: Terminal, level: string, ...data: Array<unknown>) => {
     collapsedGuardTimer = setTimeout(() => {
       if (groupStack.includes('groupCollapsed')) {
         terminal.log(
-          chalk.inverse.yellow.bold(' WARN '),
+          util.styleText(['inverse', 'yellow', 'bold'], ' WARN '),
           'Expected `console.groupEnd` to be called after `console.groupCollapsed`.',
         );
         groupStack.length = 0;
@@ -60,7 +62,7 @@ export default (terminal: Terminal, level: string, ...data: Array<unknown>) => {
     }
 
     terminal.log(
-      color.bold(` ${logFunction.toUpperCase()} `) +
+      util.styleText([...color, 'bold'], ` ${logFunction.toUpperCase()} `) +
         ''.padEnd(groupStack.length * 2, ' '),
       // `util.format` actually accepts any arguments.
       // If the first argument is a string, it tries to format it.

--- a/packages/metro/src/lib/reporting.js
+++ b/packages/metro/src/lib/reporting.js
@@ -14,8 +14,11 @@ import type {HealthCheckResult, WatcherStatus} from 'metro-file-map';
 import type {CustomResolverOptions} from 'metro-resolver';
 import type {CustomTransformOptions} from 'metro-transform-worker';
 
-import chalk from 'chalk';
+import tty from 'tty';
 import util from 'util';
+
+const supportsColor = (): boolean =>
+  process.stdout instanceof tty.WriteStream && process.stdout.hasColors();
 
 export type BundleDetails = {
   bundleType: string,
@@ -190,7 +193,11 @@ export function logWarning(
   ...args: Array<unknown>
 ): void {
   const str = util.format(format, ...args);
-  terminal.log('%s %s', chalk.yellow.inverse.bold(' WARN '), str);
+  terminal.log(
+    '%s %s',
+    util.styleText(['yellow', 'inverse', 'bold'], ' WARN '),
+    str,
+  );
 }
 
 /**
@@ -203,13 +210,13 @@ export function logError(
 ): void {
   terminal.log(
     '%s %s',
-    chalk.red.inverse.bold(' ERROR '),
+    util.styleText(['red', 'inverse', 'bold'], ' ERROR '),
     // Syntax errors may have colors applied for displaying code frames
     // in various places outside of where Metro is currently running.
     // If the current terminal does not support color, we'll strip the colors
     // here.
     util.format(
-      chalk.supportsColor ? format : util.stripVTControlCharacters(format),
+      supportsColor() ? format : util.stripVTControlCharacters(format),
       ...args,
     ),
   );
@@ -224,7 +231,11 @@ export function logInfo(
   ...args: Array<unknown>
 ): void {
   const str = util.format(format, ...args);
-  terminal.log('%s %s', chalk.cyan.inverse.bold(' INFO '), str);
+  terminal.log(
+    '%s %s',
+    util.styleText(['cyan', 'inverse', 'bold'], ' INFO '),
+    str,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

All supported Node versions in `engines` ship `util.styleText` with the array-format API, removing the need for the chalk dependency.


