### PR TITLE
Fix HttpStore write retries using the read endpoint's config

### DIFF
--- a/packages/metro-cache/src/stores/HttpStore.js
+++ b/packages/metro-cache/src/stores/HttpStore.js
@@ -396,14 +396,12 @@ export default class HttpStore<T> {
     return backOff(fn, {
       jitter: 'full',
       maxDelay: 30000,
-      numOfAttempts: this.#getEndpoint.maxAttempts || Number.POSITIVE_INFINITY,
+      numOfAttempts: endpoint.maxAttempts || Number.POSITIVE_INFINITY,
       retry: (e: Error) => {
         if (e instanceof HttpError) {
-          return this.#getEndpoint.retryStatuses.has(e.code);
+          return endpoint.retryStatuses.has(e.code);
         }
-        return (
-          e instanceof NetworkError && this.#getEndpoint.retryNetworkErrors
-        );
+        return e instanceof NetworkError && endpoint.retryNetworkErrors;
       },
     });
   }

--- a/packages/metro-cache/src/stores/__tests__/HttpStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/HttpStore-test.js
@@ -290,6 +290,39 @@ describe('HttpStore', () => {
     });
   });
 
+  test('set() retries use the set endpoint config, not the get endpoint', async () => {
+    jest.useRealTimers();
+    // Distinct read/write retry config: reads do not retry, writes retry 503s.
+    const store = new HttpStore({
+      getOptions: {endpoint: 'http://example.com', maxAttempts: 1},
+      setOptions: {
+        endpoint: 'http://example.com',
+        maxAttempts: 2,
+        retryStatuses: [503],
+      },
+    });
+    const {request} = require('http');
+
+    request.mockImplementation((opts, callback) => {
+      if (request.mock.calls.length === 1) {
+        callback(responseHttpError(503));
+      } else {
+        callback(responseHttpOk(''));
+      }
+      return new PassThrough();
+    });
+
+    let error;
+    try {
+      await store.set(Buffer.from('key-set'), {foo: 42});
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeUndefined();
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
   test('sets using the network via PUT method', done => {
     const store = new HttpStore({endpoint: 'http://www.example.com/endpoint'});
     const promise = store.set(Buffer.from('key-set'), {foo: 42});


### PR DESCRIPTION
## Summary

`HttpStore.#withRetries(fn, endpoint)` is called for both endpoints — `get()` passes `#getEndpoint`, `set()` passes `#setEndpoint` — and it correctly consults the passed `endpoint` for the `maxAttempts === 1` short-circuit. However, the `backOff` options hardcoded `this.#getEndpoint` for `numOfAttempts`, `retryStatuses`, and `retryNetworkErrors`.

As a result, when an `HttpStore` is constructed with the documented split `{ getOptions, setOptions }` form, all `set()`/PUT retries silently use the **read** endpoint's retry configuration — `setOptions.maxAttempts`, `setOptions.retryStatuses`, and `setOptions.retryNetworkErrors` are ignored. There's also an internal inconsistency: the `maxAttempts === 1` early-return reads the (set) endpoint, but `numOfAttempts` then read `#getEndpoint.maxAttempts`.

The fix uses the passed-in `endpoint` consistently.

## Test plan

The existing retry tests only use the single-options form via `get()`, where `#getEndpoint === #setEndpoint`, so they can't catch this. Added a regression test that builds the store with the split form (reads: `maxAttempts: 1`; writes: `maxAttempts: 2, retryStatuses: [503]`) and asserts `set()` retries a 503:

- Before: `set()` uses the read config (no retry) and throws the 503 → test fails.
- After: `set()` retries per `setOptions` and resolves → test passes.

```
yarn jest packages/metro-cache/src/stores/__tests__/HttpStore-test.js
# Tests: 19 passed   (full metro-cache package: 45 passed)
```