### PR TITLE
Treat dynamic imports with rejection handlers as optional dependencies

### DIFF
--- a/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
@@ -1605,6 +1605,91 @@ describe('optional dependencies', () => {
       {name: 'foo', data: expect.not.objectContaining({isOptional: true})},
     ]);
   });
+
+  describe('dynamic import with rejection handler', () => {
+    test('import().catch(handler) is optional', () => {
+      const ast = astFromCode(`
+        import('optional-async-a').catch(() => {});
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    test('import().then(handler, onReject) is optional', () => {
+      const ast = astFromCode(`
+        import('optional-async-a').then(() => {}, () => {});
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    test('import().then(...).then(...).catch(handler) is optional', () => {
+      const ast = astFromCode(`
+        import('optional-async-a')
+          .then(x => x)
+          .then(x => x)
+          .catch(() => {});
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    test('await import().catch(handler) is optional', () => {
+      const ast = astFromCode(`
+        async function f() {
+          await import('optional-async-a').catch(() => {});
+        }
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    test('try { await import() } catch {} is optional', () => {
+      const ast = astFromCode(`
+        async function f() {
+          try {
+            await import('optional-async-a');
+          } catch (e) {}
+        }
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    test('import().then(handler) without onReject is not optional', () => {
+      const ast = astFromCode(`
+        import('not-optional-async-a').then(() => {});
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    test('import().catch() with no handler argument is not optional', () => {
+      const ast = astFromCode(`
+        import('not-optional-async-a').catch();
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+
+    test('import().then(handler, null) is not optional (null/undefined onReject)', () => {
+      const ast = astFromCode(`
+        import('not-optional-async-a').then(() => {}, null);
+        import('not-optional-async-b').then(() => {}, undefined);
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 3);
+    });
+
+    test('import() detached from chain is not optional', () => {
+      const ast = astFromCode(`
+        const p = import('not-optional-async-a');
+        p.catch(() => {});
+      `);
+      const {dependencies} = collectDependencies(ast, opts);
+      validateDependencies(dependencies, 2);
+    });
+  });
 });
 
 test('uses the dependency transformer specified in the options to transform the dependency calls', () => {

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -630,6 +630,15 @@ function isOptionalDependency(
     return false;
   }
 
+  // Treat dynamic imports as optional when a rejection handler is attached
+  // close to the import call, e.g.
+  //   import('x').catch(handler)
+  //   import('x').then(handler, onReject)
+  //   import('x').then(...).catch(handler)
+  if (isInPromiseChainWithRejectionHandler(path)) {
+    return true;
+  }
+
   // Valid statement stack for single-level try-block: expressionStatement -> blockStatement -> tryStatement
   let sCount = 0;
   let p: ?(NodePath<> | NodePath<BabelNode>) = path;
@@ -650,6 +659,64 @@ function isOptionalDependency(
   }
 
   return false;
+}
+
+// Walk up a chain of `.then(...)` / `.catch(...)` member calls starting from
+// `path` (typically an `import()` CallExpression) and return true if any
+// chained call provides a rejection handler — either `.catch(handler)` or
+// `.then(_, handler)`. The chain must be unbroken: as soon as the parent is
+// not a member call applied to the previous expression, we stop. This keeps
+// the heuristic local to the import, matching the behaviour of the
+// try/catch heuristic above.
+function isInPromiseChainWithRejectionHandler(path: NodePath<>): boolean {
+  let current: NodePath<> = path;
+  while (current.parentPath != null) {
+    const member = current.parentPath;
+    if (
+      member.node.type !== 'MemberExpression' ||
+      member.node.object !== current.node ||
+      member.node.computed ||
+      member.node.property.type !== 'Identifier' ||
+      member.parentPath == null
+    ) {
+      return false;
+    }
+    const call = member.parentPath;
+    if (
+      call.node.type !== 'CallExpression' ||
+      call.node.callee !== member.node
+    ) {
+      return false;
+    }
+    const propertyName = member.node.property.name;
+    const args = call.node.arguments;
+    if (
+      propertyName === 'catch' &&
+      args.length >= 1 &&
+      isNonNullishCallbackArg(args[0])
+    ) {
+      return true;
+    }
+    if (
+      propertyName === 'then' &&
+      args.length >= 2 &&
+      isNonNullishCallbackArg(args[1])
+    ) {
+      return true;
+    }
+    current = call;
+  }
+  return false;
+}
+
+function isNonNullishCallbackArg(arg: BabelNode): boolean {
+  if (arg.type === 'NullLiteral') {
+    return false;
+  }
+  if (arg.type === 'Identifier' && arg.name === 'undefined') {
+    return false;
+  }
+  return true;
 }
 
 function getModuleNameFromCallArgs(path: NodePath<CallExpression>): ?string {


### PR DESCRIPTION
Summary:
Fixes: https://github.com/facebook/metro/issues/1681

Extends the optional-dependency heuristic in `collectDependencies` to recognise dynamic imports that attach a rejection handler — either `.catch(handler)` or `.then(_, handler)` — anywhere in an unbroken promise chain rooted at the `import()` call.

Today, `transformer.allowOptionalDependencies` only treats `require()` / `await import()` as optional when wrapped in a `try` block. Library code that relies on a chained `catch`, e.g.

```js
import('node:diagnostics_channel')
  .then(dc => { ... })
  .catch(() => { ... });
```

(seen in `lru-cache` for instance: https://unpkg.com/lru-cache@11.3.5/dist/esm/diagnostics-channel.js ) still fails the build with an unresolvable-module error, even though the developer has clearly opted into a runtime fallback.

This makes a pragmatic extension to `collectDependencies` to walk up the chain from the `import()` call and treat the dependency as optional if any chained call provides a rejection handler. The walk stops as soon as the chain is broken, keeping the heuristic local to the import.

Changelog:
```
 - **[Fix]**: Treat `import().catch()`, etc. as optional under `resolver.allowOptionalDependencies`
```

Reviewed By: huntie

Differential Revision: D102145525


