### PR TITLE
Fix MockPlugin clobbering the active mock when a non-active duplicate is removed

### DIFF
--- a/packages/metro-file-map/src/plugins/MockPlugin.js
+++ b/packages/metro-file-map/src/plugins/MockPlugin.js
@@ -147,13 +147,18 @@ export default class MockPlugin
     const duplicates = this.#raw.duplicates.get(mockName);
     if (duplicates != null) {
       const posixRelativePath = normalizePathSeparatorsToPosix(canonicalPath);
+      const wasActiveMock = this.#raw.mocks.get(mockName) === posixRelativePath;
       duplicates.delete(posixRelativePath);
       if (duplicates.size === 1) {
         this.#raw.duplicates.delete(mockName);
       }
-      // Set the mock to a remaining duplicate. Should never be empty.
-      const remaining = nullthrows(duplicates.values().next().value);
-      this.#raw.mocks.set(mockName, remaining);
+      // Only reassign the active mock if the file we removed *was* the active
+      // one; otherwise a non-active duplicate's removal would clobber it.
+      if (wasActiveMock) {
+        // Set the mock to a remaining duplicate. Should never be empty.
+        const remaining = nullthrows(duplicates.values().next().value);
+        this.#raw.mocks.set(mockName, remaining);
+      }
     } else {
       this.#raw.mocks.delete(mockName);
     }

--- a/packages/metro-file-map/src/plugins/mocks/__tests__/MockPlugin-test.js
+++ b/packages/metro-file-map/src/plugins/mocks/__tests__/MockPlugin-test.js
@@ -107,6 +107,25 @@ Duplicate manual mock found for \`foo\`:
     });
   });
 
+  test('removing a non-active duplicate keeps the active mock', () => {
+    onFileAdded(p('a/__mocks__/foo.js'));
+    onFileAdded(p('b/__mocks__/foo.js'));
+    onFileAdded(p('c/__mocks__/foo.js')); // latest wins -> active mock is c
+
+    expect(mockMap.getMockModule('foo')).toBe(p('/root/c/__mocks__/foo.js'));
+
+    // Remove a NON-active duplicate (b); the active mock (c) must be kept.
+    mockMap.onChanged({
+      addedFiles: new Map(),
+      modifiedFiles: new Map(),
+      removedFiles: new Map([[p('b/__mocks__/foo.js'), null]]),
+      addedDirectories: new Set(),
+      removedDirectories: new Set(),
+    });
+
+    expect(mockMap.getMockModule('foo')).toBe(p('/root/c/__mocks__/foo.js'));
+  });
+
   test('loads from a snapshot', async () => {
     await mockMap.initialize({
       files: {


### PR DESCRIPTION
## Summary

When a manual-mock file with duplicates is removed, `MockPlugin#onFileRemoved` unconditionally reassigns the active mock to an arbitrary remaining duplicate:

```js
duplicates.delete(posixRelativePath);
if (duplicates.size === 1) {
  this.#raw.duplicates.delete(mockName);
}
// Set the mock to a remaining duplicate. Should never be empty.
const remaining = nullthrows(duplicates.values().next().value);
this.#raw.mocks.set(mockName, remaining);   // always overwrites the active mock
```

It never checks whether the removed file was the *active* mock (`this.#raw.mocks.get(mockName)`). When a **non-active** duplicate is removed and 3+ duplicates exist, `values().next().value` returns the first-inserted path, silently changing which mock resolves — even though the previously-active mock still exists on disk.

The existing 2-duplicate "recovers from duplicates" test masks this because the single remaining element is coincidentally always the right answer.

## Fix

Capture whether the removed file was the active mock *before* deleting, and only reassign in that case.

## Test plan

```
jest packages/metro-file-map/src/plugins/mocks/__tests__/
```
Added a regression test: 3 duplicates (a, b, c → active c), remove the non-active `b`, assert the active mock stays `c`. Fails before (becomes `a`), passes after. Full MockPlugin + getMockName suites: 13 pass, no regressions.