### PR TITLE
feat: install __r in runtime only if it wasn't yet provided

### DIFF
--- a/packages/metro-runtime/src/polyfills/__tests__/require-test.js
+++ b/packages/metro-runtime/src/polyfills/__tests__/require-test.js
@@ -100,6 +100,7 @@ describe('require', () => {
     createModuleSystem(moduleSystem, false, '');
     expect(moduleSystem.__r).not.toBeUndefined();
     expect(moduleSystem.__d).not.toBeUndefined();
+    expect(moduleSystem.__e).toBeUndefined();
 
     const mockExports = {foo: 'bar'};
     const mockFactory = jest
@@ -126,6 +127,26 @@ describe('require', () => {
     expect(mockFactory.mock.calls[0][0]).toBe(moduleSystem);
     expect(m).toBe(mockExports);
     expect(mockFactory.mock.calls[0][6]).toEqual([2, 3]);
+  });
+
+  test('exposes metroRequire as __e when runtime owner has already installed __r', () => {
+    const runtimeOwnerRequire = jest.fn();
+    moduleSystem.__r = runtimeOwnerRequire;
+
+    createModuleSystem(moduleSystem, false, '');
+
+    expect(moduleSystem.__r).toBe(runtimeOwnerRequire);
+    expect(moduleSystem.__e).not.toBeUndefined();
+    expect(moduleSystem.__e).not.toBe(runtimeOwnerRequire);
+  });
+
+  test('does not overwrite __r if already provided by the runtime owner', () => {
+    const runtimeOwnerRequire = jest.fn();
+    moduleSystem.__r = runtimeOwnerRequire;
+
+    createModuleSystem(moduleSystem, false, '');
+
+    expect(moduleSystem.__r).toBe(runtimeOwnerRequire);
   });
 
   test('properly prefixes __d with global prefix', () => {

--- a/packages/metro-runtime/src/polyfills/require.js
+++ b/packages/metro-runtime/src/polyfills/require.js
@@ -80,7 +80,15 @@ export type DefineFn = (
 type VerboseModuleNameForDev = string;
 type ModuleDefiner = (moduleId: ModuleID) => void;
 
-global.__r = metroRequire as RequireFn;
+if (!global.__r) {
+  // Entry point require function.
+  // Install only if the runtime owner hasn't already provided one.
+  global.__r = metroRequire as RequireFn;
+} else {
+  // Install it as a separate binding.
+  // The runtime owner might e.g. use it to implement his own __r wrapper.
+  global.__e = metroRequire as RequireFn;
+}
 global[`${__METRO_GLOBAL_PREFIX__}__d`] = define as DefineFn;
 global.__c = clear;
 global.__registerSegment = registerSegment;


### PR DESCRIPTION
## Summary

I was thinking about the way of simplifying the amount of config required for the [Bundle Mode](https://docs.swmansion.com/react-native-worklets/docs/bundleMode), removing the need of using `getModulesRunBeforeMainModule` since it's an API difficult to integrate with (see https://github.com/expo/expo/pull/43546) and removing the hack of [throwing an error](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-worklets/src/initializers/workletRuntimeEntry.native.ts#L34) after an entry point is evaluated to block additional entry points, then proceed with a costly [catch statement](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp#L124-L134).

I came up with an idea that the runtime owner could install his own `__r` function outside of the bundle. Metro would then not override it but instead write its `__r` as `__e` if it were needed.

I think it's a better approach than relying on https://metrobundler.dev/docs/configuration/#getrunmodulestatement configuration, as it might again lead to merge issues etc. as for `getModulesRunBeforeMainModule`.

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Feature] install __r in runtime only if it wasn't yet provided

## Test plan

I added test cases to cover this feature.
