### PR TITLE
Fix asset root containment check

### DIFF
--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -352,8 +352,14 @@ function pathBelongsToRoots(
   return false;
 }
 
-function isPathInsideRoot(pathToCheck: string, rootFolder: string): boolean {
-  const relativePath = path.relative(path.resolve(rootFolder), pathToCheck);
+function isPathInsideRoot(
+  absolutePathToCheck: string,
+  rootFolder: string,
+): boolean {
+  const relativePath = path.relative(
+    path.resolve(rootFolder),
+    absolutePathToCheck,
+  );
 
   // path.relative('/repo', '/repo2') -> '../repo2', so this must reject leading "..".
   return (

--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -341,11 +341,25 @@ function pathBelongsToRoots(
   pathToCheck: string,
   roots: ReadonlyArray<string>,
 ): boolean {
+  const absolutePathToCheck = path.resolve(pathToCheck);
+
   for (const rootFolder of roots) {
-    if (pathToCheck.startsWith(path.resolve(rootFolder))) {
+    if (isPathInsideRoot(absolutePathToCheck, rootFolder)) {
       return true;
     }
   }
 
   return false;
+}
+
+function isPathInsideRoot(pathToCheck: string, rootFolder: string): boolean {
+  const relativePath = path.relative(path.resolve(rootFolder), pathToCheck);
+
+  // path.relative('/repo', '/repo2') -> '../repo2', so this must reject leading "..".
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith(`..${path.sep}`) &&
+      relativePath !== '..' &&
+      !path.isAbsolute(relativePath))
+  );
 }

--- a/packages/metro/src/__tests__/Assets-test.js
+++ b/packages/metro/src/__tests__/Assets-test.js
@@ -151,6 +151,42 @@ describe('getAsset', () => {
     ).rejects.toBeInstanceOf(Error);
   });
 
+  test('should reject sibling-prefix watchFolder paths outside watchFolders', async () => {
+    fs.mkdirSync('/watchfoldersub/imgs', {recursive: true});
+
+    fs.writeFileSync('/watchfoldersub/imgs/b.png', 'b image');
+
+    await expect(
+      getAssetStr(
+        '../watchfoldersub/imgs/b.png',
+        '/watchfolder',
+        ['/watchfolder/one'],
+        null,
+        ['png'],
+      ),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  test('should reject sibling-prefix asset paths outside root', async () => {
+    fs.mkdirSync('/app2/imgs', {recursive: true});
+
+    fs.writeFileSync('/app2/imgs/b.png', 'b image');
+
+    await expect(
+      getAssetStr('../app2/imgs/b.png', '/app', [], null, ['png']),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  test('should reject sibling-prefix asset paths outside root even with trailing root separator', async () => {
+    fs.mkdirSync('/app2/imgs', {recursive: true});
+
+    fs.writeFileSync('/app2/imgs/b.png', 'b image');
+
+    await expect(
+      getAssetStr('../app2/imgs/b.png', '/app/', [], null, ['png']),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
   test('should find an image when fileExistsInFileMap returns true', async () => {
     writeImages({'b.png': 'b image'});
 

--- a/packages/metro/src/__tests__/Assets-test.js
+++ b/packages/metro/src/__tests__/Assets-test.js
@@ -152,15 +152,19 @@ describe('getAsset', () => {
   });
 
   test('should reject sibling-prefix watchFolder paths outside watchFolders', async () => {
-    fs.mkdirSync('/watchfoldersub/imgs', {recursive: true});
+    const outsideWatchFolder = path.resolve('/watchfoldersub');
+    const insideWatchFolder = path.resolve('/watchfolder');
+    const childRoot = path.join(outsideWatchFolder, 'imgs');
+    const relativePathToAsset = path.join('..', 'watchfoldersub', 'imgs', 'b.png');
 
-    fs.writeFileSync('/watchfoldersub/imgs/b.png', 'b image');
+    fs.mkdirSync(childRoot, {recursive: true});
+    fs.writeFileSync(path.join(childRoot, 'b.png'), 'b image');
 
     await expect(
       getAssetStr(
-        '../watchfoldersub/imgs/b.png',
-        '/watchfolder',
-        ['/watchfolder/one'],
+        relativePathToAsset,
+        insideWatchFolder,
+        [path.join(insideWatchFolder, 'one')],
         null,
         ['png'],
       ),
@@ -168,22 +172,52 @@ describe('getAsset', () => {
   });
 
   test('should reject sibling-prefix asset paths outside root', async () => {
-    fs.mkdirSync('/app2/imgs', {recursive: true});
+    const rootFolder = path.resolve('/app');
+    const outsideRoot = path.resolve('/app2');
+    const childRoot = path.join(outsideRoot, 'imgs');
 
-    fs.writeFileSync('/app2/imgs/b.png', 'b image');
+    fs.mkdirSync(childRoot, {recursive: true});
+    fs.writeFileSync(path.join(childRoot, 'b.png'), 'b image');
 
     await expect(
-      getAssetStr('../app2/imgs/b.png', '/app', [], null, ['png']),
+      getAssetStr(
+        path.join('..', 'app2', 'imgs', 'b.png'),
+        rootFolder,
+        [],
+        null,
+        ['png'],
+      ),
     ).rejects.toBeInstanceOf(Error);
   });
 
-  test('should reject sibling-prefix asset paths outside root even with trailing root separator', async () => {
-    fs.mkdirSync('/app2/imgs', {recursive: true});
+  test('should accept asset paths inside root', async () => {
+    const rootFolder = path.resolve('/app');
+    const childRoot = path.join(rootFolder, 'imgs');
 
-    fs.writeFileSync('/app2/imgs/b.png', 'b image');
+    fs.mkdirSync(childRoot, {recursive: true});
+    fs.writeFileSync(path.join(childRoot, 'b.png'), 'b image');
 
     await expect(
-      getAssetStr('../app2/imgs/b.png', '/app/', [], null, ['png']),
+      getAssetStr('imgs/b.png', rootFolder, [], null, ['png']),
+    ).resolves.toContain('b image');
+  });
+
+  test('should reject sibling-prefix asset paths outside root even with trailing root separator', async () => {
+    const rootFolder = path.resolve('/app');
+    const outsideRoot = path.resolve('/app2');
+    const childRoot = path.join(outsideRoot, 'imgs');
+
+    fs.mkdirSync(childRoot, {recursive: true});
+    fs.writeFileSync(path.join(childRoot, 'b.png'), 'b image');
+
+    await expect(
+      getAssetStr(
+        path.join('..', 'app2', 'imgs', 'b.png'),
+        rootFolder + path.sep,
+        [],
+        null,
+        ['png'],
+      ),
     ).rejects.toBeInstanceOf(Error);
   });
 


### PR DESCRIPTION
## Why this change
Metro’s asset fallback guard used a string prefix check in `pathBelongsToRoots()` and could incorrectly treat sibling-prefix paths as inside allowed roots (for example, `/app2/...` matching `/app`). This can allow non-root assets to pass containment checks when file-map membership is unknown.

## What changed
- Reworked `pathBelongsToRoots()` in `packages/metro/src/Assets.js` to use `path.resolve()` + `path.relative()` containment checks.
- Added `isPathInsideRoot(...)` helper for explicit, readable root containment logic and to reject:
  - sibling-prefix false positives (`/app2` vs `/app`)
  - parent traversal escapes
- Added regression coverage in `packages/metro/src/__tests__/Assets-test.js` for:
  - rejecting sibling-prefix paths under watch folders
  - rejecting sibling-prefix paths under project root
  - rejecting with trailing root separator
  - accepting a valid in-root child asset path (positive-path guard)
- Normalized test path construction to explicit `path.join()`/`path.resolve()` calls where updated tests were introduced.

## Why this is safe
Only containment acceptance criteria changed; legitimate in-root paths remain valid while prefix-only matches are removed. This narrows access to expected roots and avoids stale or incorrect fallback reads.

## Validation
- Not run in this pass.
- Recommended command: `yarn test packages/metro/src/__tests__/Assets-test.js`
