### PR TITLE
Default unstable_renameRequire to false in base config (#1776)

### DIFF
--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -128,7 +128,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     optimizationSizeLimit: 150 * 1024, // 150 KiB.
     transformVariants: {default: {}},
     publicPath: '/assets',
-    allowOptionalDependencies: false,
+    allowOptionalDependencies: true,
     unstable_allowRequireContext: false,
     unstable_dependencyMapReservedName: null,
     unstable_disableModuleWrapping: false,

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -133,7 +133,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     unstable_dependencyMapReservedName: null,
     unstable_disableModuleWrapping: false,
     unstable_disableNormalizePseudoGlobals: false,
-    unstable_renameRequire: true,
+    unstable_renameRequire: false,
     unstable_compactOutput: false,
     unstable_memoizeInlineRequires: false,
     unstable_workerThreads: false,

--- a/packages/metro/src/integration_tests/__tests__/__snapshots__/buildGraph-test.js.snap
+++ b/packages/metro/src/integration_tests/__tests__/__snapshots__/buildGraph-test.js.snap
@@ -4,12 +4,12 @@ exports[`should build the dependency graph 1`] = `
 Array [
   Object {
     "data": Object {
-      "code": "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+      "code": "__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
-  var Bar = _$$_REQUIRE(_dependencyMap[0]);
-  var Foo = _$$_REQUIRE(_dependencyMap[1]);
-  var TypeScript = _$$_REQUIRE(_dependencyMap[2]);
+  var Bar = require(_dependencyMap[0]);
+  var Foo = require(_dependencyMap[1]);
+  var TypeScript = require(_dependencyMap[2]);
   Object.keys(Object.assign({}, Bar));
   module.exports = {
     Foo: Foo,
@@ -25,7 +25,7 @@ Array [
       },
       "lineCount": 13,
       "map": Object {
-        "mappings": ";EAUA,YAAY;;EAEZ,IAAMA,GAAG,GAAGC,WAAO,CAAAC,cAAA,GAAQ,CAAC;EAC5B,IAAMC,GAAG,GAAGF,WAAO,CAAAC,cAAA,GAAQ,CAAC;EAG5B,IAAME,UAAU,GAAGH,WAAO,CAAAC,cAAA,GAAe,CAAC;EAE1CG,MAAM,CAACC,IAAI,CAAAD,MAAA,CAAAE,MAAA,KAAKP,GAAG,CAAC,CAAC;EAErBQ,MAAM,CAACC,OAAO,GAAG;IAACN,GAAG,EAAHA,GAAG;IAAEH,GAAG,EAAHA,GAAG;IAAEI,UAAU,EAAVA;EAAU,CAAC;AAAC,G",
+        "mappings": ";EAUA,YAAY;;EAEZ,IAAMA,GAAG,GAAGC,OAAO,CAAAC,cAAA,GAAQ,CAAC;EAC5B,IAAMC,GAAG,GAAGF,OAAO,CAAAC,cAAA,GAAQ,CAAC;EAG5B,IAAME,UAAU,GAAGH,OAAO,CAAAC,cAAA,GAAe,CAAC;EAE1CG,MAAM,CAACC,IAAI,CAAAD,MAAA,CAAAE,MAAA,KAAKP,GAAG,CAAC,CAAC;EAErBQ,MAAM,CAACC,OAAO,GAAG;IAACN,GAAG,EAAHA,GAAG;IAAEH,GAAG,EAAHA,GAAG;IAAEI,UAAU,EAAVA;EAAU,CAAC;AAAC,G",
         "names": Array [
           "Bar",
           "require",

--- a/packages/metro/src/integration_tests/__tests__/optional-dependencies-test.js
+++ b/packages/metro/src/integration_tests/__tests__/optional-dependencies-test.js
@@ -44,7 +44,7 @@ test('builds a simple bundle', async () => {
   expect(match).not.toBeNull();
 
   expect(match[0]).toMatchInlineSnapshot(`
-"__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+"__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
   'use strict';
 
   Object.defineProperty(exports, '__esModule', {
@@ -52,16 +52,16 @@ test('builds a simple bundle', async () => {
   });
   var shouldBeB, shouldBeC;
   try {
-    shouldBeB = _$$_REQUIRE(_dependencyMap[0], \\"./not-exists\\");
+    shouldBeB = require(_dependencyMap[0], \\"./not-exists\\");
   } catch (_unused) {
-    shouldBeB = _$$_REQUIRE(_dependencyMap[1], \\"./optional-b\\");
+    shouldBeB = require(_dependencyMap[1], \\"./optional-b\\");
   }
   (function requireOptionalC() {
     try {
-      shouldBeC = _$$_REQUIRE(_dependencyMap[2], \\"./optional-c\\");
+      shouldBeC = require(_dependencyMap[2], \\"./optional-c\\");
     } catch (e) {}
   })();
-  var a = _$$_REQUIRE(_dependencyMap[3], \\"./required-a\\");
+  var a = require(_dependencyMap[3], \\"./required-a\\");
   var b = shouldBeB;
   var c = shouldBeC;
   exports.a = a;


### PR DESCRIPTION
Summary:

Flips the OSS default of the `unstable_renameRequire` transformer option
from `true` to `false` in `metro-config`. With renaming disabled, the scoped
`require` function is left as `require` instead of being renamed to
`_$$_REQUIRE` when serializing to the IIFE module factory (the default).

Tested with repeated, interleaved, RNTester dev builds with a cold transform cache:
```
metric                 OFF (false)   ON (true)     delta
cold build, mean       10.65 s       11.21 s       -0.56 s (~5%)
cold build, median     11.09 s       11.73 s       -0.64 s (~5.5%)
_$$_REQUIRE renames    0             3,534         -3,534
```

NB: Expo already sets this to `false`, so this is a no-op for Expo users.

```
 - **[Performance]** Don't rename `require` in bundle output, improve cold build time ~5%`
```

Reviewed By: huntie

Differential Revision: D111627295


