### PR TITLE
codemod `in/out`

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -14,6 +14,7 @@ munge_underscores=true
 enums=true
 casting_syntax=as
 experimental.pattern_matching=true
+experimental.allow_variance_keywords=true
 
 module.name_mapper='\(metro-[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'
 

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -169,8 +169,8 @@ export type DuplicatesSet = Map<string, /* type */ number>;
 export type DuplicatesIndex = Map<string, Map<string, DuplicatesSet>>;
 
 export type FileMapPluginInitOptions<
-  +SerializableState,
-  +PerFileData = void,
+  out SerializableState,
+  out PerFileData = void,
 > = Readonly<{
   files: Readonly<{
     fileIterator(
@@ -212,8 +212,8 @@ export type V8Serializable =
   | Readonly<{[key: string]: V8Serializable}>;
 
 export interface FileMapPlugin<
-  -SerializableState extends void | V8Serializable = void | V8Serializable,
-  -PerFileData extends void | V8Serializable = void | V8Serializable,
+  in SerializableState extends void | V8Serializable = void | V8Serializable,
+  in PerFileData extends void | V8Serializable = void | V8Serializable,
 > {
   +name: string;
   initialize(
@@ -459,7 +459,7 @@ export interface FileSystemListener {
   fileRemoved(canonicalPath: CanonicalPath, data: FileMetadata): void;
 }
 
-export interface ReadonlyFileSystemChanges<+T = FileMetadata> {
+export interface ReadonlyFileSystemChanges<out T = FileMetadata> {
   +addedDirectories: Iterable<CanonicalPath>;
   +removedDirectories: Iterable<CanonicalPath>;
 

--- a/packages/metro-file-map/src/plugins/FileDataPlugin.js
+++ b/packages/metro-file-map/src/plugins/FileDataPlugin.js
@@ -29,7 +29,7 @@ export type FileDataPluginOptions = Readonly<{
  * of lifecycle methods that subclasses can override as needed.
  */
 export default class FileDataPlugin<
-  -PerFileData extends void | V8Serializable = void | V8Serializable,
+  in PerFileData extends void | V8Serializable = void | V8Serializable,
 > implements FileMapPlugin<null, PerFileData>
 {
   +name: string;

--- a/packages/metro-resolver/src/types.js
+++ b/packages/metro-resolver/src/types.js
@@ -11,7 +11,7 @@
 
 import type {TransformResultDependency} from 'metro/private/DeltaBundler/types';
 
-export type Result<+TResolution, +TCandidates> =
+export type Result<out TResolution, out TCandidates> =
   | {+type: 'resolved', +resolution: TResolution}
   | {+type: 'failed', +candidates: TCandidates};
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/react-native/pull/56930

X-link: https://github.com/facebook/relay/pull/5290

```
pastry P2346790458 | sed 's|^|xplat/js/|' | js1 flow-runner codemod flow/transformAllVariance --variance in,out --format-files=false @
```

Reviewed By: SamChou19815

Differential Revision: D106021144


