### PR TITLE
Remove deprecated default exports from public entry points (#1759)

### DIFF
--- a/packages/metro-babel-transformer/src/index.js
+++ b/packages/metro-babel-transformer/src/index.js
@@ -188,11 +188,3 @@ function getCacheKey(options?: BabelTransformerCacheKeyOptions): string {
 */
 
 export {transform, getCacheKey};
-
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-babel-transformer' is deprecated, use named exports.
- */
-export default {transform, getCacheKey};

--- a/packages/metro-babel-transformer/types/index.d.ts
+++ b/packages/metro-babel-transformer/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<c71ff6c13c916919d1340d231518de8f>>
+ * @generated SignedSource<<346524f1f00a1d545b2f71e3afa6df07>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-babel-transformer/src/index.js
@@ -105,16 +105,3 @@ declare function transform(
  */
 declare function getCacheKey(options?: BabelTransformerCacheKeyOptions): string;
 export {transform, getCacheKey};
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-babel-transformer' is deprecated, use named exports.
- */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: {
-  transform: typeof transform;
-  getCacheKey: typeof getCacheKey;
-};
-declare type $$EXPORT_DEFAULT_DECLARATION$$ =
-  typeof $$EXPORT_DEFAULT_DECLARATION$$;
-export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-cache/src/index.js
+++ b/packages/metro-cache/src/index.js
@@ -37,18 +37,3 @@ export interface MetroCache {
   readonly HttpStore: typeof HttpStore;
   readonly stableHash: typeof stableHash;
 }
-
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-cache' is deprecated, use named exports.
- */
-export default {
-  AutoCleanFileStore,
-  Cache,
-  FileStore,
-  HttpGetStore,
-  HttpStore,
-  stableHash,
-} as MetroCache;

--- a/packages/metro-cache/types/index.d.ts
+++ b/packages/metro-cache/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<2bb72546f80164eb8c0068f9de3a1487>>
+ * @generated SignedSource<<804f03bb7635d27850a096a40e46de0c>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-cache/src/index.js
@@ -41,13 +41,3 @@ export interface MetroCache {
   readonly HttpStore: typeof HttpStore;
   readonly stableHash: typeof stableHash;
 }
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-cache' is deprecated, use named exports.
- */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: MetroCache;
-declare type $$EXPORT_DEFAULT_DECLARATION$$ =
-  typeof $$EXPORT_DEFAULT_DECLARATION$$;
-export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -15,11 +15,3 @@ import getDefaultConfig from './defaults';
 import {loadConfig, mergeConfig, resolveConfig} from './loadConfig';
 
 export {getDefaultConfig, loadConfig, mergeConfig, resolveConfig};
-
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-config' is deprecated, use named exports.
- */
-export default {getDefaultConfig, loadConfig, mergeConfig, resolveConfig};

--- a/packages/metro-config/types/index.d.ts
+++ b/packages/metro-config/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<e60b75113fdb3dbe291de1bc9b2656e2>>
+ * @generated SignedSource<<9dd33483d38a4822221997a63b6ed7d0>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-config/src/index.flow.js
@@ -20,18 +20,3 @@ import getDefaultConfig from './defaults';
 import {loadConfig, mergeConfig, resolveConfig} from './loadConfig';
 
 export {getDefaultConfig, loadConfig, mergeConfig, resolveConfig};
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-config' is deprecated, use named exports.
- */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: {
-  getDefaultConfig: typeof getDefaultConfig;
-  loadConfig: typeof loadConfig;
-  mergeConfig: typeof mergeConfig;
-  resolveConfig: typeof resolveConfig;
-};
-declare type $$EXPORT_DEFAULT_DECLARATION$$ =
-  typeof $$EXPORT_DEFAULT_DECLARATION$$;
-export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-core/src/index.js
+++ b/packages/metro-core/src/index.js
@@ -20,16 +20,3 @@ export {
   PackageResolutionError,
   Terminal,
 };
-
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-core' is deprecated, use named exports.
- */
-export default {
-  AmbiguousModuleResolutionError,
-  Logger,
-  PackageResolutionError,
-  Terminal,
-};

--- a/packages/metro-core/types/index.d.ts
+++ b/packages/metro-core/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<80e0670a74f3bf0ae7524193ec36bff9>>
+ * @generated SignedSource<<7bae6aff5277ac3c20ebc15002863e29>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-core/src/index.js
@@ -26,18 +26,3 @@ export {
   PackageResolutionError,
   Terminal,
 };
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-core' is deprecated, use named exports.
- */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: {
-  AmbiguousModuleResolutionError: typeof AmbiguousModuleResolutionError;
-  Logger: typeof Logger;
-  PackageResolutionError: typeof PackageResolutionError;
-  Terminal: typeof Terminal;
-};
-declare type $$EXPORT_DEFAULT_DECLARATION$$ =
-  typeof $$EXPORT_DEFAULT_DECLARATION$$;
-export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-resolver/src/index.js
+++ b/packages/metro-resolver/src/index.js
@@ -40,18 +40,3 @@ export {
   InvalidPackageError,
   resolve,
 };
-
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-resolver' is deprecated, use named exports.
- */
-export default {
-  FailedToResolveNameError,
-  FailedToResolvePathError,
-  FailedToResolveUnsupportedError,
-  formatFileCandidates,
-  InvalidPackageError,
-  resolve,
-};

--- a/packages/metro-resolver/types/index.d.ts
+++ b/packages/metro-resolver/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<c26a662896a7bf2992a47a7daf457cbf>>
+ * @generated SignedSource<<ff5d24a27b09aefdeb721ffcce936372>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-resolver/src/index.js
@@ -45,20 +45,3 @@ export {
   InvalidPackageError,
   resolve,
 };
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-resolver' is deprecated, use named exports.
- */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: {
-  FailedToResolveNameError: typeof FailedToResolveNameError;
-  FailedToResolvePathError: typeof FailedToResolvePathError;
-  FailedToResolveUnsupportedError: typeof FailedToResolveUnsupportedError;
-  formatFileCandidates: typeof formatFileCandidates;
-  InvalidPackageError: typeof InvalidPackageError;
-  resolve: typeof resolve;
-};
-declare type $$EXPORT_DEFAULT_DECLARATION$$ =
-  typeof $$EXPORT_DEFAULT_DECLARATION$$;
-export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-source-map/src/source-map.js
+++ b/packages/metro-source-map/src/source-map.js
@@ -616,23 +616,3 @@ export {
   vlqMapFromBabelDecodedMap,
   vlqMapFromTuples,
 };
-
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-source-map' is deprecated, use named exports.
- */
-export default {
-  BundleBuilder,
-  composeSourceMaps,
-  Consumer,
-  createIndexMap,
-  generateFunctionMap,
-  fromRawMappings,
-  fromRawMappingsNonBlocking,
-  functionMapBabelPlugin,
-  normalizeSourcePath,
-  toBabelSegments,
-  toSegmentTuple,
-};

--- a/packages/metro-source-map/types/source-map.d.ts
+++ b/packages/metro-source-map/types/source-map.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<13fbae6a38a28c6a6e3a2be58804c33d>>
+ * @generated SignedSource<<a3a499a683d5ea557e429489802510ae>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-source-map/src/source-map.js
@@ -219,25 +219,3 @@ export {
   vlqMapFromBabelDecodedMap,
   vlqMapFromTuples,
 };
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-source-map' is deprecated, use named exports.
- */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: {
-  BundleBuilder: typeof BundleBuilder;
-  composeSourceMaps: typeof composeSourceMaps;
-  Consumer: typeof Consumer;
-  createIndexMap: typeof createIndexMap;
-  generateFunctionMap: typeof generateFunctionMap;
-  fromRawMappings: typeof fromRawMappings;
-  fromRawMappingsNonBlocking: typeof fromRawMappingsNonBlocking;
-  functionMapBabelPlugin: typeof functionMapBabelPlugin;
-  normalizeSourcePath: typeof normalizeSourcePath;
-  toBabelSegments: typeof toBabelSegments;
-  toSegmentTuple: typeof toSegmentTuple;
-};
-declare type $$EXPORT_DEFAULT_DECLARATION$$ =
-  typeof $$EXPORT_DEFAULT_DECLARATION$$;
-export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro-transform-worker/src/index.js
+++ b/packages/metro-transform-worker/src/index.js
@@ -835,14 +835,3 @@ function countLinesAndTerminateMap(
   }
   return {lineCount, map: [...map]};
 }
-
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-transform-worker' is deprecated, use named exports.
- */
-export default {
-  getCacheKey,
-  transform,
-};

--- a/packages/metro-transform-worker/types/index.d.ts
+++ b/packages/metro-transform-worker/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<9cf6eca6abe0d86fd41c697473f45aff>>
+ * @generated SignedSource<<42a021f72552951fbd1a0bdc2c2bb138>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-transform-worker/src/index.js
@@ -115,16 +115,3 @@ export declare const getCacheKey: (
   opts?: Readonly<{projectRoot: string}>,
 ) => string;
 export declare type getCacheKey = typeof getCacheKey;
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro-transform-worker' is deprecated, use named exports.
- */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: {
-  getCacheKey: typeof getCacheKey;
-  transform: typeof transform;
-};
-declare type $$EXPORT_DEFAULT_DECLARATION$$ =
-  typeof $$EXPORT_DEFAULT_DECLARATION$$;
-export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/metro/src/index.flow.js
+++ b/packages/metro/src/index.flow.js
@@ -587,23 +587,3 @@ async function earlyPortCheck(host: void | string, port: number) {
     await new Promise(resolve => server.close(() => resolve()));
   }
 }
-
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro' is deprecated, use named exports.
- */
-export default {
-  attachMetroCli,
-  runServer,
-  Terminal,
-  JsonReporter,
-  TerminalReporter,
-  loadConfig,
-  mergeConfig,
-  resolveConfig,
-  createConnectMiddleware,
-  runBuild,
-  buildGraph,
-};

--- a/packages/metro/types/index.d.ts
+++ b/packages/metro/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<3c6460427c6760887187d6b16151c609>>
+ * @generated SignedSource<<8cfd5068558051749a42bc72eb4b915f>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/index.flow.js
@@ -182,25 +182,3 @@ export declare const attachMetroCli: (
   options?: AttachMetroCLIOptions,
 ) => Yargs;
 export declare type attachMetroCli = typeof attachMetroCli;
-/**
- * Backwards-compatibility with CommonJS consumers using interopRequireDefault.
- * Do not add to this list.
- *
- * @deprecated Default import from 'metro' is deprecated, use named exports.
- */
-declare const $$EXPORT_DEFAULT_DECLARATION$$: {
-  attachMetroCli: typeof attachMetroCli;
-  runServer: typeof runServer;
-  Terminal: typeof Terminal;
-  JsonReporter: typeof JsonReporter;
-  TerminalReporter: typeof TerminalReporter;
-  loadConfig: typeof loadConfig;
-  mergeConfig: typeof mergeConfig;
-  resolveConfig: typeof resolveConfig;
-  createConnectMiddleware: typeof createConnectMiddleware;
-  runBuild: typeof runBuild;
-  buildGraph: typeof buildGraph;
-};
-declare type $$EXPORT_DEFAULT_DECLARATION$$ =
-  typeof $$EXPORT_DEFAULT_DECLARATION$$;
-export default $$EXPORT_DEFAULT_DECLARATION$$;


### PR DESCRIPTION
Summary:

Remove the deprecated default-object export from Metro packages. The supported public API is now exclusively named exports, so any consumer importing a Metro package's default - directly, or implicitly via Babel/TypeScript `esModuleInterop` - will break and must migrate to named imports.

This affects the public entry points of `metro`, `metro-config`, `metro-cache`, `metro-core`, `metro-resolver`, `metro-source-map`, `metro-babel-transformer`, and `metro-transform-worker`.

Default imports like these will no longer work:

```js
import metro from 'metro';
metro.runServer(config);

import metroConfig from 'metro-config';
const config = await metroConfig.loadConfig();
```

```js
const metro = require('metro').default;
metro.runBuild(config, options);
```

Switch to named imports instead:

```js
import {runServer, runBuild} from 'metro';
import {loadConfig, mergeConfig} from 'metro-config';

runServer(config);
```

```js
const {runBuild} = require('metro');
runBuild(config, options);
```

Namespace imports are unaffected and continue to work, since they bind the package's named exports:

```js
import * as metro from 'metro';
metro.runServer(config);
```

Changelog: [Breaking] Removed the deprecated default export from Metro's public packages; use named (or namespace) imports instead.

___

Reviewed By: huntie

Differential Revision: D110062342


