### PR TITLE
Remove long-deprecated `resolver.blacklistRE` config (use `blockList`)

### DIFF
--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -369,11 +369,7 @@ async function loadConfig(
   validate(configuration, {
     exampleConfig: await validConfig(),
     recursiveDenylist: ['reporter', 'resolver', 'transformer'],
-    deprecatedConfig: {
-      blacklistRE: () =>
-        `Warning: Metro config option \`blacklistRE\` is deprecated.
-         Please use \`blockList\` instead.`,
-    },
+    deprecatedConfig: {},
   });
 
   // Override the configuration with cli parameters

--- a/packages/metro-config/src/types.js
+++ b/packages/metro-config/src/types.js
@@ -102,7 +102,6 @@ export type PerfLoggerFactory = (
 type ResolverConfigT = {
   assetExts: ReadonlyArray<string>,
   assetResolutions: ReadonlyArray<string>,
-  blacklistRE?: RegExp | Array<RegExp>,
   blockList: RegExp | Array<RegExp>,
   disableHierarchicalLookup: boolean,
   dependencyExtractor: ?string,

--- a/packages/metro-config/types/types.d.ts
+++ b/packages/metro-config/types/types.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<926fc453e7c2af496911a003ca20e556>>
+ * @generated SignedSource<<fcd4ec40719bf4050bc337bfa17ccc5a>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-config/src/types.js
@@ -91,7 +91,6 @@ export type PerfLoggerFactory = (
 type ResolverConfigT = {
   assetExts: ReadonlyArray<string>;
   assetResolutions: ReadonlyArray<string>;
-  blacklistRE?: RegExp | Array<RegExp>;
   blockList: RegExp | Array<RegExp>;
   disableHierarchicalLookup: boolean;
   dependencyExtractor: null | undefined | string;

--- a/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
+++ b/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
@@ -19,43 +19,29 @@ import MetroFileMap, {
   HastePlugin,
 } from 'metro-file-map';
 
-function getIgnorePattern(config: ConfigT): RegExp {
-  // For now we support both options
-  const {blockList, blacklistRE} = config.resolver;
-  const ignorePattern = blacklistRE || blockList;
-
-  // If neither option has been set, use default pattern
-  if (!ignorePattern) {
-    return / ^/;
+const flattenBlockList = (regexes: ConfigT['resolver']['blockList']) => {
+  if (!Array.isArray(regexes)) {
+    return regexes;
   }
-
-  const combine = (regexes: Array<RegExp>) =>
-    new RegExp(
-      regexes
-        .map((regex, index) => {
-          if (regex.flags !== regexes[0].flags) {
-            throw new Error(
-              'Cannot combine blockList patterns, because they have different flags:\n' +
-                ' - Pattern 0: ' +
-                regexes[0].toString() +
-                '\n' +
-                ` - Pattern ${index}: ` +
-                regexes[index].toString(),
-            );
-          }
-          return '(' + regex.source + ')';
-        })
-        .join('|'),
-      regexes[0]?.flags ?? '',
-    );
-
-  // If ignorePattern is an array, merge it into one
-  if (Array.isArray(ignorePattern)) {
-    return combine(ignorePattern);
-  }
-
-  return ignorePattern;
-}
+  return new RegExp(
+    regexes
+      .map((regex, index) => {
+        if (regex.flags !== regexes[0].flags) {
+          throw new Error(
+            'Cannot combine blockList patterns, because they have different flags:\n' +
+              ' - Pattern 0: ' +
+              regexes[0].toString() +
+              '\n' +
+              ` - Pattern ${index}: ` +
+              regexes[index].toString(),
+          );
+        }
+        return '(' + regex.source + ')';
+      })
+      .join('|'),
+    regexes[0]?.flags ?? '',
+  );
+};
 
 export default function createFileMap(
   config: ConfigT,
@@ -126,7 +112,7 @@ export default function createFileMap(
       ]),
     ),
     healthCheck: config.watcher.healthCheck,
-    ignorePattern: getIgnorePattern(config),
+    ignorePattern: flattenBlockList(config.resolver.blockList),
     maxWorkers: config.maxWorkers,
     plugins,
     retainAllFiles: true,


### PR DESCRIPTION
Summary:
`blacklistRE` was deprecated in favour of `blockList` [in 2020](https://github.com/react/metro/commit/94c0b541b4bfa17aee4efa0f1969565522ce830d). This removes it (the next release is semver major anyway), and tidies up some shim code.

Changelog:
```
 - **[Breaking]**: Remove deprecated `resolver.blacklistRE` (use `blockList`) 
```

Reviewed By: huntie

Differential Revision: D110175146


