### PR TITLE
Collect dependencies from createRequire-bound require calls

### DIFF
--- a/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
@@ -1209,6 +1209,125 @@ test('collects dependencies from module.createRequire factory pattern', () => {
   ]);
 });
 
+test('collects dependencies when createRequire result is bound to non-require name', () => {
+  const ast = astFromCode(`
+    import { createRequire } from 'node:module';
+    const customRequire = createRequire(import.meta.url);
+    const dep = customRequire('./x');
+  `);
+  const {dependencies} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'node:module', data: objectContaining({asyncType: null})},
+    {name: './x', data: objectContaining({asyncType: null})},
+  ]);
+});
+
+test('collects dependencies with aliased createRequire named import', () => {
+  const ast = astFromCode(`
+    import { createRequire as cr } from 'node:module';
+    const req = cr(import.meta.url);
+    const dep = req('./aliased');
+  `);
+  const {dependencies} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'node:module', data: objectContaining({asyncType: null})},
+    {name: './aliased', data: objectContaining({asyncType: null})},
+  ]);
+});
+
+test('collects dependencies with namespace import mod.createRequire', () => {
+  const ast = astFromCode(`
+    import * as mod from 'node:module';
+    const req = mod.createRequire(import.meta.url);
+    const dep = req('./namespaced');
+  `);
+  const {dependencies} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'node:module', data: objectContaining({asyncType: null})},
+    {name: './namespaced', data: objectContaining({asyncType: null})},
+  ]);
+});
+
+test('collects dependencies with CJS destructured createRequire', () => {
+  const ast = astFromCode(`
+    const { createRequire } = require('node:module');
+    const req = createRequire(import.meta.url);
+    const dep = req('./cjs-destructured');
+  `);
+  const {dependencies} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'node:module', data: objectContaining({asyncType: null})},
+    {name: './cjs-destructured', data: objectContaining({asyncType: null})},
+  ]);
+});
+
+test('collects dependencies with CJS mod.createRequire two-statement pattern', () => {
+  const ast = astFromCode(`
+    const mod = require('node:module');
+    const req = mod.createRequire(import.meta.url);
+    const dep = req('./cjs-two-step');
+  `);
+  const {dependencies} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'node:module', data: objectContaining({asyncType: null})},
+    {name: './cjs-two-step', data: objectContaining({asyncType: null})},
+  ]);
+});
+
+test('does not collect from arbitrary factory call (tightening)', () => {
+  const ast = astFromCode(`
+    const require = someFactory();
+    require('should-be-ignored');
+  `);
+  const {dependencies} = collectDependencies(ast, opts);
+  expect(dependencies).toEqual([]);
+});
+
+test('does not collect when createRequire is imported from wrong module', () => {
+  const ast = astFromCode(`
+    import { createRequire } from 'some-other-module';
+    const req = createRequire(import.meta.url);
+    req('./should-be-ignored');
+  `);
+  const {dependencies} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'some-other-module', data: objectContaining({asyncType: null})},
+  ]);
+});
+
+test('does not collect when CJS require uses bare "module" specifier instead of "node:module"', () => {
+  const ast = astFromCode(`
+    const { createRequire } = require('module');
+    const req = createRequire(import.meta.url);
+    req('./should-be-ignored');
+  `);
+  const {dependencies} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'module', data: objectContaining({asyncType: null})},
+  ]);
+});
+
 test('still ignores require shadowed by function expression or parameter', () => {
   const ast = astFromCode(`
     const require = function(name) { return {}; };

--- a/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
+++ b/packages/metro/src/ModuleGraph/worker/__tests__/collectDependencies-test.js
@@ -1167,6 +1167,57 @@ test('ignores require functions defined defined by lower scopes', () => {
   );
 });
 
+test('collects dependencies from createRequire-bound require calls', () => {
+  const ast = astFromCode(`
+    import { createRequire } from 'node:module';
+    const require = createRequire(import.meta.url);
+    const version = require('../package.json').version;
+    const otherDep = require('some-module');
+  `);
+  const {dependencies, dependencyMapName} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'node:module', data: objectContaining({asyncType: null})},
+    {name: '../package.json', data: objectContaining({asyncType: null})},
+    {name: 'some-module', data: objectContaining({asyncType: null})},
+  ]);
+  expect(codeFromAst(ast)).toEqual(
+    comparableCode(`
+      import { createRequire } from 'node:module';
+      const require = createRequire(import.meta.url);
+      const version = require(${dependencyMapName}[1], "../package.json").version;
+      const otherDep = require(${dependencyMapName}[2], "some-module");
+    `),
+  );
+});
+
+test('collects dependencies from module.createRequire factory pattern', () => {
+  const ast = astFromCode(`
+    import module from 'node:module';
+    const require = module.createRequire(import.meta.url);
+    const data = require('./data.json');
+  `);
+  const {dependencies} = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    {name: 'node:module', data: objectContaining({asyncType: null})},
+    {name: './data.json', data: objectContaining({asyncType: null})},
+  ]);
+});
+
+test('still ignores require shadowed by function expression or parameter', () => {
+  const ast = astFromCode(`
+    const require = function(name) { return {}; };
+    require('should-be-ignored');
+  `);
+  const {dependencies} = collectDependencies(ast, opts);
+  expect(dependencies).toEqual([]);
+});
+
 test('collects imports', () => {
   const ast = astFromCode(`
     import b from 'b/lib/a';

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -83,6 +83,9 @@ export type InternalDependency = Readonly<MutableInternalDependency>;
 export type State = {
   asyncRequireModulePathStringLiteral: ?StringLiteral,
   dependencyCalls: Set<string>,
+  requireFactoryBindings: Set<{path: NodePath<>, ...}>,
+  nodeModuleBindings: Set<{path: NodePath<>, ...}>,
+  createRequireExportBindings: Set<{path: NodePath<>, ...}>,
   dependencyRegistry: DependencyRegistry,
   dependencyTransformer: DependencyTransformer,
   dynamicRequires: DynamicRequiresBehavior,
@@ -157,6 +160,9 @@ export default function collectDependencies(
   const state: State = {
     asyncRequireModulePathStringLiteral: null,
     dependencyCalls: new Set(),
+    requireFactoryBindings: new Set(),
+    nodeModuleBindings: new Set(),
+    createRequireExportBindings: new Set(),
     dependencyRegistry: new DependencyRegistry(),
     dependencyTransformer:
       options.dependencyTransformer ?? DefaultDependencyTransformer,
@@ -258,11 +264,71 @@ export default function collectDependencies(
         return;
       }
 
-      if (name != null && state.dependencyCalls.has(name)) {
+      if (name != null) {
         const binding = path.scope.getBinding(name);
-        if (!binding || isRequireFactoryBinding(binding)) {
+        if (binding == null) {
+          if (state.dependencyCalls.has(name)) {
+            processRequireCall(path, state);
+            visited.add(path.node);
+          }
+        } else if (state.requireFactoryBindings.has(binding)) {
           processRequireCall(path, state);
           visited.add(path.node);
+        }
+      }
+    },
+
+    VariableDeclarator(
+      path: NodePath<BabelNodeVariableDeclarator>,
+      state: State,
+    ): void {
+      const id = path.node.id;
+      const init = path.node.init;
+      if (init == null || init.type !== 'CallExpression') {
+        return;
+      }
+      const initPath = path.get('init');
+      if (!initPath.isCallExpression()) {
+        return;
+      }
+
+      // `const mod = require('node:module')` — track for MemberExpression detection
+      if (id.type === 'Identifier' && isRequireNodeModuleCall(initPath)) {
+        const binding = path.scope.getBinding(id.name);
+        if (binding != null) {
+          state.nodeModuleBindings.add(binding);
+        }
+        return;
+      }
+
+      // `const {createRequire} = require('node:module')` or
+      // `const {createRequire: alias} = require('node:module')`
+      if (id.type === 'ObjectPattern' && isRequireNodeModuleCall(initPath)) {
+        for (const prop of id.properties) {
+          if (
+            prop.type === 'ObjectProperty' &&
+            !prop.computed &&
+            prop.key.type === 'Identifier' &&
+            prop.key.name === 'createRequire' &&
+            prop.value.type === 'Identifier'
+          ) {
+            const binding = path.scope.getBinding(prop.value.name);
+            if (binding != null) {
+              state.createRequireExportBindings.add(binding);
+            }
+          }
+        }
+        return;
+      }
+
+      // `const req = createRequire(...)` or `const req = mod.createRequire(...)`
+      if (id.type === 'Identifier') {
+        const calleePath = initPath.get('callee');
+        if (isCreateRequireCallee(calleePath, state)) {
+          const binding = path.scope.getBinding(id.name);
+          if (binding != null) {
+            state.requireFactoryBindings.add(binding);
+          }
         }
       }
     },
@@ -286,6 +352,9 @@ export default function collectDependencies(
       }
 
       state.dependencyCalls = new Set(['require', ...options.inlineableCalls]);
+      state.requireFactoryBindings = new Set();
+      state.nodeModuleBindings = new Set();
+      state.createRequireExportBindings = new Set();
     },
   };
 
@@ -527,13 +596,88 @@ function processImportCall(
   }
 }
 
-function isRequireFactoryBinding(binding: {path: NodePath<>, ...}): boolean {
+function isCreateRequireCallee(
+  calleePath: NodePath<>,
+  state: State,
+): boolean {
+  if (calleePath.isIdentifier()) {
+    const name = calleePath.node.name;
+    const binding = calleePath.scope.getBinding(name);
+    return binding != null && isCreateRequireExportBinding(binding, state);
+  }
+  if (
+    calleePath.isMemberExpression() &&
+    !calleePath.node.computed &&
+    calleePath.node.property.type === 'Identifier' &&
+    calleePath.node.property.name === 'createRequire' &&
+    calleePath.node.object.type === 'Identifier'
+  ) {
+    const objName = calleePath.node.object.name;
+    const binding = calleePath.scope.getBinding(objName);
+    return binding != null && isNodeModuleBinding(binding, state);
+  }
+  return false;
+}
+
+function isCreateRequireExportBinding(
+  binding: {path: NodePath<>, ...},
+  state: State,
+): boolean {
   const bindingPath = binding.path;
-  if (!bindingPath.isVariableDeclarator()) {
+  // ESM: import {createRequire} from 'node:module'
+  //   or import {createRequire as alias} from 'node:module'
+  if (bindingPath.isImportSpecifier()) {
+    const imported = bindingPath.node.imported;
+    const importedName =
+      imported.type === 'Identifier' ? imported.name : imported.value;
+    return importedName === 'createRequire' && importSourceIs(bindingPath, 'node:module');
+  }
+  // CJS: detected and tracked during VariableDeclarator traversal
+  return state.createRequireExportBindings.has(binding);
+}
+
+function isNodeModuleBinding(
+  binding: {path: NodePath<>, ...},
+  state: State,
+): boolean {
+  const bindingPath = binding.path;
+  // ESM: import module from 'node:module' or import * as module from 'node:module'
+  if (
+    bindingPath.isImportDefaultSpecifier() ||
+    bindingPath.isImportNamespaceSpecifier()
+  ) {
+    return importSourceIs(bindingPath, 'node:module');
+  }
+  // CJS: detected and tracked during VariableDeclarator traversal
+  return state.nodeModuleBindings.has(binding);
+}
+
+function importSourceIs(specifierPath: NodePath<>, source: string): boolean {
+  const declaration = specifierPath.parentPath;
+  return (
+    declaration != null &&
+    declaration.isImportDeclaration() &&
+    declaration.node.source.value === source
+  );
+}
+
+function isRequireNodeModuleCall(initPath: NodePath<>): boolean {
+  if (!initPath.isCallExpression()) {
     return false;
   }
-  const init = bindingPath.get('init');
-  return init.isCallExpression();
+  const callee = initPath.node.callee;
+  if (callee.type !== 'Identifier' || callee.name !== 'require') {
+    return false;
+  }
+  if (initPath.scope.getBinding('require') != null) {
+    return false;
+  }
+  const args = initPath.node.arguments;
+  return (
+    args.length >= 1 &&
+    args[0].type === 'StringLiteral' &&
+    args[0].value === 'node:module'
+  );
 }
 
 function processRequireCall(

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -258,13 +258,12 @@ export default function collectDependencies(
         return;
       }
 
-      if (
-        name != null &&
-        state.dependencyCalls.has(name) &&
-        !path.scope.getBinding(name)
-      ) {
-        processRequireCall(path, state);
-        visited.add(path.node);
+      if (name != null && state.dependencyCalls.has(name)) {
+        const binding = path.scope.getBinding(name);
+        if (!binding || isRequireFactoryBinding(binding)) {
+          processRequireCall(path, state);
+          visited.add(path.node);
+        }
       }
     },
 
@@ -526,6 +525,15 @@ function processImportCall(
       options.asyncType as empty;
       throw new Error('Unreachable');
   }
+}
+
+function isRequireFactoryBinding(binding: {path: NodePath<>, ...}): boolean {
+  const bindingPath = binding.path;
+  if (!bindingPath.isVariableDeclarator()) {
+    return false;
+  }
+  const init = bindingPath.get('init');
+  return init.isCallExpression();
 }
 
 function processRequireCall(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
 ESM packages use `const require = createRequire(import.meta.url)` to emulate CJS require. Previously, `collectDependencies` skipped these calls because `require` had a local binding. This change detects when the binding comes from a factory call

Upstream issue from Expo: [46129](https://github.com/expo/expo/issues/46129)

## Test plan

Regular unit tests and the project from the issue: https://github.com/floklein/expo-server-sdk-packagejson-bug

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
