### PR TITLE
chore: declare contents: read on nightly-tests workflow

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -40,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     if: ${{ always() && needs.test.result == 'failure' }}
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -12,6 +12,9 @@ on:
     # Daily at at 5:00 UTC
     - cron:  '0 5 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
The nightly tests workflow runs the test suite on a cron schedule. Pure CI: checkout + yarn install + jest. No git push, no API write. Other workflows in this repo already declare permissions.