### PR TITLE
Fix mergeConfig dropping state when a config in the chain is async

### DIFF
--- a/packages/metro-config/src/__tests__/mergeConfig-test.js
+++ b/packages/metro-config/src/__tests__/mergeConfig-test.js
@@ -29,6 +29,20 @@ describe('mergeConfig', () => {
     });
   });
 
+  test('applies trailing overrides after an async config function', async () => {
+    const base: InputConfigT = {server: {port: 8081}};
+    const asyncOverride = (): Promise<InputConfigT> =>
+      Promise.resolve({transformer: {assetPlugins: ['async-plugin']}});
+    const trailing: InputConfigT = {resolver: {sourceExts: ['ts']}};
+
+    const result = await mergeConfig(base, asyncOverride, trailing);
+
+    // The base and every config in the chain must survive the async branch.
+    expect(result.server?.port).toBe(8081);
+    expect(result.transformer?.assetPlugins).toEqual(['async-plugin']);
+    expect(result.resolver?.sourceExts).toEqual(['ts']);
+  });
+
   describe('server.tls merging', () => {
     describe('override IS applied when tls is false or object', () => {
       test('override tls: object replaces base tls: false', () => {

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -244,7 +244,10 @@ function mergeConfig<
       typeof next === 'function' ? next(currentConfig) : next;
     if (nextConfig instanceof Promise) {
       // $FlowFixMe[incompatible-type] Not clear why Flow doesn't like this
-      return mergeConfigAsync(nextConfig, reversedConfigs.toReversed());
+      return mergeConfigAsync(
+        nextConfig.then(resolved => mergeConfigObjects(currentConfig, resolved)),
+        ...reversedConfigs.toReversed(),
+      );
     }
     currentConfig = mergeConfigObjects(currentConfig, nextConfig) as T;
   }


### PR DESCRIPTION
## Summary

When `mergeConfig(base, ...configs)` encounters a config that resolves to a `Promise` (e.g. an async `metro.config.js` / a config function returning a promise) and at least one more config follows it, it hands off to `mergeConfigAsync` with two defects:

1. **Missing spread.** `mergeConfigAsync(baseConfig, ...reversedConfigs)` takes a rest parameter, but the call passed `reversedConfigs.toReversed()` as a single array argument. The remaining configs end up wrapped one level too deep, so they're merged as a bogus object (producing junk keys like `"0"`) instead of being applied as configs.
2. **Dropped accumulator.** `currentConfig` (the base merged with every config to the *left* of the async one) was discarded — the unresolved promise was passed as the base, so all prior merges were lost.

The fix spreads the remaining configs into the rest parameter and folds `currentConfig` into the resolved async config so both the accumulated state and the trailing overrides are preserved.

## Test plan

The existing `mergeConfig` tests only cover sync configs, so this path was uncovered. Added a regression test (an async config function followed by a trailing override) asserting the base, the async config, and the trailing override all survive:

```
yarn jest packages/metro-config/src/__tests__/mergeConfig-test.js
# Tests: 19 passed  (full metro-config package: 40 passed)
```
- Before: `result.server.port` is `undefined` (base dropped); trailing override mangled.
- After: all three configs merge correctly.