### PR TITLE
Remove support for deprecated YAML and `.es6` config files (#1752)

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -25,8 +25,7 @@
     "metro": "0.85.0",
     "metro-cache": "0.85.0",
     "metro-core": "0.85.0",
-    "metro-runtime": "0.85.0",
-    "yaml": "^2.6.1"
+    "metro-runtime": "0.85.0"
   },
   "devDependencies": {
     "@types/connect": "^3.4.35",

--- a/packages/metro-config/src/__fixtures__/yaml-extensionless
+++ b/packages/metro-config/src/__fixtures__/yaml-extensionless
@@ -1,2 +1,0 @@
-# Use cacheVersion as a dummy free text field to check we've read the config
-cacheVersion: yaml-extensionless

--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -156,16 +156,6 @@ describe('loadConfig', () => {
     );
   });
 
-  test('supports loading YAML (deprecated)', async () => {
-    const result = await loadConfig({
-      config: path.resolve(FIXTURES, 'yaml-extensionless'),
-    });
-    expect(console.warn).toHaveBeenCalledWith(
-      'YAML config is deprecated, please migrate to JavaScript config (e.g. metro.config.js)',
-    );
-    expect(result.cacheVersion).toEqual('yaml-extensionless');
-  });
-
   describe('given a search directory', () => {
     const HOME = process.platform === 'win32' ? 'C:\\Home' : '/home';
     const mockHomeDir = jest.fn().mockReturnValue(HOME);

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -20,7 +20,6 @@ import {homedir} from 'os';
 import * as path from 'path';
 // eslint-disable-next-line no-restricted-imports
 import {pathToFileURL} from 'url';
-import {parse as parseYaml} from 'yaml';
 
 type ResolveConfigResult = {
   filepath: string,
@@ -57,12 +56,8 @@ const SEARCH_PLACES = [
   'package.json',
 ];
 
-const JS_EXTENSIONS = new Set([
-  ...SEARCH_JS_EXTS,
-  '.es6', // Deprecated
-]);
+const JS_EXTENSIONS = new Set(SEARCH_JS_EXTS);
 const TS_EXTENSIONS = new Set(SEARCH_TS_EXTS);
-const YAML_EXTENSIONS = new Set(['.yml', '.yaml', '']); // Deprecated
 
 const PACKAGE_JSON = path.sep + 'package.json';
 const PACKAGE_JSON_PROP_NAME = 'metro';
@@ -394,7 +389,7 @@ async function loadConfig(
 export async function loadConfigFile(
   absolutePath: string,
 ): Promise<ResolveConfigResult> {
-  // Config should be JSON, CommonJS, ESM or YAML (deprecated)
+  // Config should be JSON, CommonJS, or ESM
   let config: unknown;
   const extension = path.extname(absolutePath);
 
@@ -436,15 +431,14 @@ export async function loadConfigFile(
         throw error;
       }
     }
-  } else if (YAML_EXTENSIONS.has(extension)) {
-    console.warn(
-      'YAML config is deprecated, please migrate to JavaScript config (e.g. metro.config.js)',
+  } else if (extension === '.yaml' || extension === '.yml') {
+    throw new Error(
+      'YAML config is no longer supported, please migrate to JavaScript config (e.g. metro.config.js)',
     );
-    config = parseYaml(fs.readFileSync(absolutePath, 'utf8'));
   } else {
     throw new Error(
       `Unsupported config file extension: ${extension}. ` +
-        `Supported extensions are ${[...JS_EXTENSIONS, ...TS_EXTENSIONS, ...YAML_EXTENSIONS].map(ext => (ext === '' ? 'none' : `${ext}`)).join()})}.`,
+        `Supported extensions are ${[...JS_EXTENSIONS, ...TS_EXTENSIONS].map(ext => (ext === '' ? 'none' : `${ext}`)).join()})}.`,
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5913,11 +5913,6 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.6.1.tgz#42f2b1ba89203f374609572d5349fb8686500773"
-  integrity sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==
-
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"


### PR DESCRIPTION
Summary:

These have been deprecated (with a runtime warning) and removal planned for a year now. I believe they're little used in the wild and inherently very limited. Expo has already dropped support.

Removing YAML support lets us drop a dependency also.

Changelog:
```
 - **[Breaking]**: Remove support for YAML and `.es6` config files
```

Differential Revision: D109987702


