### PR TITLE
Resolver: Implement PACKAGE_SELF_RESOLVE for self-referencing imports

### DIFF
--- a/docs/Resolution.md
+++ b/docs/Resolution.md
@@ -75,18 +75,21 @@ Parameters: (*context*, *moduleName*, *platform*)
     2. If resolved as a Haste package path, then
         1. Perform the algorithm for resolving a path (step 2 above). Throw an error if this resolution fails.
             For example, if the Haste package path for `'a/b'` is `foo/package.json`, perform step 2 as if _moduleName_ was `foo/c`.
-6. If [`context.disableHierarchicalLookup`](#disableHierarchicalLookup-boolean) is not `true`, then
+6. If [`context.enablePackageExports`](#enablepackageexports-boolean) is enabled, then
+    1. Get the result of [**PACKAGE_SELF_RESOLVE**](#package_self_resolve)(*context*, *moduleName*, *platform*).
+    2. If resolved, return result.
+7. If [`context.disableHierarchicalLookup`](#disableHierarchicalLookup-boolean) is not `true`, then
     1. Try resolving _moduleName_ under `node_modules` from the current directory (i.e. parent of [`context.originModulePath`](#originmodulepath-string)) up to the root directory.
     2. Perform [**RESOLVE_PACKAGE**](#resolve_package)(*context*, *modulePath*, *platform*) for each candidate path.
-7. For each element _nodeModulesPath_ of [`context.nodeModulesPaths`](#nodemodulespaths-readonlyarraystring):
+8. For each element _nodeModulesPath_ of [`context.nodeModulesPaths`](#nodemodulespaths-readonlyarraystring):
     1. Try resolving _moduleName_ under _nodeModulesPath_ as if the latter was another `node_modules` directory (similar to step 5 above).
     2. Perform [**RESOLVE_PACKAGE**](#resolve_package)(*context*, *modulePath*, *platform*) for each candidate path.
-8. If [`context.extraNodeModules`](#extranodemodules-string-string) is set:
+9. If [`context.extraNodeModules`](#extranodemodules-string-string) is set:
     1. Split _moduleName_ into a package name (including an optional [scope](https://docs.npmjs.com/cli/v8/using-npm/scope)) and relative path.
     2. Look up the package name in [`context.extraNodeModules`](#extranodemodules-string-string). If found, then
         1. Construct a path _modulePath_ by replacing the package name part of _moduleName_ with the value found in [`context.extraNodeModules`](#extranodemodules-string-string)
         2. Return the result of [**RESOLVE_PACKAGE**](#resolve_package)(*context*, *modulePath*, *platform*).
-9. If no valid resolution has been found, throw a resolution failure error.
+10. If no valid resolution has been found, throw a resolution failure error.
 
 #### RESOLVE_MODULE
 
@@ -109,6 +112,18 @@ Parameters: (*context*, *moduleName*, *platform*)
     1. If resolved path exists, return result.
     2. Else, log either a package configuration or package encapsulation warning.
 2. Return the result of [**RESOLVE_MODULE**](#resolve_module)(*context*, *filePath*, *platform*).
+
+#### PACKAGE_SELF_RESOLVE
+
+Parameters: (*context*, *moduleName*, *platform*)
+
+1. Find the closest package to [`context.originModulePath`](#originmodulepath-string). If no package is found, return no resolution.
+2. If the package does not declare both a `"name"` field and an `"exports"` field, return no resolution.
+3. Split _moduleName_ into a package name (including an optional [scope](https://docs.npmjs.com/cli/v8/using-npm/scope)) and relative path.
+4. If the package name does not match the current package's `"name"` field, return no resolution.
+5. Get the result of [**RESOLVE_PACKAGE_EXPORTS**](#resolve_package-exports)(*context*, *packagePath*, *filePath*, *exportsField*, *platform*) against the current package's `"exports"` field.
+    1. If resolved path exists, return result.
+    2. Else, log either a package configuration or package encapsulation warning, then continue with normal resolution.
 
 #### RESOLVE_PACKAGE_EXPORTS
 

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -1210,4 +1210,97 @@ describe('with package exports resolution enabled', () => {
       });
     });
   });
+
+  describe('self-referencing imports (PACKAGE_SELF_RESOLVE)', () => {
+    const packageJson = {
+      name: 'self-pkg',
+      main: 'index-main.js',
+      exports: {
+        '.': './index.js',
+        './sub': './lib/sub.js',
+      },
+    };
+    const baseContext = {
+      ...createResolutionContext({
+        '/root/node_modules/self-pkg/package.json': JSON.stringify(packageJson),
+        '/root/node_modules/self-pkg/index.js': '',
+        '/root/node_modules/self-pkg/index-main.js': '',
+        '/root/node_modules/self-pkg/lib/sub.js': '',
+        '/root/node_modules/self-pkg/lib/internal.js': '',
+      }),
+      originModulePath: '/root/node_modules/self-pkg/index.js',
+      unstable_enablePackageExports: true,
+    };
+
+    test('should resolve own package name via its own "exports" field', () => {
+      expect(Resolver.resolve(baseContext, 'self-pkg', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/self-pkg/index.js',
+      });
+    });
+
+    test('should resolve a subpath of the own package via "exports"', () => {
+      expect(Resolver.resolve(baseContext, 'self-pkg/sub', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/self-pkg/lib/sub.js',
+      });
+    });
+
+    test('[nonstrict] should warn and fall back when self subpath is not in "exports"', () => {
+      const logWarning = jest.fn();
+      // `./lib/internal.js` is not exported, but exists on disk. We log the
+      // out-of-exports access and fall through to the regular hierarchical
+      // lookup, which finds the file inside `node_modules/self-pkg/`.
+      expect(
+        Resolver.resolve(
+          {...baseContext, unstable_logWarning: logWarning},
+          'self-pkg/lib/internal',
+          null,
+        ),
+      ).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/self-pkg/lib/internal.js',
+      });
+      expect(logWarning).toHaveBeenCalled();
+      expect(logWarning.mock.calls[0][0]).toMatch(
+        /which is not listed in the "exports"/,
+      );
+    });
+
+    test('should not self-resolve when origin package has no name', () => {
+      const noNameContext = {
+        ...baseContext,
+        ...createPackageAccessors({
+          '/root/node_modules/self-pkg/package.json': {
+            main: 'index-main.js',
+            exports: {'.': './index.js'},
+          },
+        }),
+      };
+      // With no `name`, falls through to hierarchical lookup (and finds the
+      // package in node_modules, going through "exports" as a normal import).
+      expect(Resolver.resolve(noNameContext, 'self-pkg', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/self-pkg/index.js',
+      });
+    });
+
+    test('should not self-resolve when the package has no "exports" field', () => {
+      const noExportsContext = {
+        ...baseContext,
+        ...createPackageAccessors({
+          '/root/node_modules/self-pkg/package.json': {
+            name: 'self-pkg',
+            main: 'index-main.js',
+          },
+        }),
+      };
+      // Without `exports`, self-resolve does not apply. Falls back to
+      // node_modules lookup, which resolves via "main".
+      expect(Resolver.resolve(noExportsContext, 'self-pkg', null)).toEqual({
+        type: 'sourceFile',
+        filePath: '/root/node_modules/self-pkg/index-main.js',
+      });
+    });
+  });
 });

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -193,6 +193,56 @@ export default function resolve(
 
   // parsedSpecifier is now a non-Haste bare specifier.
 
+  // PACKAGE_SELF_RESOLVE: if the origin lives inside a package whose `name`
+  // matches the bare specifier and which declares an `exports` field, resolve
+  // the request via that package's `exports`. Per Node.js ESM spec section 6.5
+  // (https://nodejs.org/api/esm.html#resolution-algorithm-specification).
+  if (
+    context.unstable_enablePackageExports &&
+    closestPackageToOrigin != null &&
+    closestPackageToOrigin.packageJson.exports != null &&
+    closestPackageToOrigin.packageJson.name === parsedSpecifier.packageName
+  ) {
+    try {
+      const exportsField = closestPackageToOrigin.packageJson.exports;
+      const packageExportsResult = resolvePackageTargetFromExports(
+        context,
+        closestPackageToOrigin.rootPath,
+        path.join(
+          closestPackageToOrigin.rootPath,
+          parsedSpecifier.posixSubpath,
+        ),
+        // packageRelativePath for the requested subpath, stripping the leading
+        // './' so the empty string represents the package root (matching how
+        // `getPackageForModule` reports `packageRelativePath`).
+        parsedSpecifier.posixSubpath === '.'
+          ? ''
+          : parsedSpecifier.posixSubpath.slice(2),
+        exportsField,
+        platform,
+      );
+      if (packageExportsResult != null) {
+        return packageExportsResult;
+      }
+    } catch (e) {
+      // NB: Falling back is a departure from the spec, but retained for
+      // backwards compatibility. Remove this in a breaking change.
+      if (e instanceof PackagePathNotExportedError) {
+        context.unstable_logWarning(
+          e.message +
+            ' Falling back to hierarchical resolution for backwards compatibility.',
+        );
+      } else if (e instanceof InvalidPackageConfigurationError) {
+        context.unstable_logWarning(
+          e.message +
+            ' Falling back to hierarchical resolution for backwards compatibility.',
+        );
+      } else {
+        throw e;
+      }
+    }
+  }
+
   const {disableHierarchicalLookup} = context;
 
   if (!disableHierarchicalLookup) {


### PR DESCRIPTION
Summary:
Add support to Metro's resolver for [self-referencing](https://nodejs.org/api/packages.html#self-referencing-a-package-using-its-name). A package can import itself by name, resolving via its own `exports` field. Per the [Node ESM resolution algorithm](https://nodejs.org/api/esm.html#resolution-algorithm-specification) (6.5 `PACKAGE_SELF_RESOLVE`), if the origin module lives in a package whose `name` matches the bare specifier and which declares `exports`, the request is routed through `PACKAGE_EXPORTS_RESOLVE` against that package, in preference to hierarchical `node_modules` lookup.

(In particular, this allows `react-native`'s own source to `import {Platform} from 'react-native'`, which *may* be the approach we take to fix broken platform inlining)

Gated behind the existing `unstable_enablePackageExports` flag (enabled by default). When on, the resolver attempts self-resolve before hierarchical lookup; on `PackagePathNotExportedError` it follows Metro's existing nonstrict policy of warning and falling through to legacy resolution, consistent with how non-self bare specifiers behave today. This nonstrict fallback will be removed in future.

Matches webpack's `SelfReferencePlugin` and Node's own behaviour.

```
 - **[Feature]**: Resolver: support self-referencing packages ([`PACKAGE_SELF_RESOLVE`](https://nodejs.org/api/esm.html#resolution-algorithm-specification))
```

Reviewed By: huntie, motiz88

Differential Revision: D105485943


