### PR TITLE
Fix: Resolving normalPath when it belongs to a separate drive location (as absolute path)

### DIFF
--- a/packages/metro-file-map/src/lib/RootPathUtils.js
+++ b/packages/metro-file-map/src/lib/RootPathUtils.js
@@ -150,6 +150,9 @@ export class RootPathUtils {
     if (right.length === 0) {
       return left;
     }
+    if (path.isAbsolute(right)) {
+      return right;
+    }
     // left may already end in a path separator only if it is a filesystem root,
     // '/' or 'X:\'.
     if (i === this.#rootDepth) {

--- a/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
@@ -110,6 +110,20 @@ describe.each([['win32'], ['posix']])('RootPathUtils on %s', platform => {
       expect(pathUtils.normalToAbsolute(normalPath)).toEqual(expected);
     });
 
+    if (platform === 'win32') {
+      test.each(['D:\\some\\file.js', 'D:\\some\\', 'D:\\'])(
+        `normalToAbsolute('%s') returns cross-drive absolute normal path as-is`,
+        normalPath => {
+          // On Windows, path.relative() returns an absolute path when source
+          // and target are on different drives. Such paths are stored as the
+          // "normal path" in the file map and must be returned as-is by
+          // normalToAbsolute rather than being prepended with rootDir (which
+          // would produce invalid paths like C:\project\root\D:\file.js).
+          expect(pathUtils.normalToAbsolute(normalPath)).toEqual(normalPath);
+        },
+      );
+    }
+
     test.each([
       p('..'),
       p('../root'),


### PR DESCRIPTION
## Summary

On Windows, path.relative() returns an absolute path when source and target are on different drives (e.g. Z:\ -> C:\...). In that case the stored "normal path" is already absolute, so return it as-is instead of prepending rootDir which would produce Z:\C:\... paths.

Changelog: [Fix] Fix resolution to absolute paths when the normalPath is an absolute path in another drive.

## Test plan

A new test case is added. When running the test case without the added fix, it will fail, showing the incorrect path resolution. If we run the test case after the fix is applied, the test case passes.
