### PR TITLE
Use node: schema to import Node.js builtins (#1782)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const crypto = require('crypto');
-const fs = require('fs');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
 
 /*::
 import type {BabelCoreOptions} from '@babel/core';

--- a/packages/buck-worker-tool/src/__tests__/worker-test.js
+++ b/packages/buck-worker-tool/src/__tests__/worker-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 jest
-  .mock('console', () => {
+  .mock('node:console', () => {
     // Automocking is no longer working with jest after https://github.com/nodejs/node/pull/35399
     // because the typeof console is now 'console' and no longer Object.
     const mock = jest.fn();
@@ -21,16 +21,17 @@ jest
 
     return {Console};
   })
-  .mock('fs', () => new (require('metro-memory-fs'))())
+  .mock('node:fs', () => new (require('metro-memory-fs'))())
   .useRealTimers();
 
 const JSONStream = require('../third-party/JSONStream');
 const {buckWorker} = require('../worker-tool');
-// mocked
-const {Console} = require('console');
-const fs = require('fs');
-const path = require('path');
+const path = require('node:path');
 const through = require('through');
+
+// mocked
+const {Console} = jest.requireMock('node:console');
+const fs = jest.requireMock('node:fs');
 
 const {any, anything} = expect;
 

--- a/packages/buck-worker-tool/src/profiling.js
+++ b/packages/buck-worker-tool/src/profiling.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import fs from 'fs';
+import fs from 'node:fs';
 
 let currentInspectorSession;
 let isProfiling = false;
@@ -19,7 +19,7 @@ function getInspectorSession() {
     return currentInspectorSession;
   }
   // eslint-disable-next-line import/no-commonjs
-  const inspector = require('inspector');
+  const inspector = require('node:inspector');
   currentInspectorSession = new inspector.Session();
   currentInspectorSession.connect();
   return currentInspectorSession;

--- a/packages/buck-worker-tool/src/worker-tool.js
+++ b/packages/buck-worker-tool/src/worker-tool.js
@@ -9,14 +9,14 @@
  * @oncall react_native
  */
 
-import type {Duplex, Writable} from 'stream';
+import type {Duplex, Writable} from 'node:stream';
 
 import {startProfiling, stopProfilingAndWrite} from './profiling';
 import JSONStream from './third-party/JSONStream';
-import {Console} from 'console';
 import duplexer from 'duplexer';
-import fs from 'fs';
 import invariant from 'invariant';
+import {Console} from 'node:console';
+import fs from 'node:fs';
 
 export type Command = (
   argv: Array<string>,

--- a/packages/buck-worker-tool/types/worker-tool.d.ts
+++ b/packages/buck-worker-tool/types/worker-tool.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<a2ba9ab7d2f4ec16efe9d5fae9bbab44>>
+ * @generated SignedSource<<ac520db8175e0ea99ea26ccce74debc2>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/buck-worker-tool/src/worker-tool.js
@@ -15,9 +15,9 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {Duplex} from 'stream';
+import type {Duplex} from 'node:stream';
 
-import {Console} from 'console';
+import {Console} from 'node:console';
 
 export type Command = (argv: Array<string>, structuredArgs: unknown, console: Console) => Promise<void> | void;
 export type Commands = {[key: string]: Command};

--- a/packages/metro-babel-register/src/__tests__/parses-without-transpilation-test.js
+++ b/packages/metro-babel-register/src/__tests__/parses-without-transpilation-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const {promises: fsPromises} = require('fs');
-const vm = require('vm');
+const {promises: fsPromises} = require('node:fs');
+const vm = require('node:vm');
 
 test('can be loaded directly without transpilation', async () => {
   const code = await fsPromises.readFile(

--- a/packages/metro-babel-register/src/babel-register.js
+++ b/packages/metro-babel-register/src/babel-register.js
@@ -18,8 +18,8 @@ import type {BabelCoreOptions} from '@babel/core';
 */
 
 const escapeRegExp = require('escape-string-regexp');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 let _only /*: ReadonlyArray<RegExp | string> */ = [];
 

--- a/packages/metro-babel-transformer/src/__tests__/transform-test.js
+++ b/packages/metro-babel-transformer/src/__tests__/transform-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const {transform} = require('../index.js');
-const path = require('path');
+const path = require('node:path');
 
 const PROJECT_ROOT = path.sep === '/' ? '/my/project' : 'C:\\my\\project';
 

--- a/packages/metro-cache-key/src/__tests__/index-test.js
+++ b/packages/metro-cache-key/src/__tests__/index-test.js
@@ -11,10 +11,11 @@
 
 'use strict';
 
-jest.mock('fs', () => new (require('metro-memory-fs'))());
+jest.mock('node:fs', () => new (require('metro-memory-fs'))());
 
 const {getCacheKey} = require('../index');
-const fs = require('fs');
+
+const fs = jest.requireMock('node:fs');
 
 beforeAll(() => {
   fs.writeFileSync('/a.txt', 'fake content for a.txt');

--- a/packages/metro-cache-key/src/index.js
+++ b/packages/metro-cache-key/src/index.js
@@ -9,8 +9,8 @@
  * @oncall react_native
  */
 
-import crypto from 'crypto';
-import fs from 'fs';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
 
 export function getCacheKey(files: ReadonlyArray<string>): string {
   return files

--- a/packages/metro-cache/src/stableHash.js
+++ b/packages/metro-cache/src/stableHash.js
@@ -9,8 +9,8 @@
  * @oncall react_native
  */
 
-import crypto from 'crypto';
 import canonicalize from 'metro-core/private/canonicalize';
+import crypto from 'node:crypto';
 
 export default function stableHash(value: unknown): Buffer {
   return (

--- a/packages/metro-cache/src/stores/AutoCleanFileStore.js
+++ b/packages/metro-cache/src/stores/AutoCleanFileStore.js
@@ -12,8 +12,8 @@
 import type {Options} from './FileStore';
 
 import FileStore from './FileStore';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 type CleanOptions = Readonly<{
   ...Options,

--- a/packages/metro-cache/src/stores/FileStore.js
+++ b/packages/metro-cache/src/stores/FileStore.js
@@ -9,8 +9,8 @@
  * @oncall react_native
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const NULL_BYTE = 0x00;
 const NULL_BYTE_BUFFER = Buffer.from([NULL_BYTE]);

--- a/packages/metro-cache/src/stores/HttpStore.js
+++ b/packages/metro-cache/src/stores/HttpStore.js
@@ -14,10 +14,10 @@ import type {HttpsProxyAgentOptions} from 'https-proxy-agent';
 import HttpError from './HttpError';
 import NetworkError from './NetworkError';
 import {backOff} from 'exponential-backoff';
-import http from 'http';
-import https from 'https';
 import {HttpsProxyAgent} from 'https-proxy-agent';
-import zlib from 'zlib';
+import http from 'node:http';
+import https from 'node:https';
+import zlib from 'node:zlib';
 
 export type Options =
   | EndpointOptions // Uses the same options for both reads and writes

--- a/packages/metro-cache/src/stores/__tests__/AutoCleanFileStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/AutoCleanFileStore-test.js
@@ -19,9 +19,9 @@ describe('AutoCleanFileStore', () => {
     jest
       .resetModules()
       .resetAllMocks()
-      .mock('fs', () => memfs().fs);
+      .mock('node:fs', () => memfs().fs);
     AutoCleanFileStore = require('../AutoCleanFileStore').default;
-    fs = require('fs');
+    fs = jest.requireMock('node:fs');
     jest.spyOn(fs, 'statSync');
     jest.spyOn(fs, 'unlinkSync');
   });

--- a/packages/metro-cache/src/stores/__tests__/FileStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/FileStore-test.js
@@ -19,10 +19,10 @@ describe('FileStore', () => {
     jest
       .resetModules()
       .resetAllMocks()
-      .mock('fs', () => memfs().fs);
+      .mock('node:fs', () => memfs().fs);
 
     FileStore = require('../FileStore').default;
-    fs = require('fs');
+    fs = jest.requireMock('node:fs');
     jest.spyOn(fs, 'unlinkSync');
   });
 
@@ -54,7 +54,7 @@ describe('FileStore', () => {
     const cache = Buffer.from([0xfa, 0xce, 0xb0, 0x0c]);
     const data = Buffer.from([0xca, 0xc4, 0xe5]);
 
-    require('fs').rmSync('/root', {recursive: true, force: true});
+    jest.requireMock('node:fs').rmSync('/root', {recursive: true, force: true});
     await fileStore.set(cache, data);
     expect(await fileStore.get(cache)).toEqual(data);
   });

--- a/packages/metro-cache/src/stores/__tests__/HttpGetStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/HttpGetStore-test.js
@@ -7,8 +7,8 @@
 
 'use strict';
 
-const {PassThrough} = require('stream');
-const zlib = require('zlib');
+const {PassThrough} = require('node:stream');
+const zlib = require('node:zlib');
 
 jest.useRealTimers();
 
@@ -37,10 +37,10 @@ describe('HttpGetStore', () => {
   }
 
   beforeEach(() => {
-    jest.resetModules().resetAllMocks().mock('http');
+    jest.resetModules().resetAllMocks().mock('node:http');
 
     httpPassThrough = new PassThrough();
-    require('http').request.mockReturnValue(httpPassThrough);
+    jest.requireMock('node:http').request.mockReturnValue(httpPassThrough);
 
     HttpGetStore = require('../HttpGetStore').default;
 
@@ -56,7 +56,7 @@ describe('HttpGetStore', () => {
       endpoint: 'http://www.example.com/endpoint',
     });
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] = jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
     expect(opts.host).toEqual('www.example.com');
@@ -72,7 +72,7 @@ describe('HttpGetStore', () => {
   test("doesn't throw any error and doesn't warn on http status 404 errors", async () => {
     const store = new HttpGetStore({endpoint: 'http://example.com'});
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] = jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
 
@@ -88,7 +88,7 @@ describe('HttpGetStore', () => {
   test("doesn't throw any error and warns on http status 502 errors", async () => {
     const store = new HttpGetStore({endpoint: 'http://example.com'});
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] = jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
 

--- a/packages/metro-cache/src/stores/__tests__/HttpStore-test.js
+++ b/packages/metro-cache/src/stores/__tests__/HttpStore-test.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const {PassThrough} = require('stream');
-const zlib = require('zlib');
+const {PassThrough} = require('node:stream');
+const zlib = require('node:zlib');
 
 describe('HttpStore', () => {
   let HttpStore;
@@ -60,12 +60,12 @@ describe('HttpStore', () => {
       .resetModules()
       .resetAllMocks()
       .useFakeTimers({legacyFakeTimers: true}) // Legacy fake timers are reset by `resetAllMocks()`
-      .mock('http')
-      .mock('https');
+      .mock('node:http')
+      .mock('node:https');
 
     httpPassThrough = new PassThrough();
-    require('http').request.mockReturnValue(httpPassThrough);
-    require('https').request.mockReturnValue(httpPassThrough);
+    jest.requireMock('node:http').request.mockReturnValue(httpPassThrough);
+    jest.requireMock('node:https').request.mockReturnValue(httpPassThrough);
 
     HttpStore = require('../HttpStore').default;
   });
@@ -75,20 +75,21 @@ describe('HttpStore', () => {
     const httpsStore = new HttpStore({endpoint: 'https://example.com'});
 
     httpStore.get(Buffer.from('foo'));
-    expect(require('http').request).toHaveBeenCalledTimes(1);
-    expect(require('https').request).not.toHaveBeenCalled();
+    expect(jest.requireMock('node:http').request).toHaveBeenCalledTimes(1);
+    expect(jest.requireMock('node:https').request).not.toHaveBeenCalled();
 
     jest.clearAllMocks();
 
     httpsStore.get(Buffer.from('foo'));
-    expect(require('http').request).not.toHaveBeenCalled();
-    expect(require('https').request).toHaveBeenCalledTimes(1);
+    expect(jest.requireMock('node:http').request).not.toHaveBeenCalled();
+    expect(jest.requireMock('node:https').request).toHaveBeenCalledTimes(1);
   });
 
   test('gets using the network via GET method', async () => {
     const store = new HttpStore({endpoint: 'http://www.example.com/endpoint'});
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
     expect(opts.host).toEqual('www.example.com');
@@ -104,7 +105,8 @@ describe('HttpStore', () => {
   test('rejects when an HTTP different from 200 is returned', done => {
     const store = new HttpStore({endpoint: 'http://example.com'});
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
 
@@ -126,7 +128,8 @@ describe('HttpStore', () => {
       retryStatuses: [429],
     });
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
 
@@ -143,7 +146,7 @@ describe('HttpStore', () => {
     expect(err).toBeInstanceOf(HttpStore.HttpError);
     expect(err.message).toMatch(/HTTP error: 429 Too Many Requests/);
     expect(err.code).toBe(429);
-    expect(require('http').request).toHaveBeenCalledTimes(1);
+    expect(jest.requireMock('node:http').request).toHaveBeenCalledTimes(1);
   });
 
   test('retries http errors when maxAttempts>1 and status in retryStatuses', async () => {
@@ -153,7 +156,7 @@ describe('HttpStore', () => {
       maxAttempts: 2,
       retryStatuses: [429],
     });
-    const {request} = require('http');
+    const {request} = jest.requireMock('node:http');
 
     request.mockImplementation((opts, callback) => {
       if (request.mock.calls.length === 1) {
@@ -175,7 +178,7 @@ describe('HttpStore', () => {
       maxAttempts: 3,
       retryStatuses: [429],
     });
-    const {request} = require('http');
+    const {request} = jest.requireMock('node:http');
 
     request.mockImplementation((opts, callback) => {
       callback(responseHttpError(429));
@@ -201,7 +204,7 @@ describe('HttpStore', () => {
       maxAttempts: 2,
       retryNetworkErrors: true,
     });
-    const {request} = require('http');
+    const {request} = jest.requireMock('node:http');
 
     request.mockImplementation((opts, callback) => {
       if (request.mock.calls.length === 1) {
@@ -221,7 +224,8 @@ describe('HttpStore', () => {
   test('get() includes HTTP error body in rejection with debug: true', done => {
     const store = new HttpStore({endpoint: 'http://example.com', debug: true});
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
 
@@ -244,7 +248,8 @@ describe('HttpStore', () => {
       additionalSuccessStatuses: [419],
     });
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
     expect(opts.host).toEqual('www.example.com');
@@ -260,7 +265,8 @@ describe('HttpStore', () => {
   test('rejects when it gets an invalid JSON response', done => {
     const store = new HttpStore({endpoint: 'http://example.com'});
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
 
@@ -276,7 +282,8 @@ describe('HttpStore', () => {
   test('rejects when the HTTP layer throws', done => {
     const store = new HttpStore({endpoint: 'http://example.com'});
     const promise = store.get(Buffer.from('key'));
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('GET');
 
@@ -301,7 +308,7 @@ describe('HttpStore', () => {
         retryStatuses: [503],
       },
     });
-    const {request} = require('http');
+    const {request} = jest.requireMock('node:http');
 
     request.mockImplementation((opts, callback) => {
       if (request.mock.calls.length === 1) {
@@ -326,7 +333,8 @@ describe('HttpStore', () => {
   test('sets using the network via PUT method', done => {
     const store = new HttpStore({endpoint: 'http://www.example.com/endpoint'});
     const promise = store.set(Buffer.from('key-set'), {foo: 42});
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
     const buf = [];
 
     expect(opts.method).toEqual('PUT');
@@ -351,7 +359,8 @@ describe('HttpStore', () => {
   test('rejects when setting and HTTP fails', done => {
     const store = new HttpStore({endpoint: 'http://example.com'});
     const promise = store.set(Buffer.from('key-set'), {foo: 42});
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('PUT');
 
@@ -371,7 +380,8 @@ describe('HttpStore', () => {
       additionalSuccessStatuses: [403],
     });
     const promise = store.set(Buffer.from('key-set'), {foo: 42});
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('PUT');
     expect(opts.host).toEqual('www.example.com');
@@ -392,7 +402,8 @@ describe('HttpStore', () => {
   test('rejects when setting and HTTP returns an error response', done => {
     const store = new HttpStore({endpoint: 'http://example.com'});
     const promise = store.set(Buffer.from('key-set'), {foo: 42});
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('PUT');
 
@@ -410,7 +421,8 @@ describe('HttpStore', () => {
   test('set() includes HTTP error body in rejection with debug: true', done => {
     const store = new HttpStore({endpoint: 'http://example.com', debug: true});
     const promise = store.set(Buffer.from('key-set'), {foo: 42});
-    const [opts, callback] = require('http').request.mock.calls[0];
+    const [opts, callback] =
+      jest.requireMock('node:http').request.mock.calls[0];
 
     expect(opts.method).toEqual('PUT');
 
@@ -439,7 +451,8 @@ describe('HttpStore', () => {
     httpPassThrough.on('end', () => {
       storedValue = zlib.gunzipSync(Buffer.concat(chunks));
 
-      const callbackSet = require('http').request.mock.calls[0][1];
+      const callbackSet =
+        jest.requireMock('node:http').request.mock.calls[0][1];
 
       callbackSet(responseHttpOk(''));
     });
@@ -447,7 +460,7 @@ describe('HttpStore', () => {
     await store.set(Buffer.from('key-set'), {foo: 42});
 
     const promiseGet = store.get(Buffer.from('key-set'));
-    const callbackGet = require('http').request.mock.calls[1][1];
+    const callbackGet = jest.requireMock('node:http').request.mock.calls[1][1];
 
     callbackGet(responseHttpOk(storedValue));
 
@@ -466,7 +479,8 @@ describe('HttpStore', () => {
     httpPassThrough.on('end', () => {
       storedValue = zlib.gunzipSync(Buffer.concat(chunks));
 
-      const callbackSet = require('http').request.mock.calls[0][1];
+      const callbackSet =
+        jest.requireMock('node:http').request.mock.calls[0][1];
 
       callbackSet(responseHttpOk(''));
     });
@@ -476,7 +490,7 @@ describe('HttpStore', () => {
     await store.set(Buffer.from('key-set'), bufferValue);
 
     const promiseGet = store.get(Buffer.from('key-set'));
-    const callbackGet = require('http').request.mock.calls[1][1];
+    const callbackGet = jest.requireMock('node:http').request.mock.calls[1][1];
 
     callbackGet(responseHttpOk(storedValue));
 

--- a/packages/metro-config/src/__tests__/loadConfig-test.js
+++ b/packages/metro-config/src/__tests__/loadConfig-test.js
@@ -13,9 +13,9 @@
 import getDefaultConfig from '../defaults';
 
 const {loadConfig} = require('../loadConfig');
-const path = require('path');
+const path = require('node:path');
 const prettyFormat = require('pretty-format');
-const util = require('util');
+const util = require('node:util');
 
 const FIXTURES = path.resolve(__dirname, '../__fixtures__');
 
@@ -108,11 +108,11 @@ describe('loadConfig', () => {
   });
 
   test('can load the config with no config present', async () => {
-    jest.mock('fs', () => ({
+    jest.mock('node:fs', () => ({
       existsSync: jest.fn(() => false),
     }));
     const result = await loadConfig({cwd: process.cwd()});
-    jest.unmock('fs');
+    jest.unmock('node:fs');
 
     let defaultConfig = await getDefaultConfig(process.cwd());
     defaultConfig = {
@@ -164,11 +164,11 @@ describe('loadConfig', () => {
 
     beforeAll(() => {
       jest.resetModules();
-      jest.mock('os', () => ({
-        ...jest.requireActual('os'),
+      jest.mock('node:os', () => ({
+        ...jest.requireActual('node:os'),
         homedir: mockHomeDir,
       }));
-      jest.mock('fs', () => ({
+      jest.mock('node:fs', () => ({
         existsSync: mockExistsSync,
       }));
       // Reload after mocking above

--- a/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
+++ b/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
@@ -11,7 +11,7 @@
 
 import exclusionList from '../exclusionList';
 
-const path = require('path');
+const path = require('node:path');
 
 describe('exclusionList', () => {
   let originalSeparator;
@@ -32,9 +32,9 @@ describe('exclusionList', () => {
 
   test('proves we can write to path.sep for setting up the tests', () => {
     setPathSeperator('/');
-    expect(require('path').sep).toBe('/');
+    expect(require('node:path').sep).toBe('/');
     setPathSeperator('\\');
-    expect(require('path').sep).toBe('\\');
+    expect(require('node:path').sep).toBe('\\');
   });
 
   describe('simulate macOS/linux enviornment', () => {

--- a/packages/metro-config/src/defaults/__tests__/getMaxWorkers-test.js
+++ b/packages/metro-config/src/defaults/__tests__/getMaxWorkers-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-jest.mock('os');
+jest.mock('node:os');
 
 import getMaxWorkers from '../getMaxWorkers';
 
-const os = require('os');
+const os = jest.requireMock('node:os');
 
 test('calculates the number of max workers', () => {
   /* $FlowFixMe[prop-missing](>=0.99.0 site=react_native_fb) This comment suppresses an error

--- a/packages/metro-config/src/defaults/exclusionList.js
+++ b/packages/metro-config/src/defaults/exclusionList.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import path from 'path';
+import path from 'node:path';
 
 const list = [/\/__tests__\/.*/];
 

--- a/packages/metro-config/src/defaults/getMaxWorkers.js
+++ b/packages/metro-config/src/defaults/getMaxWorkers.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import os from 'os';
+import os from 'node:os';
 
 export default function getMaxWorkers(workers: ?number): number {
   // $FlowFixMe[prop-missing] Missing Flow lib def for availableParallelism

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -26,8 +26,8 @@ import getMaxWorkers from './getMaxWorkers';
 import {FileStore} from 'metro-cache';
 import {Terminal} from 'metro-core';
 import TerminalReporter from 'metro/private/lib/TerminalReporter';
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 const getDefaultValues = (projectRoot: ?string): ConfigT => ({
   resolver: {

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -13,13 +13,13 @@ import type {ConfigT, InputConfigT, YargArguments} from './types';
 
 import getDefaultConfig from './defaults';
 import validConfig from './defaults/validConfig';
-import * as fs from 'fs';
 import {validate} from 'jest-validate';
 import * as MetroCache from 'metro-cache';
-import {homedir} from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import {homedir} from 'node:os';
+import * as path from 'node:path';
 // eslint-disable-next-line no-restricted-imports
-import {pathToFileURL} from 'url';
+import {pathToFileURL} from 'node:url';
 
 type ResolveConfigResult = {
   filepath: string,

--- a/packages/metro-core/src/Logger.js
+++ b/packages/metro-core/src/Logger.js
@@ -11,8 +11,8 @@
 
 import type {BundleOptions} from 'metro/private/shared/types';
 
-import EventEmitter from 'events';
-import os from 'os';
+import EventEmitter from 'node:events';
+import os from 'node:os';
 
 // eslint-disable-next-line import/no-commonjs
 const VERSION = require('../package.json').version;

--- a/packages/metro-core/src/Terminal.js
+++ b/packages/metro-core/src/Terminal.js
@@ -9,13 +9,13 @@
  * @oncall react_native
  */
 
-import type {Socket} from 'net';
-import type {Writable} from 'stream';
+import type {Socket} from 'node:net';
+import type {Writable} from 'node:stream';
 
 import throttle from 'lodash.throttle';
-import readline from 'readline';
-import tty from 'tty';
-import util from 'util';
+import readline from 'node:readline';
+import tty from 'node:tty';
+import util from 'node:util';
 
 const {promisify} = util;
 

--- a/packages/metro-core/src/__tests__/Terminal-test.js
+++ b/packages/metro-core/src/__tests__/Terminal-test.js
@@ -14,7 +14,7 @@ const Terminal = require('../Terminal').default;
 
 jest.useRealTimers();
 
-jest.mock('readline', () => ({
+jest.mock('node:readline', () => ({
   moveCursor: (stream, dx, dy, callback = () => {}) => {
     const {cursor, columns} = stream;
     stream.cursor =
@@ -50,7 +50,9 @@ describe.each([false, true])(
       const lines = 10;
       const columns = 10;
       const stream = Object.create(
-        isTTY ? require('tty').WriteStream.prototype : require('net').Socket,
+        isTTY
+          ? require('node:tty').WriteStream.prototype
+          : require('node:net').Socket,
       );
       Object.assign(stream, {
         cursor: 0,

--- a/packages/metro-core/types/Terminal.d.ts
+++ b/packages/metro-core/types/Terminal.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<0b066ed2be97f8d1db5abb8f1a933cb0>>
+ * @generated SignedSource<<d815d55f8c0bab870b4615aa494fce29>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-core/src/Terminal.js
@@ -15,8 +15,8 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {Socket} from 'net';
-import type {Writable} from 'stream';
+import type {Socket} from 'node:net';
+import type {Writable} from 'node:stream';
 
 type UnderlyingStream = Socket | Writable;
 /**

--- a/packages/metro-file-map/src/Watcher.js
+++ b/packages/metro-file-map/src/Watcher.js
@@ -26,11 +26,11 @@ import FallbackWatcher from './watchers/FallbackWatcher';
 import NativeWatcher from './watchers/NativeWatcher';
 import WatchmanWatcher from './watchers/WatchmanWatcher';
 import debugModule from 'debug';
-import EventEmitter from 'events';
-import * as fs from 'fs';
+import EventEmitter from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {performance} from 'node:perf_hooks';
 import nullthrows from 'nullthrows';
-import * as path from 'path';
-import {performance} from 'perf_hooks';
 
 const debug = debugModule('Metro:Watcher');
 

--- a/packages/metro-file-map/src/__tests__/changes-between-starts-test.js
+++ b/packages/metro-file-map/src/__tests__/changes-between-starts-test.js
@@ -12,7 +12,7 @@
 import type {CacheData, FileData, FileMetadata} from '../flow-types';
 import type FileMapT from '../index';
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 jest.useRealTimers();
 

--- a/packages/metro-file-map/src/__tests__/haste_impl.js
+++ b/packages/metro-file-map/src/__tests__/haste_impl.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 let cacheKey;
 

--- a/packages/metro-file-map/src/__tests__/includes_dotfiles-test.js
+++ b/packages/metro-file-map/src/__tests__/includes_dotfiles-test.js
@@ -10,7 +10,7 @@
  */
 
 import HasteMap from '../index';
-import path from 'path';
+import path from 'node:path';
 
 jest.useRealTimers();
 

--- a/packages/metro-file-map/src/__tests__/index-test.js
+++ b/packages/metro-file-map/src/__tests__/index-test.js
@@ -32,9 +32,9 @@ import type {MockMapOptions} from '../plugins/MockPlugin';
 import typeof WorkerModule from '../worker';
 
 import {AbstractWatcher} from '../watchers/AbstractWatcher';
-import crypto from 'crypto';
-import * as path from 'path';
-import {serialize} from 'v8';
+import crypto from 'node:crypto';
+import * as path from 'node:path';
+import {serialize} from 'node:v8';
 
 jest.useRealTimers();
 
@@ -72,7 +72,7 @@ jest.mock('../crawlers/node', () => ({
 jest.mock('../crawlers/watchman', () => ({
   __esModule: true,
   default: jest.fn(options => {
-    const path = require('path');
+    const path = require('node:path');
 
     const {
       previousState,
@@ -177,7 +177,7 @@ jest.mock('fs', () => ({
     throw error;
   }),
   writeFileSync: jest.fn((path, data, options) => {
-    expect(options).toBe(require('v8').serialize ? undefined : 'utf8');
+    expect(options).toBe(require('node:v8').serialize ? undefined : 'utf8');
     mockFs[path] = data;
   }),
   promises: {
@@ -196,6 +196,7 @@ jest.mock('fs', () => ({
     }),
   },
 }));
+jest.mock('node:fs', () => jest.requireMock('fs'));
 
 const hasteImplModulePath = require.resolve('./haste_impl.js');
 let inBandWorker;
@@ -1459,7 +1460,7 @@ describe('FileMap', () => {
 
   test('distributes work across workers', async () => {
     const jestWorker = require('jest-worker').Worker;
-    const path = require('path');
+    const path = require('node:path');
     const dependencyExtractor = path.resolve(
       __dirname,
       '../plugins/dependencies/__tests__/mockDependencyExtractor.js',

--- a/packages/metro-file-map/src/__tests__/worker-test.js
+++ b/packages/metro-file-map/src/__tests__/worker-test.js
@@ -11,16 +11,15 @@
 
 import type {WorkerMessage, WorkerMetadata} from '../flow-types';
 import typeof TWorker from '../worker';
-import typeof FS from 'fs';
+import typeof FS from 'node:fs';
 
 import {HastePlugin} from '..';
 import {Worker} from '../worker';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as vm from 'vm';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
 
 jest.mock('fs', () => {
-  const path = require('path');
+  const path = require('node:path');
   const mockFs = {
     [path.join('/project', 'fruits', 'Banana.js')]: `
         const Strawberry = require("Strawberry");
@@ -64,6 +63,8 @@ jest.mock('fs', () => {
     }),
   };
 });
+
+const fs: FS = jest.requireMock('fs');
 
 const defaults: WorkerMessage = {
   computeSha1: false,

--- a/packages/metro-file-map/src/cache/DiskCacheManager.js
+++ b/packages/metro-file-map/src/cache/DiskCacheManager.js
@@ -19,11 +19,11 @@ import type {
 
 import rootRelativeCacheKeys from '../lib/rootRelativeCacheKeys';
 import debugModule from 'debug';
-import {promises as fsPromises} from 'fs';
-import {tmpdir} from 'os';
-import path from 'path';
-import {Timeout, clearTimeout, setTimeout} from 'timers';
-import {deserialize, serialize} from 'v8';
+import {promises as fsPromises} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {Timeout, clearTimeout, setTimeout} from 'node:timers';
+import {deserialize, serialize} from 'node:v8';
 
 const debug = debugModule('Metro:FileMapCache');
 

--- a/packages/metro-file-map/src/cache/__tests__/DiskCacheManager-test.js
+++ b/packages/metro-file-map/src/cache/__tests__/DiskCacheManager-test.js
@@ -17,14 +17,14 @@ import type {
 } from '../../flow-types';
 
 import {DiskCacheManager} from '../DiskCacheManager';
-import EventEmitter from 'events';
-import * as path from 'path';
-import {serialize} from 'v8';
+import EventEmitter from 'node:events';
+import * as path from 'node:path';
+import {serialize} from 'node:v8';
 
 const mockReadFile = jest.fn();
 const mockWriteFile = jest.fn();
 
-jest.mock('fs', () => ({
+jest.mock('node:fs', () => ({
   promises: {
     readFile: (...args) => mockReadFile(...args),
     writeFile: (...args) => mockWriteFile(...args),
@@ -33,7 +33,7 @@ jest.mock('fs', () => ({
 
 // We're explicitly using node:timers, which Jest doesn't automatically mock
 // with useFakeTimers. Global timers are mocked.
-jest.mock('timers', () => ({
+jest.mock('node:timers', () => ({
   setTimeout: globalThis.setTimeout,
   clearTimeout: globalThis.clearTimeout,
 }));

--- a/packages/metro-file-map/src/crawlers/__tests__/integration-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/integration-test.js
@@ -12,10 +12,10 @@
 import TreeFS from '../../lib/TreeFS';
 import nodeCrawl from '../node';
 import watchmanCrawl from '../watchman';
-import {execSync} from 'child_process';
 import invariant from 'invariant';
-import os from 'os';
-import {join} from 'path';
+import {execSync} from 'node:child_process';
+import os from 'node:os';
+import {join} from 'node:path';
 
 jest.useRealTimers();
 

--- a/packages/metro-file-map/src/crawlers/__tests__/watchman-test.js
+++ b/packages/metro-file-map/src/crawlers/__tests__/watchman-test.js
@@ -10,7 +10,7 @@
 
 import TreeFS from '../../lib/TreeFS';
 
-const path = require('path');
+const path = require('node:path');
 
 jest.useRealTimers();
 

--- a/packages/metro-file-map/src/crawlers/node/index.js
+++ b/packages/metro-file-map/src/crawlers/node/index.js
@@ -19,7 +19,7 @@ import type {
 
 import {RootPathUtils} from '../../lib/RootPathUtils';
 import * as fs from 'graceful-fs';
-import * as path from 'path';
+import * as path from 'node:path';
 
 type Callback = (result: FileData) => void;
 

--- a/packages/metro-file-map/src/crawlers/watchman/__tests__/index-test.js
+++ b/packages/metro-file-map/src/crawlers/watchman/__tests__/index-test.js
@@ -13,9 +13,9 @@ import type {CrawlerOptions} from '../../../flow-types';
 
 import TreeFS from '../../../lib/TreeFS';
 import watchmanCrawl from '../index';
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
+import path from 'node:path';
 import nullthrows from 'nullthrows';
-import path from 'path';
 
 class MockClient extends EventEmitter {
   command: JestMockFn<ReadonlyArray<$FlowFixMe>, unknown> = jest.fn();

--- a/packages/metro-file-map/src/crawlers/watchman/index.js
+++ b/packages/metro-file-map/src/crawlers/watchman/index.js
@@ -26,8 +26,8 @@ import {RootPathUtils} from '../../lib/RootPathUtils';
 import {planQuery} from './planQuery';
 import watchman from 'fb-watchman';
 import invariant from 'invariant';
-import * as path from 'path';
-import {performance} from 'perf_hooks';
+import * as path from 'node:path';
+import {performance} from 'node:perf_hooks';
 
 type WatchmanRoots = Map<
   string, // Posix-separated absolute path

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -53,11 +53,11 @@ import {RootPathUtils} from './lib/RootPathUtils';
 import TreeFS from './lib/TreeFS';
 import {Watcher} from './Watcher';
 import debugModule from 'debug';
-import EventEmitter from 'events';
-import {promises as fsPromises} from 'fs';
 import invariant from 'invariant';
-import * as path from 'path';
-import {performance} from 'perf_hooks';
+import EventEmitter from 'node:events';
+import {promises as fsPromises} from 'node:fs';
+import * as path from 'node:path';
+import {performance} from 'node:perf_hooks';
 
 const debug = debugModule('Metro:FileMap');
 

--- a/packages/metro-file-map/src/lib/FileProcessor.js
+++ b/packages/metro-file-map/src/lib/FileProcessor.js
@@ -23,7 +23,7 @@ import {Worker} from '../worker';
 import {RootPathUtils} from './RootPathUtils';
 import debugModule from 'debug';
 import {Worker as JestWorker} from 'jest-worker';
-import {sep} from 'path';
+import {sep} from 'node:path';
 
 const debug = debugModule('Metro:FileMap');
 

--- a/packages/metro-file-map/src/lib/RootPathUtils.js
+++ b/packages/metro-file-map/src/lib/RootPathUtils.js
@@ -9,7 +9,7 @@
  */
 
 import invariant from 'invariant';
-import * as path from 'path';
+import * as path from 'node:path';
 
 /**
  * This module provides path utility functions - similar to `node:path` -

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -23,7 +23,7 @@ import type {
 import H from '../constants';
 import {RootPathUtils} from './RootPathUtils';
 import invariant from 'invariant';
-import path from 'path';
+import path from 'node:path';
 
 type DirectoryNode = Map<string, MixedNode>;
 type FileNode = FileMetadata;

--- a/packages/metro-file-map/src/lib/__tests__/FileProcessor-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/FileProcessor-test.js
@@ -17,7 +17,7 @@ import type {
 } from '../../flow-types';
 
 import H from '../../constants';
-import path from 'path';
+import path from 'node:path';
 
 const MockJestWorker = jest.fn().mockImplementation(() => ({
   processFile: async () => ({}),

--- a/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
@@ -12,7 +12,7 @@
 import type {RootPathUtils as RootPathUtilsT} from '../RootPathUtils';
 
 let mockPathModule;
-jest.mock('path', () => mockPathModule);
+jest.mock('node:path', () => mockPathModule);
 
 describe.each([['win32'], ['posix']])('RootPathUtils on %s', platform => {
   // Convenience function to write paths with posix separators but convert them

--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -20,7 +20,7 @@ import type TreeFSType from '../TreeFS';
 import H from '../../constants';
 
 let mockPathModule;
-jest.mock('path', () => mockPathModule);
+jest.mock('node:path', () => mockPathModule);
 
 describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
   // Convenience function to write paths with posix separators but convert them

--- a/packages/metro-file-map/src/lib/__tests__/checkWatchmanCapabilities-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/checkWatchmanCapabilities-test.js
@@ -11,7 +11,7 @@
 import checkWatchmanCapabilities from '../checkWatchmanCapabilities';
 
 const mockExecFile = jest.fn();
-jest.mock('child_process', () => ({
+jest.mock('node:child_process', () => ({
   execFile: (...args) => mockExecFile(...args),
 }));
 

--- a/packages/metro-file-map/src/lib/__tests__/normalizePathSeparatorsToSystem-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/normalizePathSeparatorsToSystem-test.js
@@ -13,7 +13,7 @@
 describe('normalizePathSeparatorsToSystem', () => {
   test('does nothing on posix', () => {
     jest.resetModules();
-    jest.mock('path', () => jest.requireActual('path').posix);
+    jest.mock('node:path', () => jest.requireActual('node:path').posix);
     const normalizePathSeparatorsToSystem =
       require('../normalizePathSeparatorsToSystem').default;
     expect(normalizePathSeparatorsToSystem('foo/bar/baz.js')).toEqual(
@@ -23,7 +23,7 @@ describe('normalizePathSeparatorsToSystem', () => {
 
   test('replace slashes on windows', () => {
     jest.resetModules();
-    jest.mock('path', () => jest.requireActual('path').win32);
+    jest.mock('node:path', () => jest.requireActual('node:path').win32);
     const normalizePathSeparatorsToSystem =
       require('../normalizePathSeparatorsToSystem').default;
     expect(normalizePathSeparatorsToSystem('foo/bar/baz.js')).toEqual(

--- a/packages/metro-file-map/src/lib/__tests__/rootRelativeCacheKeys-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/rootRelativeCacheKeys-test.js
@@ -9,7 +9,7 @@
  */
 
 import type {BuildParameters, FileMapPlugin} from '../../flow-types';
-import typeof PathModule from 'path';
+import typeof PathModule from 'node:path';
 
 import rootRelativeCacheKeys from '../rootRelativeCacheKeys';
 
@@ -116,12 +116,12 @@ test('returns a distinct cache key for any change', () => {
 
 describe('cross-platform cache keys', () => {
   afterEach(() => {
-    jest.unmock('path');
+    jest.unmock('node:path');
   });
 
   test('returns the same cache key for Windows and POSIX path parameters', () => {
     let mockPathModule;
-    jest.mock('path', () => mockPathModule);
+    jest.mock('node:path', () => mockPathModule);
 
     jest.resetModules();
     mockPathModule = jest.requireActual<PathModule>('path').posix;

--- a/packages/metro-file-map/src/lib/checkWatchmanCapabilities.js
+++ b/packages/metro-file-map/src/lib/checkWatchmanCapabilities.js
@@ -8,8 +8,8 @@
  * @format
  */
 
-import {execFile} from 'child_process';
-import {promisify} from 'util';
+import {execFile} from 'node:child_process';
+import {promisify} from 'node:util';
 
 export default async function checkWatchmanCapabilities(
   requiredCapabilities: ReadonlyArray<string>,

--- a/packages/metro-file-map/src/lib/normalizePathSeparatorsToPosix.js
+++ b/packages/metro-file-map/src/lib/normalizePathSeparatorsToPosix.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 let normalizePathSeparatorsToPosix;
 if (path.sep === '/') {

--- a/packages/metro-file-map/src/lib/normalizePathSeparatorsToSystem.js
+++ b/packages/metro-file-map/src/lib/normalizePathSeparatorsToSystem.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 let normalizePathSeparatorsToSystem;
 if (path.sep === '/') {

--- a/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
+++ b/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
@@ -13,7 +13,7 @@ import type {BuildParameters} from '../flow-types';
 
 import normalizePathSeparatorsToPosix from './normalizePathSeparatorsToPosix';
 import {RootPathUtils} from './RootPathUtils';
-import {createHash} from 'crypto';
+import {createHash} from 'node:crypto';
 
 export default function rootRelativeCacheKeys(
   buildParameters: BuildParameters,

--- a/packages/metro-file-map/src/plugins/HastePlugin.js
+++ b/packages/metro-file-map/src/plugins/HastePlugin.js
@@ -32,7 +32,7 @@ import {chainComparators, compareStrings} from '../lib/sorting';
 import {DuplicateHasteCandidatesError} from './haste/DuplicateHasteCandidatesError';
 import getPlatformExtension from './haste/getPlatformExtension';
 import {HasteConflictsError} from './haste/HasteConflictsError';
-import path from 'path';
+import path from 'node:path';
 
 const EMPTY_OBJ: Readonly<{[string]: HasteMapItemMetadata}> = {};
 const EMPTY_MAP: ReadonlyMap<string, DuplicatesSet> = new Map();

--- a/packages/metro-file-map/src/plugins/MockPlugin.js
+++ b/packages/metro-file-map/src/plugins/MockPlugin.js
@@ -23,8 +23,8 @@ import normalizePathSeparatorsToPosix from '../lib/normalizePathSeparatorsToPosi
 import normalizePathSeparatorsToSystem from '../lib/normalizePathSeparatorsToSystem';
 import {RootPathUtils} from '../lib/RootPathUtils';
 import getMockName from './mocks/getMockName';
+import path from 'node:path';
 import nullthrows from 'nullthrows';
-import path from 'path';
 
 export const CACHE_VERSION = 2;
 

--- a/packages/metro-file-map/src/plugins/dependencies/__tests__/DependencyPlugin-test.js
+++ b/packages/metro-file-map/src/plugins/dependencies/__tests__/DependencyPlugin-test.js
@@ -10,7 +10,7 @@
  */
 
 import DependencyPlugin from '../../DependencyPlugin';
-import path from 'path';
+import path from 'node:path';
 
 describe('DependencyPlugin', () => {
   let plugin: DependencyPlugin;

--- a/packages/metro-file-map/src/plugins/haste/HasteConflictsError.js
+++ b/packages/metro-file-map/src/plugins/haste/HasteConflictsError.js
@@ -11,7 +11,7 @@
 
 import type {HasteConflict} from '../../flow-types';
 
-import path from 'path';
+import path from 'node:path';
 
 export class HasteConflictsError extends Error {
   #conflicts: ReadonlyArray<HasteConflict>;

--- a/packages/metro-file-map/src/plugins/haste/__tests__/HastePlugin-test.js
+++ b/packages/metro-file-map/src/plugins/haste/__tests__/HastePlugin-test.js
@@ -16,7 +16,7 @@ import type {
 import type HasteMapType from '../../HastePlugin';
 
 let mockPathModule;
-jest.mock('path', () => mockPathModule);
+jest.mock('node:path', () => mockPathModule);
 
 describe.each([['win32'], ['posix']])('HastePlugin on %s', platform => {
   const p: string => string = filePath =>

--- a/packages/metro-file-map/src/plugins/haste/computeConflicts.js
+++ b/packages/metro-file-map/src/plugins/haste/computeConflicts.js
@@ -12,7 +12,7 @@ import type {HasteMapItem} from '../../flow-types';
 
 import H from '../../constants';
 import {chainComparators, compareStrings} from '../../lib/sorting';
-import path from 'path';
+import path from 'node:path';
 
 type Conflict = {
   id: string,

--- a/packages/metro-file-map/src/plugins/haste/worker.js
+++ b/packages/metro-file-map/src/plugins/haste/worker.js
@@ -13,7 +13,7 @@
 'use strict';
 
 const excludedExtensions = require('../../workerExclusionList');
-const path = require('path');
+const path = require('node:path');
 
 /*::
 import type {MetadataWorker, WorkerMessage, V8Serializable} from '../../flow-types';

--- a/packages/metro-file-map/src/plugins/mocks/__tests__/MockPlugin-test.js
+++ b/packages/metro-file-map/src/plugins/mocks/__tests__/MockPlugin-test.js
@@ -12,7 +12,7 @@
 import type MockMapType from '../../MockPlugin';
 
 let mockPathModule;
-jest.mock('path', () => mockPathModule);
+jest.mock('node:path', () => mockPathModule);
 
 describe.each([['win32'], ['posix']])('MockPlugin on %s', platform => {
   const p: string => string = filePath =>

--- a/packages/metro-file-map/src/plugins/mocks/__tests__/getMockName-test.js
+++ b/packages/metro-file-map/src/plugins/mocks/__tests__/getMockName-test.js
@@ -9,7 +9,7 @@
  */
 
 import getMockName from '../getMockName';
-import path from 'path';
+import path from 'node:path';
 
 describe('getMockName', () => {
   test('extracts mock name from file path', () => {

--- a/packages/metro-file-map/src/plugins/mocks/getMockName.js
+++ b/packages/metro-file-map/src/plugins/mocks/getMockName.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 const MOCKS_PATTERN = path.sep + '__mocks__' + path.sep;
 

--- a/packages/metro-file-map/src/watchers/AbstractWatcher.js
+++ b/packages/metro-file-map/src/watchers/AbstractWatcher.js
@@ -15,8 +15,8 @@ import type {
 } from '../flow-types';
 
 import {posixPathMatchesPattern} from './common';
-import EventEmitter from 'events';
-import * as path from 'path';
+import EventEmitter from 'node:events';
+import * as path from 'node:path';
 
 export type Listeners = Readonly<{
   onFileEvent: (event: WatcherBackendChangeEvent) => void,

--- a/packages/metro-file-map/src/watchers/FallbackWatcher.js
+++ b/packages/metro-file-map/src/watchers/FallbackWatcher.js
@@ -17,13 +17,13 @@ import type {
   ChangeEventMetadata,
   WatcherBackendChangeEvent,
 } from '../flow-types';
-import type {FSWatcher, Stats} from 'fs';
+import type {FSWatcher, Stats} from 'node:fs';
 
 import {AbstractWatcher} from './AbstractWatcher';
 import * as common from './common';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 // $FlowFixMe[untyped-import] - Write libdefs for `walker`
 import walker from 'walker';
 

--- a/packages/metro-file-map/src/watchers/NativeWatcher.js
+++ b/packages/metro-file-map/src/watchers/NativeWatcher.js
@@ -8,14 +8,14 @@
  * @format
  */
 
-import type {FSWatcher} from 'fs';
+import type {FSWatcher} from 'node:fs';
 
 import {AbstractWatcher} from './AbstractWatcher';
 import {includedByGlob, typeFromStat} from './common';
 import debugModule from 'debug';
-import {promises as fsPromises, watch} from 'fs';
-import {platform} from 'os';
-import * as path from 'path';
+import {promises as fsPromises, watch} from 'node:fs';
+import {platform} from 'node:os';
+import * as path from 'node:path';
 
 const debug = debugModule('Metro:NativeWatcher');
 

--- a/packages/metro-file-map/src/watchers/WatchmanWatcher.js
+++ b/packages/metro-file-map/src/watchers/WatchmanWatcher.js
@@ -24,11 +24,11 @@ import normalizePathSeparatorsToSystem from '../lib/normalizePathSeparatorsToSys
 import {AbstractWatcher} from './AbstractWatcher';
 import * as common from './common';
 import RecrawlWarning from './RecrawlWarning';
-import assert from 'assert';
-import {createHash} from 'crypto';
 import debugModule from 'debug';
 import watchman from 'fb-watchman';
 import invariant from 'invariant';
+import assert from 'node:assert';
+import {createHash} from 'node:crypto';
 
 const debug = debugModule('Metro:WatchmanWatcher');
 

--- a/packages/metro-file-map/src/watchers/__tests__/WatchmanWatcher-test.js
+++ b/packages/metro-file-map/src/watchers/__tests__/WatchmanWatcher-test.js
@@ -16,7 +16,7 @@ import type {
 } from 'fb-watchman';
 
 import WatchmanWatcher from '../WatchmanWatcher';
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 
 class MockClient extends EventEmitter {
   command: JestMockFn<ReadonlyArray<$FlowFixMe>, unknown> = jest.fn();

--- a/packages/metro-file-map/src/watchers/__tests__/helpers.js
+++ b/packages/metro-file-map/src/watchers/__tests__/helpers.js
@@ -15,11 +15,11 @@ import type {WatcherOptions} from '../common';
 import FallbackWatcher from '../FallbackWatcher';
 import NativeWatcher from '../NativeWatcher';
 import WatchmanWatcher from '../WatchmanWatcher';
-import {execSync} from 'child_process';
-import {promises as fsPromises} from 'fs';
 import invariant from 'invariant';
-import os from 'os';
-import {join} from 'path';
+import {execSync} from 'node:child_process';
+import {promises as fsPromises} from 'node:fs';
+import os from 'node:os';
+import {join} from 'node:path';
 
 jest.useRealTimers();
 

--- a/packages/metro-file-map/src/watchers/__tests__/integration-test.js
+++ b/packages/metro-file-map/src/watchers/__tests__/integration-test.js
@@ -14,9 +14,9 @@ import type {EventHelpers, WatcherName} from './helpers';
 
 import NativeWatcher from '../NativeWatcher';
 import {WATCHERS, createTempWatchRoot, startWatching} from './helpers';
-import {promises as fsPromises} from 'fs';
-import os from 'os';
-import {join} from 'path';
+import {promises as fsPromises} from 'node:fs';
+import os from 'node:os';
+import {join} from 'node:path';
 
 const {mkdir, writeFile, rm, symlink, unlink} = fsPromises;
 

--- a/packages/metro-file-map/src/watchers/common.js
+++ b/packages/metro-file-map/src/watchers/common.js
@@ -15,11 +15,11 @@
  */
 
 import type {ChangeEventMetadata} from '../flow-types';
-import type {Stats} from 'fs';
+import type {Stats} from 'node:fs';
 
 // $FlowFixMe[untyped-import] - Write libdefs for `micromatch`
 import micromatch from 'micromatch';
-import path from 'path';
+import path from 'node:path';
 
 /**
  * Constants

--- a/packages/metro-file-map/src/worker.js
+++ b/packages/metro-file-map/src/worker.js
@@ -23,8 +23,8 @@ import type {
 
 'use strict';
 
-const {createHash} = require('crypto');
 const fs = require('graceful-fs');
+const {createHash} = require('node:crypto');
 
 function sha1hex(content /*: string | Buffer */) /*: string */ {
   return createHash('sha1').update(content).digest('hex');

--- a/packages/metro-file-map/types/Watcher.d.ts
+++ b/packages/metro-file-map/types/Watcher.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @noformat
- * @generated SignedSource<<264a91514e87b4d291030528067bc411>>
+ * @generated SignedSource<<f8c0d07df9a512cbfb4a3025ab1df4fb>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-file-map/src/Watcher.js
@@ -16,7 +16,7 @@
 
 import type {Console, CrawlerOptions, CrawlResult, PerfLogger, WatcherBackendChangeEvent} from './flow-types';
 
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 
 type WatcherOptions = {
   abortSignal: AbortSignal;

--- a/packages/metro-file-map/types/index.d.ts
+++ b/packages/metro-file-map/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<280eebdbd2507969e4b6df9e48a4495c>>
+ * @generated SignedSource<<ac5262bbac56ab4b35f7643b0c9d87d7>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-file-map/src/index.js
@@ -31,7 +31,7 @@ import type {
   PerfLoggerFactory,
 } from './flow-types';
 
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 
 export type {BuildParameters, BuildResult, CacheData, ChangeEventMetadata, FileData, FileMap, FileSystem, HasteMapData, HasteMapItem, InputFileMapPlugin};
 export type InputOptions = Readonly<{

--- a/packages/metro-file-map/types/watchers/common.d.ts
+++ b/packages/metro-file-map/types/watchers/common.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<56a5351ea6e2e4904e17953a832baea1>>
+ * @generated SignedSource<<b1f992864b487f099044c1da57f1db9b>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-file-map/src/watchers/common.js
@@ -21,7 +21,7 @@
  */
 
 import type {ChangeEventMetadata} from '../flow-types';
-import type {Stats} from 'fs';
+import type {Stats} from 'node:fs';
 /**
  * Constants
  */

--- a/packages/metro-resolver/src/PackageExportsResolve.js
+++ b/packages/metro-resolver/src/PackageExportsResolve.js
@@ -25,7 +25,7 @@ import isAssetFile from './utils/isAssetFile';
 import {isSubpathDefinedInExportsLike} from './utils/isSubpathDefinedInExportsLike';
 import {matchSubpathFromExportsLike} from './utils/matchSubpathFromExportsLike';
 import {systemToPosixPath} from './utils/paths';
-import path from 'path';
+import path from 'node:path';
 
 /**
  * Resolve a package subpath based on the entry points defined in the package's

--- a/packages/metro-resolver/src/PackageImportsResolve.js
+++ b/packages/metro-resolver/src/PackageImportsResolve.js
@@ -17,7 +17,7 @@ import resolveAsset from './resolveAsset';
 import isAssetFile from './utils/isAssetFile';
 import {isSubpathDefinedInExportsLike} from './utils/isSubpathDefinedInExportsLike';
 import {matchSubpathFromExportsLike} from './utils/matchSubpathFromExportsLike';
-import path from 'path';
+import path from 'node:path';
 
 /**
  * Resolve a package subpath based on the entry points defined in the package's

--- a/packages/metro-resolver/src/PackageResolve.js
+++ b/packages/metro-resolver/src/PackageResolve.js
@@ -12,7 +12,7 @@
 import type {PackageInfo, PackageJson, ResolutionContext} from './types';
 
 import {systemToPosixPath} from './utils/paths';
-import path from 'path';
+import path from 'node:path';
 
 /**
  * Resolve the main entry point subpath for a package.

--- a/packages/metro-resolver/src/__tests__/assets-test.js
+++ b/packages/metro-resolver/src/__tests__/assets-test.js
@@ -11,7 +11,7 @@
 
 import * as Resolver from '../index';
 import {createResolutionContext} from './utils';
-import path from 'path';
+import path from 'node:path';
 
 describe('asset resolutions', () => {
   const baseContext = {

--- a/packages/metro-resolver/src/__tests__/package-exports-test.js
+++ b/packages/metro-resolver/src/__tests__/package-exports-test.js
@@ -11,7 +11,7 @@
 
 import * as Resolver from '../index';
 import {createPackageAccessors, createResolutionContext} from './utils';
-import path from 'path';
+import path from 'node:path';
 
 // Tests validating Package Exports resolution behaviour. See RFC0534:
 // https://github.com/react-native-community/discussions-and-proposals/blob/master/proposals/0534-metro-package-exports-support.md

--- a/packages/metro-resolver/src/__tests__/utils.js
+++ b/packages/metro-resolver/src/__tests__/utils.js
@@ -12,7 +12,7 @@
 import type {ResolutionContext} from '../index';
 import type {PackageJson} from '../types';
 
-import path from 'path';
+import path from 'node:path';
 
 /**
  * Data structure approximating a file tree. Should be populated with complete

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -34,7 +34,7 @@ import {
 import resolveAsset from './resolveAsset';
 import isAssetFile from './utils/isAssetFile';
 import {posixToSystemPath} from './utils/paths';
-import path from 'path';
+import path from 'node:path';
 
 type ParsedBareSpecifier = Readonly<{
   isSinglePart: boolean,

--- a/packages/metro-resolver/src/resolveAsset.js
+++ b/packages/metro-resolver/src/resolveAsset.js
@@ -11,7 +11,7 @@
 
 import type {AssetResolution, ResolutionContext} from './types';
 
-import path from 'path';
+import path from 'node:path';
 
 /**
  * Resolve a file path as an asset. Returns the set of files found after

--- a/packages/metro-resolver/src/utils/isAssetFile.js
+++ b/packages/metro-resolver/src/utils/isAssetFile.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import path from 'path';
+import path from 'node:path';
 
 /**
  * Determine if a file path should be considered an asset file based on the

--- a/packages/metro-resolver/src/utils/paths.js
+++ b/packages/metro-resolver/src/utils/paths.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import path from 'path';
+import path from 'node:path';
 
 export const systemToPosixPath: (relativeSystemPath: string) => string =
   path.sep === '/'

--- a/packages/metro-runtime/src/polyfills/__tests__/MetroFastRefreshMockRuntime.js
+++ b/packages/metro-runtime/src/polyfills/__tests__/MetroFastRefreshMockRuntime.js
@@ -15,7 +15,7 @@ import typeof ReactRefreshRuntime from 'react-refresh/runtime';
 import typeof ReactTestRenderer from 'react-test-renderer';
 
 import {transformSync} from '@babel/core';
-import fs from 'fs';
+import fs from 'node:fs';
 
 type RuntimeGlobal = Object;
 

--- a/packages/metro-runtime/src/polyfills/__tests__/require-test.js
+++ b/packages/metro-runtime/src/polyfills/__tests__/require-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const {transformSync} = require('@babel/core');
-const fs = require('fs');
+const fs = require('node:fs');
 
 function createModule(
   moduleSystem,

--- a/packages/metro-source-map/src/__tests__/composeSourceMaps-test.js
+++ b/packages/metro-source-map/src/__tests__/composeSourceMaps-test.js
@@ -15,9 +15,9 @@ import composeSourceMaps from '../composeSourceMaps';
 import Consumer from '../Consumer';
 import {add0, add1} from 'ob1';
 
-const fs = require('fs');
 const invariant = require('invariant');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const terser = require('terser');
 
 const {objectContaining} = expect;

--- a/packages/metro-source-map/src/generateFunctionMap.js
+++ b/packages/metro-source-map/src/generateFunctionMap.js
@@ -42,8 +42,8 @@ import {
   isVariableDeclarator,
 } from '@babel/types';
 import invariant from 'invariant';
+import fsPath from 'node:path';
 import nullthrows from 'nullthrows';
-import fsPath from 'path';
 
 type Position = {
   line: number,

--- a/packages/metro-symbolicate/src/Symbolication.js
+++ b/packages/metro-symbolicate/src/Symbolication.js
@@ -11,15 +11,15 @@
 
 import type {ChromeHeapSnapshot} from './ChromeHeapSnapshot';
 import type {HermesFunctionOffsets, MixedSourceMap} from 'metro-source-map';
-import type {Writable} from 'stream';
+import type {Writable} from 'node:stream';
 
 import {ChromeHeapSnapshotProcessor} from './ChromeHeapSnapshot';
 import GoogleIgnoreListConsumer from './GoogleIgnoreListConsumer';
 import SourceMetadataMapConsumer from './SourceMetadataMapConsumer';
-import fs from 'fs';
 import invariant from 'invariant';
+import fs from 'node:fs';
+import path from 'node:path';
 import nullthrows from 'nullthrows';
-import path from 'path';
 // flowlint-next-line untyped-type-import:off
 import {typeof SourceMapConsumer} from 'source-map';
 

--- a/packages/metro-symbolicate/src/__tests__/Symbolication-test.js
+++ b/packages/metro-symbolicate/src/__tests__/Symbolication-test.js
@@ -11,8 +11,8 @@
 'use strict';
 
 const Symbolication = require('../Symbolication.js');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {SourceMapConsumer} = require('source-map');
 
 const resolve = fileName => path.resolve(__dirname, '__fixtures__', fileName);

--- a/packages/metro-symbolicate/src/__tests__/symbolicate-heap-snapshot-test.js
+++ b/packages/metro-symbolicate/src/__tests__/symbolicate-heap-snapshot-test.js
@@ -12,9 +12,9 @@
 import symbolicate from '../symbolicate';
 
 const {ChromeHeapSnapshotProcessor} = require('../ChromeHeapSnapshot');
-const fs = require('fs');
-const path = require('path');
-const {PassThrough} = require('stream');
+const fs = require('node:fs');
+const path = require('node:path');
+const {PassThrough} = require('node:stream');
 
 const resolve = (fileName: string) =>
   path.resolve(__dirname, '__fixtures__', fileName);

--- a/packages/metro-symbolicate/src/__tests__/symbolicate-test.js
+++ b/packages/metro-symbolicate/src/__tests__/symbolicate-test.js
@@ -11,10 +11,10 @@
 
 import symbolicate from '../symbolicate';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const {PassThrough} = require('stream');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {PassThrough} = require('node:stream');
 
 jest.useRealTimers();
 

--- a/packages/metro-symbolicate/src/symbolicate.js
+++ b/packages/metro-symbolicate/src/symbolicate.js
@@ -17,14 +17,14 @@
 // In our third form, we symbolicate using a module ID, a line number, and
 // optionally a column.
 
-import type {Readable, Writable} from 'stream';
-import type {ReadStream} from 'tty';
+import type {Readable, Writable} from 'node:stream';
+import type {ReadStream} from 'node:tty';
 
 import * as Symbolication from './Symbolication';
-import fs from 'fs';
+import fs from 'node:fs';
+import {Transform} from 'node:stream';
 // $FlowFixMe[untyped-import] source-map
 import {SourceMapConsumer} from 'source-map';
-import {Transform} from 'stream';
 
 function printHelp() {
   const usages = [

--- a/packages/metro-symbolicate/types/Symbolication.d.ts
+++ b/packages/metro-symbolicate/types/Symbolication.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<5f4d1981a4d319279ca64bcd7f24f02c>>
+ * @generated SignedSource<<91474206d25909f6f6d546877efa6e0a>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-symbolicate/src/Symbolication.js
@@ -17,7 +17,7 @@
 
 import type {ChromeHeapSnapshot} from './ChromeHeapSnapshot';
 import type {MixedSourceMap} from 'metro-source-map';
-import type {Writable} from 'stream';
+import type {Writable} from 'node:stream';
 
 import SourceMetadataMapConsumer from './SourceMetadataMapConsumer';
 import {type SourceMapConsumer as $$IMPORT_TYPEOF_1$$} from 'source-map';

--- a/packages/metro-symbolicate/types/symbolicate.d.ts
+++ b/packages/metro-symbolicate/types/symbolicate.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<514225e55c0b3bbdbef6f68fb16f4085>>
+ * @generated SignedSource<<cf5eb72b236393b4e08cc4b1814f4e49>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-symbolicate/src/symbolicate.js
@@ -15,8 +15,8 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {Readable, Writable} from 'stream';
-import type {ReadStream} from 'tty';
+import type {Readable, Writable} from 'node:stream';
+import type {ReadStream} from 'node:tty';
 
 declare function main(
   argvInput?: Array<string>,

--- a/packages/metro-transform-plugins/src/__tests__/import-export-plugin-test.js
+++ b/packages/metro-transform-plugins/src/__tests__/import-export-plugin-test.js
@@ -18,7 +18,7 @@ const importExportPlugin = require('../import-export-plugin');
 // $FlowFixMe[untyped-import] @babel/code-frame
 const {codeFrameColumns} = require('@babel/code-frame');
 const generate = require('@babel/generator').default;
-const vm = require('vm');
+const vm = require('node:vm');
 
 const opts = {
   importAll: '_$$_IMPORT_ALL',

--- a/packages/metro-transform-worker/src/__tests__/index-test.js
+++ b/packages/metro-transform-worker/src/__tests__/index-test.js
@@ -30,16 +30,16 @@ jest
 
 import type {JsTransformerConfig, JsTransformOptions} from '../index';
 import typeof * as TransformerType from '../index';
-import typeof FSType from 'fs';
+import typeof FSType from 'node:fs';
 
-const {Buffer} = require('buffer');
-const path = require('path');
+const {Buffer} = require('node:buffer');
+const path = require('node:path');
 
 const babelTransformerPath =
   require.resolve('@react-native/metro-babel-transformer');
 
 const transformerContents = (() =>
-  require('fs').readFileSync(babelTransformerPath))();
+  require('node:fs').readFileSync(babelTransformerPath))();
 
 const HEADER_DEV =
   '__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {';
@@ -83,9 +83,9 @@ const baseTransformOptions: JsTransformOptions = {
 beforeEach(() => {
   jest.resetModules();
 
-  jest.mock('fs', () => new (require('metro-memory-fs'))());
+  jest.mock('node:fs', () => new (require('metro-memory-fs'))());
 
-  fs = require('fs');
+  fs = jest.requireMock('node:fs');
   Transformer = require('../');
   // $FlowFixMe[prop-missing] Cannot call `fs.reset` because property `reset` is missing in  module `fs`
   fs.reset();

--- a/packages/metro-transform-worker/src/utils/assetTransformer.js
+++ b/packages/metro-transform-worker/src/utils/assetTransformer.js
@@ -14,7 +14,7 @@ import type {BabelTransformerArgs} from 'metro-babel-transformer';
 
 import {getAssetData} from 'metro/private/Assets';
 import {generateAssetCodeFileAst} from 'metro/private/Bundler/util';
-import path from 'path';
+import path from 'node:path';
 
 export async function transform(
   {filename, options, src}: BabelTransformerArgs,

--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -13,11 +13,11 @@ import type {AssetPath} from './node-haste/lib/AssetPaths';
 
 import {normalizePathSeparatorsToPosix} from './lib/pathUtils';
 import * as AssetPaths from './node-haste/lib/AssetPaths';
-import crypto from 'crypto';
-import fs from 'fs';
 // $FlowFixMe[untyped-import] image-size
 import getImageSize from 'image-size';
-import path from 'path';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export type AssetInfo = {
   readonly files: Array<string>,

--- a/packages/metro/src/Bundler.js
+++ b/packages/metro/src/Bundler.js
@@ -11,8 +11,8 @@
 
 import type {TransformResultWithSource} from './DeltaBundler';
 import type {TransformOptions} from './DeltaBundler/Worker';
-import type EventEmitter from 'events';
 import type {ConfigT} from 'metro-config';
+import type EventEmitter from 'node:events';
 
 import Transformer from './DeltaBundler/Transformer';
 import DependencyGraph from './node-haste/DependencyGraph';

--- a/packages/metro/src/DeltaBundler.js
+++ b/packages/metro/src/DeltaBundler.js
@@ -17,7 +17,7 @@ import type {
   Options,
   ReadOnlyGraph,
 } from './DeltaBundler/types';
-import type EventEmitter from 'events';
+import type EventEmitter from 'node:events';
 
 import DeltaCalculator from './DeltaBundler/DeltaCalculator';
 

--- a/packages/metro/src/DeltaBundler/DeltaCalculator.js
+++ b/packages/metro/src/DeltaBundler/DeltaCalculator.js
@@ -13,10 +13,10 @@ import type {DeltaResult, Options} from './types';
 import type {ChangeEvent} from 'metro-file-map';
 
 import {Graph} from './Graph';
-import crypto from 'crypto';
 import debugModule from 'debug';
-import EventEmitter from 'events';
-import path from 'path';
+import crypto from 'node:crypto';
+import EventEmitter from 'node:events';
+import path from 'node:path';
 
 const debug = debugModule('Metro:DeltaCalculator');
 

--- a/packages/metro/src/DeltaBundler/Serializers/__tests__/baseJSBundle-test.js
+++ b/packages/metro/src/DeltaBundler/Serializers/__tests__/baseJSBundle-test.js
@@ -15,7 +15,7 @@ import CountingSet from '../../../lib/CountingSet';
 import baseJSBundle from '../baseJSBundle';
 import createModuleIdFactory from 'metro-config/private/defaults/createModuleIdFactory';
 
-const path = require('path');
+const path = require('node:path');
 
 const {objectContaining} = expect;
 

--- a/packages/metro/src/DeltaBundler/Serializers/getAssets.js
+++ b/packages/metro/src/DeltaBundler/Serializers/getAssets.js
@@ -14,7 +14,7 @@ import type {Module, ReadOnlyDependencies} from '../types';
 
 import {getAssetData} from '../../Assets';
 import {getJsOutput, isJsModule} from './helpers/js';
-import path from 'path';
+import path from 'node:path';
 
 type Options = {
   readonly processModuleFilter: (module: Module<>) => boolean,

--- a/packages/metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
+++ b/packages/metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
@@ -19,8 +19,8 @@ import getAppendScripts from '../../lib/getAppendScripts';
 import getTransitiveDependencies from './helpers/getTransitiveDependencies';
 import {isJsModule, wrapModule} from './helpers/js';
 import {sourceMapObject} from './sourceMapObject';
+import path from 'node:path';
 import nullthrows from 'nullthrows';
-import path from 'path';
 
 type Options = Readonly<{
   ...SerializerOptions,

--- a/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
+++ b/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
@@ -17,7 +17,7 @@ import {normalizePathSeparatorsToPosix} from '../../../lib/pathUtils';
 import invariant from 'invariant';
 import * as jscSafeUrl from 'jsc-safe-url';
 import {addParamsToDefineCall} from 'metro-transform-plugins';
-import path from 'path';
+import path from 'node:path';
 
 export type Options = Readonly<{
   createModuleId: string => number | string,

--- a/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
+++ b/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
@@ -16,7 +16,7 @@ import {isJsModule, wrapModule} from './helpers/js';
 import debugModule from 'debug';
 import * as jscSafeUrl from 'jsc-safe-url';
 import {addParamsToDefineCall} from 'metro-transform-plugins';
-import path from 'path';
+import path from 'node:path';
 
 const debug = debugModule('Metro:HMR');
 

--- a/packages/metro/src/DeltaBundler/Transformer.js
+++ b/packages/metro/src/DeltaBundler/Transformer.js
@@ -16,12 +16,12 @@ import type {ConfigT} from 'metro-config';
 import {normalizePathSeparatorsToPosix} from '../lib/pathUtils';
 import getTransformCacheKey from './getTransformCacheKey';
 import WorkerFarm from './WorkerFarm';
-import assert from 'assert';
-import crypto from 'crypto';
 import debugModule from 'debug';
-import fs from 'fs';
 import {Cache, stableHash} from 'metro-cache';
-import path from 'path';
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const debug = debugModule('Metro:Transformer');
 

--- a/packages/metro/src/DeltaBundler/Worker.flow.js
+++ b/packages/metro/src/DeltaBundler/Worker.flow.js
@@ -17,9 +17,9 @@ import type {
 } from 'metro-transform-worker';
 
 import traverse from '@babel/traverse';
-import crypto from 'crypto';
-import fs from 'fs';
-import path from 'path';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export type {JsTransformOptions as TransformOptions} from 'metro-transform-worker';
 

--- a/packages/metro/src/DeltaBundler/WorkerFarm.js
+++ b/packages/metro/src/DeltaBundler/WorkerFarm.js
@@ -12,7 +12,7 @@
 import type {TransformResult} from '../DeltaBundler';
 import type {TransformerConfig, TransformOptions, Worker} from './Worker';
 import type {ConfigT} from 'metro-config';
-import type {Readable} from 'stream';
+import type {Readable} from 'node:stream';
 
 import {Worker as JestWorker} from 'jest-worker';
 import {Logger} from 'metro-core';

--- a/packages/metro/src/DeltaBundler/__fixtures__/hasteImpl.js
+++ b/packages/metro/src/DeltaBundler/__fixtures__/hasteImpl.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const fs = require('fs');
+const fs = require('node:fs');
 
 /**
  * Simple hasteImpl that parses @providesModule annotation from JS modules.

--- a/packages/metro/src/DeltaBundler/__tests__/DeltaBundler-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/DeltaBundler-test.js
@@ -14,7 +14,7 @@ import type {MixedOutput, Options, TransformResultDependency} from '../types';
 import DeltaBundler from '../../DeltaBundler';
 import DeltaCalculator from '../DeltaCalculator';
 
-const {EventEmitter} = require('events');
+const {EventEmitter} = require('node:events');
 
 jest.mock('../DeltaCalculator');
 

--- a/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-context-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-context-test.js
@@ -18,9 +18,9 @@ import CountingSet from '../../lib/CountingSet';
 import DeltaCalculator from '../DeltaCalculator';
 import {Graph} from '../Graph';
 import {createEmitChange, createPathNormalizer} from './test-utils';
-import path from 'path';
+import path from 'node:path';
 
-const {EventEmitter} = require('events');
+const {EventEmitter} = require('node:events');
 
 const traverseDependencies = jest.spyOn(
   Graph.prototype,

--- a/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js
@@ -61,12 +61,12 @@ describe.each(['posix', 'win32'])('DeltaCalculator (%s)', osPlatform => {
 
   beforeEach(async () => {
     if (osPlatform === 'win32') {
-      jest.doMock('path', () => jest.requireActual('path/win32'));
+      jest.doMock('node:path', () => jest.requireActual('node:path/win32'));
     } else {
-      jest.doMock('path', () => jest.requireActual('path'));
+      jest.doMock('node:path', () => jest.requireActual('node:path'));
     }
 
-    const {EventEmitter} = require('events');
+    const {EventEmitter} = require('node:events');
     const {Graph} = require('../Graph');
 
     traverseDependencies = jest.spyOn(Graph.prototype, 'traverseDependencies');

--- a/packages/metro/src/DeltaBundler/__tests__/Graph-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/Graph-test.js
@@ -158,7 +158,7 @@ const Actions = {
     }
     const deps = getMockDependency(path);
     const depName = name ?? dependencyPath.replace('/', '');
-    const key = require('crypto')
+    const key = require('node:crypto')
       .createHash('sha1')
       .update([depName, data?.asyncType ?? '(null)'].join('\0'))
       .digest('base64');

--- a/packages/metro/src/DeltaBundler/__tests__/Transformer-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/Transformer-test.js
@@ -12,17 +12,18 @@
 
 jest
   .setMock('jest-worker', () => ({}))
-  .mock('fs', () => new (require('metro-memory-fs'))())
-  .mock('assert')
+  .mock('node:fs', () => new (require('metro-memory-fs'))())
+  .mock('node:assert')
   .mock('../getTransformCacheKey', () => jest.fn(() => 'hash'))
   .mock('../WorkerFarm')
   .mock('/path/to/transformer.js', () => ({}), {virtual: true});
 
 // Must be required after mocks above
 const Transformer = require('../Transformer').default;
-const fs = require('fs');
 const {getDefaultValues} = require('metro-config').getDefaultConfig;
 const {mergeConfig} = require('metro-config/private/loadConfig');
+
+const fs = jest.requireMock('node:fs');
 
 describe('Transformer', function () {
   let watchFolders;

--- a/packages/metro/src/DeltaBundler/__tests__/WorkerFarm-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/WorkerFarm-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const {getDefaultConfig} = require('metro-config');
-const {Readable} = require('stream');
+const {Readable} = require('node:stream');
 
 describe('Worker Farm', function () {
   let api;
@@ -23,10 +23,10 @@ describe('Worker Farm', function () {
   beforeEach(async function () {
     jest
       .resetModules()
-      .mock('fs', () => ({writeFileSync: jest.fn()}))
+      .mock('node:fs', () => ({writeFileSync: jest.fn()}))
       .mock('jest-worker', () => ({__esModule: true, Worker: jest.fn()}));
 
-    const fs = require('fs');
+    const fs = jest.requireMock('node:fs');
     const jestWorker = require('jest-worker');
     config = await getDefaultConfig();
 

--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -21,23 +21,23 @@ const {
   DuplicateHasteCandidatesError,
   default: {H: Haste},
 } = require('metro-file-map');
-const path = require('path');
+const path = require('node:path');
 
 const mockPlatform = process.platform;
 
 jest.useRealTimers();
 jest
   // It's noticeably faster to prevent running watchman from FileWatcher.
-  .mock('child_process', () => ({}))
-  .mock('os', () => ({
-    ...jest.requireActual('os'),
+  .mock('node:child_process', () => ({}))
+  .mock('node:os', () => ({
+    ...jest.requireActual('node:os'),
     platform: () => 'test',
     tmpdir: () => (mockPlatform === 'win32' ? 'C:\\tmp' : '/tmp'),
     hostname: () => 'testhost',
     endianness: () => 'LE',
     release: () => '',
   }))
-  .mock('graceful-fs', () => require('fs'))
+  .mock('graceful-fs', () => jest.requireMock('node:fs'))
   .spyOn(console, 'warn')
   .mockImplementation(() => {});
 
@@ -79,13 +79,13 @@ function dep(name: string): TransformResultDependency {
     for (const entName in desc) {
       const ent = desc[entName];
 
-      const entPath = require('path').join(dirPath, entName);
+      const entPath = jest.requireMock('node:path').join(dirPath, entName);
       if (typeof ent === 'string') {
         fs.writeFileSync(entPath, ent);
         continue;
       }
       if (typeof ent !== 'object') {
-        throw new Error(require('util').format('invalid entity:', ent));
+        throw new Error(require('node:util').format('invalid entity:', ent));
       }
       fs.mkdirSync(entPath);
       mockDir(entPath, ent);
@@ -162,20 +162,20 @@ function dep(name: string): TransformResultDependency {
 
       if (osPlatform === 'win32') {
         const mockPath = jest.requireActual<{win32: unknown}>('path');
-        jest.mock('path', () => mockPath.win32);
+        jest.mock('node:path', () => mockPath.win32);
         jest.mock(
-          'fs',
+          'node:fs',
           () => new (require('metro-memory-fs'))({platform: 'win32'}),
         );
       } else {
-        jest.mock('path', () => jest.requireActual('path'));
-        jest.mock('fs', () => new (require('metro-memory-fs'))());
+        jest.mock('node:path', () => jest.requireActual('node:path'));
+        jest.mock('node:fs', () => new (require('metro-memory-fs'))());
       }
 
       // $FlowFixMe[cannot-write]
-      require('os').tmpdir = () => p('/tmp');
+      jest.requireMock('node:os').tmpdir = () => p('/tmp');
 
-      fs = require('fs');
+      fs = jest.requireMock('node:fs');
       originalError = console.error;
       // $FlowFixMe[cannot-write]
       console.error = jest.fn((...args) => {

--- a/packages/metro/src/DeltaBundler/__tests__/test-utils.js
+++ b/packages/metro/src/DeltaBundler/__tests__/test-utils.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import type EventEmitter from 'events';
+import type EventEmitter from 'node:events';
 
 export type FileEntry =
   string | [string, {isSymlink?: boolean, modifiedTime?: number}];

--- a/packages/metro/src/DeltaBundler/buildSubgraph.js
+++ b/packages/metro/src/DeltaBundler/buildSubgraph.js
@@ -20,7 +20,7 @@ import type {
 
 import {deriveAbsolutePathFromContext} from '../lib/contextModule';
 import {isResolvedDependency} from '../lib/isResolvedDependency';
-import path from 'path';
+import path from 'node:path';
 
 type Parameters<T> = Readonly<{
   resolve: ResolveFn,

--- a/packages/metro/src/DeltaBundler/getTransformCacheKey.js
+++ b/packages/metro/src/DeltaBundler/getTransformCacheKey.js
@@ -12,8 +12,8 @@
 import type {TransformerConfig} from './Worker';
 import type {JsTransformerConfig} from 'metro-transform-worker';
 
-import crypto from 'crypto';
 import {getCacheKey} from 'metro-cache-key';
+import crypto from 'node:crypto';
 
 // eslint-disable-next-line import/no-commonjs
 const VERSION = require('../../package.json').version;

--- a/packages/metro/src/IncrementalBundler.js
+++ b/packages/metro/src/IncrementalBundler.js
@@ -25,9 +25,9 @@ import ResourceNotFoundError from './IncrementalBundler/ResourceNotFoundError';
 import getGraphId from './lib/getGraphId';
 import getPrependedScripts from './lib/getPrependedScripts';
 import * as transformHelpers from './lib/transformHelpers';
-import crypto from 'crypto';
-import fs from 'fs';
-import path from 'path';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export opaque type RevisionId: string = string;
 

--- a/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+++ b/packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -26,8 +26,8 @@ import template from '@babel/template';
 import traverse from '@babel/traverse';
 import * as types from '@babel/types';
 import {isImport, isProgram} from '@babel/types';
-import crypto from 'crypto';
 import invariant from 'invariant';
+import crypto from 'node:crypto';
 import nullthrows from 'nullthrows';
 
 type ImportDependencyOptions = Readonly<{

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -33,7 +33,6 @@ import type {
   SplitBundleOptions,
 } from './shared/types';
 import type {IncomingMessage} from 'connect';
-import type {ServerResponse} from 'http';
 import type {CacheStore} from 'metro-cache';
 import type {ConfigT, RootPerfLogger} from 'metro-config';
 import type {
@@ -42,6 +41,7 @@ import type {
 } from 'metro-core/private/Logger';
 import type {CustomResolverOptions} from 'metro-resolver/private/types';
 import type {CustomTransformOptions} from 'metro-transform-worker';
+import type {ServerResponse} from 'node:http';
 
 import {getAsset} from './Assets';
 import baseJSBundle from './DeltaBundler/Serializers/baseJSBundle';
@@ -71,10 +71,10 @@ import * as fs from 'graceful-fs';
 import * as jscSafeUrl from 'jsc-safe-url';
 import {Logger} from 'metro-core';
 import mime from 'mime-types';
+import path from 'node:path';
+import {performance} from 'node:perf_hooks';
+import querystring from 'node:querystring';
 import nullthrows from 'nullthrows';
-import path from 'path';
-import {performance} from 'perf_hooks';
-import querystring from 'querystring';
 
 const debug = debugModule('Metro:Server');
 

--- a/packages/metro/src/Server/MultipartResponse.js
+++ b/packages/metro/src/Server/MultipartResponse.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import type {IncomingMessage, ServerResponse} from 'http';
+import type {IncomingMessage, ServerResponse} from 'node:http';
 
 import accepts from 'accepts';
 

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -30,7 +30,7 @@ import MockResponse from 'mock-res';
 const {
   getDefaultConfig: {getDefaultValues},
 } = require('metro-config');
-const path = require('path');
+const path = require('node:path');
 
 jest
   .mock('jest-worker', () => ({}))
@@ -78,8 +78,8 @@ describe('processRequest', () => {
     getAsset = jest.fn();
 
     let i = 0;
-    jest.doMock('crypto', () => ({
-      ...jest.requireActual('crypto'),
+    jest.doMock('node:crypto', () => ({
+      ...jest.requireActual('node:crypto'),
       randomBytes: jest.fn().mockImplementation(() => `XXXXX-${i++}`),
     }));
 
@@ -97,13 +97,16 @@ describe('processRequest', () => {
       getResolveDependencyFn,
     }));
 
+    const mockFs = new (require('metro-memory-fs'))();
+    jest.doMock('fs', () => mockFs);
+    jest.doMock('node:fs', () => mockFs);
+
     Bundler = require('../../Bundler').default;
     jest
       .spyOn(Bundler.prototype, 'getDependencyGraph')
       .mockImplementation(getDependencyGraph);
 
-    jest.mock('fs', () => new (require('metro-memory-fs'))());
-    fs = require('fs');
+    fs = mockFs;
 
     DeltaBundler = require('../../DeltaBundler').default;
     jest
@@ -326,7 +329,9 @@ describe('processRequest', () => {
     );
 
     // $FlowFixMe[cannot-write]
-    fs.realpath = jest.fn((file, cb) => cb?.(null, '/root/foo.js'));
+    fs.realpath = jest.fn((file, cb) => {
+      cb?.(null, '/root/foo.js');
+    });
   });
 
   test.each(['?', '//&'])(

--- a/packages/metro/src/__tests__/Assets-test.js
+++ b/packages/metro/src/__tests__/Assets-test.js
@@ -10,15 +10,16 @@
 
 'use strict';
 
-jest.mock('fs', () => new (require('metro-memory-fs'))());
+jest.mock('node:fs', () => new (require('metro-memory-fs'))());
 jest.mock('image-size');
 
 jest.useRealTimers();
 
 const {getAsset, getAssetData} = require('../Assets');
-const crypto = require('crypto');
-const fs = require('fs');
-const path = require('path');
+const crypto = require('node:crypto');
+const path = require('node:path');
+
+const fs = jest.requireMock('node:fs');
 
 const mockImageWidth = 300;
 const mockImageHeight = 200;

--- a/packages/metro/src/__tests__/HmrServer-test.js
+++ b/packages/metro/src/__tests__/HmrServer-test.js
@@ -18,8 +18,8 @@ import DeltaBundler from '../DeltaBundler';
 import HmrServer from '../HmrServer';
 import IncrementalBundler from '../IncrementalBundler';
 import getGraphId from '../lib/getGraphId';
-import EventEmitter from 'events';
 import {mergeConfig} from 'metro-config';
+import EventEmitter from 'node:events';
 
 const {
   getDefaultConfig: {getDefaultValues},
@@ -29,7 +29,7 @@ jest.mock('../lib/transformHelpers', () => ({
   getResolveDependencyFn:
     () => (from: string, to: TransformResultDependency) => ({
       type: 'sourceFile',
-      filePath: `${require('path').resolve(from, to.name)}.js`,
+      filePath: `${require('node:path').resolve(from, to.name)}.js`,
     }),
 }));
 

--- a/packages/metro/src/cli-utils.js
+++ b/packages/metro/src/cli-utils.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import fs from 'fs';
+import fs from 'node:fs';
 
 export const watchFile = async function (
   filename: string,

--- a/packages/metro/src/commands/dependencies.js
+++ b/packages/metro/src/commands/dependencies.js
@@ -15,10 +15,10 @@ import typeof Yargs from 'yargs';
 
 import {makeAsyncCommand} from '../cli-utils';
 import Server from '../Server';
-import fs from 'fs';
 import {loadConfig} from 'metro-config';
-import path from 'path';
-import {promisify} from 'util';
+import fs from 'node:fs';
+import path from 'node:path';
+import {promisify} from 'node:util';
 
 type Args = Readonly<{
   _: unknown,

--- a/packages/metro/src/commands/serve.js
+++ b/packages/metro/src/commands/serve.js
@@ -9,13 +9,13 @@
  * @oncall react_native
  */
 
-import type {ServerOptions as HttpsServerOptions} from 'https';
+import type {ServerOptions as HttpsServerOptions} from 'node:https';
 import type {CommandModule} from 'yargs';
 import typeof Yargs from 'yargs';
 
 import {makeAsyncCommand, watchFile} from '../cli-utils';
 import {loadConfig, resolveConfig} from 'metro-config';
-import {promisify} from 'util';
+import {promisify} from 'node:util';
 
 type Args = Readonly<{
   _: unknown,

--- a/packages/metro/src/index.flow.js
+++ b/packages/metro/src/index.flow.js
@@ -14,11 +14,6 @@ import type {ReadOnlyGraph} from './DeltaBundler';
 import type {ServerOptions} from './Server';
 import type {BuildOptions, OutputOptions, RequestOptions} from './shared/types';
 import type {HandleFunction} from 'connect';
-import type {Server as HttpServer} from 'http';
-import type {
-  Server as HttpsServer,
-  ServerOptions as HttpsServerOptions,
-} from 'https';
 import type {TransformProfile} from 'metro-babel-transformer';
 import type {
   ConfigT,
@@ -28,6 +23,11 @@ import type {
 } from 'metro-config';
 import type {CustomResolverOptions} from 'metro-resolver';
 import type {CustomTransformOptions} from 'metro-transform-worker';
+import type {Server as HttpServer} from 'node:http';
+import type {
+  Server as HttpsServer,
+  ServerOptions as HttpsServerOptions,
+} from 'node:https';
 import type {Server as WebSocketServer} from 'ws';
 import typeof Yargs from 'yargs';
 
@@ -41,9 +41,6 @@ import JsonReporter from './lib/JsonReporter';
 import TerminalReporter from './lib/TerminalReporter';
 import MetroServer from './Server';
 import * as outputBundle from './shared/output/bundle';
-import fs from 'fs';
-import http from 'http';
-import https from 'https';
 import {
   getDefaultConfig,
   loadConfig,
@@ -51,9 +48,12 @@ import {
   resolveConfig,
 } from 'metro-config';
 import {Terminal} from 'metro-core';
-import net from 'net';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import util from 'node:util';
 import nullthrows from 'nullthrows';
-import util from 'util';
 
 const DEFAULTS = MetroServer.DEFAULT_BUNDLE_OPTIONS;
 

--- a/packages/metro/src/integration_tests/__tests__/build-errors-test.js
+++ b/packages/metro/src/integration_tests/__tests__/build-errors-test.js
@@ -12,7 +12,7 @@
 'use strict';
 
 const Metro = require('../../..');
-const path = require('path');
+const path = require('node:path');
 
 jest.setTimeout(30 * 1000);
 const BUILD_ERRORS_SRC_DIR =

--- a/packages/metro/src/integration_tests/__tests__/build-test.js
+++ b/packages/metro/src/integration_tests/__tests__/build-test.js
@@ -14,7 +14,7 @@
 const Metro = require('../../..');
 const execBundle = require('../execBundle');
 const MetroConfig = require('metro-config');
-const path = require('path');
+const path = require('node:path');
 
 jest.setTimeout(30 * 1000);
 

--- a/packages/metro/src/integration_tests/__tests__/buildGraph-test.js
+++ b/packages/metro/src/integration_tests/__tests__/buildGraph-test.js
@@ -13,7 +13,7 @@
 import CountingSet from '../../lib/CountingSet';
 
 const Metro = require('../../..');
-const path = require('path');
+const path = require('node:path');
 
 jest.useRealTimers();
 jest.setTimeout(120 * 1000);

--- a/packages/metro/src/integration_tests/__tests__/rambundle-test.js
+++ b/packages/metro/src/integration_tests/__tests__/rambundle-test.js
@@ -12,10 +12,10 @@ import * as Metro from '../../..';
 import RamBundleParser from '../../lib/RamBundleParser';
 import * as ramBundleOutput from '../../shared/output/unbundle';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const vm = require('vm');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const vm = require('node:vm');
 
 jest.setTimeout(30 * 1000);
 

--- a/packages/metro/src/integration_tests/__tests__/server-endpoints-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-endpoints-test.js
@@ -11,8 +11,8 @@
 'use strict';
 
 const Metro = require('../../..');
-const http = require('http');
-const https = require('https');
+const http = require('node:http');
+const https = require('node:https');
 const selfsigned = require('selfsigned');
 const WebSocket = require('ws');
 

--- a/packages/metro/src/integration_tests/__tests__/server-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-test.js
@@ -12,8 +12,8 @@
 
 const Metro = require('../../..');
 const execBundle = require('../execBundle');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 jest.useRealTimers();
 jest.setTimeout(60 * 1000);

--- a/packages/metro/src/integration_tests/__tests__/server-tls-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-tls-test.js
@@ -11,11 +11,11 @@
 'use strict';
 
 const Metro = require('../../..');
-const fs = require('fs');
-const http = require('http');
-const https = require('https');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const os = require('node:os');
+const path = require('node:path');
 const selfsigned = require('selfsigned');
 
 jest.useRealTimers();

--- a/packages/metro/src/integration_tests/__tests__/server-torn-down-test.js
+++ b/packages/metro/src/integration_tests/__tests__/server-torn-down-test.js
@@ -11,7 +11,7 @@
 
 const Metro = require('../../..');
 // $FlowFixMe[cannot-resolve-module] - Untyped module
-const asyncHooks = require('async_hooks');
+const asyncHooks = require('node:async_hooks');
 
 jest.useRealTimers();
 

--- a/packages/metro/src/integration_tests/__tests__/sourcemap-test.js
+++ b/packages/metro/src/integration_tests/__tests__/sourcemap-test.js
@@ -12,7 +12,7 @@
 
 const Metro = require('../../..');
 const execBundle = require('../execBundle');
-const fs = require('fs');
+const fs = require('node:fs');
 const sourceMap = require('source-map');
 const stackTrace = require('stack-trace');
 

--- a/packages/metro/src/integration_tests/execBundle.js
+++ b/packages/metro/src/integration_tests/execBundle.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import vm from 'vm';
+import vm from 'node:vm';
 
 module.exports = function execBundle(code: string, context: any = {}): unknown {
   if (vm.isContext(context)) {

--- a/packages/metro/src/integration_tests/metro.config.js
+++ b/packages/metro/src/integration_tests/metro.config.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 const ROOT_PATH = path.resolve(__dirname, 'basic_bundle');
 

--- a/packages/metro/src/lib/BatchProcessor.js
+++ b/packages/metro/src/lib/BatchProcessor.js
@@ -10,7 +10,7 @@
  */
 
 import invariant from 'invariant';
-import {clearTimeout, setTimeout} from 'timers';
+import {clearTimeout, setTimeout} from 'node:timers';
 
 type ProcessBatch<TItem, TResult> = (
   batch: Array<TItem>,

--- a/packages/metro/src/lib/JsonReporter.js
+++ b/packages/metro/src/lib/JsonReporter.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import type {Writable} from 'stream';
+import type {Writable} from 'node:stream';
 
 export type SerializedError = {
   message: string,

--- a/packages/metro/src/lib/TerminalReporter.js
+++ b/packages/metro/src/lib/TerminalReporter.js
@@ -12,7 +12,7 @@
 import type {BundleDetails, ReportableEvent} from './reporting';
 import type {Terminal} from 'metro-core';
 import type {HealthCheckResult, WatcherStatus} from 'metro-file-map';
-import type {BackgroundColors, ForegroundColors, Modifiers} from 'util';
+import type {BackgroundColors, ForegroundColors, Modifiers} from 'node:util';
 
 import {calculateBundleProgressRatio} from './bundleProgressUtils';
 import logToConsole from './logToConsole';
@@ -20,8 +20,8 @@ import * as reporting from './reporting';
 // $FlowFixMe[untyped-import] lodash.throttle
 import throttle from 'lodash.throttle';
 import {AmbiguousModuleResolutionError} from 'metro-core';
-import path from 'path';
-import util from 'util';
+import path from 'node:path';
+import util from 'node:util';
 
 type StyleFormat = ReadonlyArray<
   ForegroundColors | BackgroundColors | Modifiers,

--- a/packages/metro/src/lib/__mocks__/getAbsolutePath.js
+++ b/packages/metro/src/lib/__mocks__/getAbsolutePath.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 export default (file: string, roots: ReadonlyArray<string>): string =>
   path.resolve(roots[0], file);

--- a/packages/metro/src/lib/__tests__/contextModuleTemplates-test.js
+++ b/packages/metro/src/lib/__tests__/contextModuleTemplates-test.js
@@ -53,7 +53,7 @@ describe('getContextModuleTemplate', () => {
   test('creates posix paths on windows for sync template', () => {
     jest.resetModules();
     const mockPath = jest.requireActual<{win32: unknown}>('path');
-    jest.mock('path', () => mockPath.win32);
+    jest.mock('node:path', () => mockPath.win32);
     const {
       getContextModuleTemplate: getWindowsTemplate,
     } = require('../contextModuleTemplates');

--- a/packages/metro/src/lib/__tests__/getPreludeCode-test.js
+++ b/packages/metro/src/lib/__tests__/getPreludeCode-test.js
@@ -11,7 +11,7 @@
 
 import getPreludeCode from '../getPreludeCode';
 
-const vm = require('vm');
+const vm = require('node:vm');
 
 ['development', 'production'].forEach((mode: string) => {
   describe(`${mode} mode`, () => {

--- a/packages/metro/src/lib/contextModule.js
+++ b/packages/metro/src/lib/contextModule.js
@@ -14,9 +14,9 @@ import type {
   RequireContextParams,
 } from '../ModuleGraph/worker/collectDependencies';
 
-import crypto from 'crypto';
+import crypto from 'node:crypto';
+import path from 'node:path';
 import nullthrows from 'nullthrows';
-import path from 'path';
 
 export type RequireContext = Readonly<{
   /* Should search for files recursively. Optional, default `true` when `require.context` is used */

--- a/packages/metro/src/lib/contextModuleTemplates.js
+++ b/packages/metro/src/lib/contextModuleTemplates.js
@@ -11,8 +11,8 @@
 
 import type {ContextMode} from '../ModuleGraph/worker/collectDependencies';
 
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 function createFileMap(
   modulePath: string,

--- a/packages/metro/src/lib/createWebsocketServer.js
+++ b/packages/metro/src/lib/createWebsocketServer.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import {clearInterval, setInterval} from 'timers';
+import {clearInterval, setInterval} from 'node:timers';
 import ws from 'ws';
 
 type WebsocketServiceInterface<T> = interface {

--- a/packages/metro/src/lib/formatBundlingError.js
+++ b/packages/metro/src/lib/formatBundlingError.js
@@ -16,8 +16,8 @@ import RevisionNotFoundError from '../IncrementalBundler/RevisionNotFoundError';
 import {UnableToResolveError} from '../node-haste/DependencyGraph/ModuleResolution';
 import {codeFrameColumns} from '@babel/code-frame';
 import ErrorStackParser from 'error-stack-parser';
-import fs from 'fs';
 import {AmbiguousModuleResolutionError} from 'metro-core';
+import fs from 'node:fs';
 import serializeError from 'serialize-error';
 
 export type CustomError = Error &

--- a/packages/metro/src/lib/logToConsole.js
+++ b/packages/metro/src/lib/logToConsole.js
@@ -11,9 +11,9 @@
 /* eslint-disable no-console */
 
 import type {Terminal} from 'metro-core';
-import type {BackgroundColors, ForegroundColors, Modifiers} from 'util';
+import type {BackgroundColors, ForegroundColors, Modifiers} from 'node:util';
 
-import util from 'util';
+import util from 'node:util';
 
 const groupStack = [];
 let collapsedGuardTimer;

--- a/packages/metro/src/lib/parseBundleOptionsFromBundleRequestUrl.js
+++ b/packages/metro/src/lib/parseBundleOptionsFromBundleRequestUrl.js
@@ -18,7 +18,7 @@ import parseCustomResolverOptions from './parseCustomResolverOptions';
 import parseCustomTransformOptions from './parseCustomTransformOptions';
 import debugModule from 'debug';
 import * as jscSafeUrl from 'jsc-safe-url';
-import path from 'path';
+import path from 'node:path';
 
 const debug = debugModule(
   'Metro:Server:parseBundleOptionsFromBundleRequestUrl',

--- a/packages/metro/src/lib/parseJsonBody.js
+++ b/packages/metro/src/lib/parseJsonBody.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import type {IncomingMessage} from 'http';
+import type {IncomingMessage} from 'node:http';
 
 const CONTENT_TYPE = 'application/json';
 const SIZE_LIMIT = 100 * 1024 * 1024; // 100MB

--- a/packages/metro/src/lib/pathUtils.js
+++ b/packages/metro/src/lib/pathUtils.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 export const normalizePathSeparatorsToPosix: string => string =
   path.sep === '/'

--- a/packages/metro/src/lib/relativizeSourceMap.js
+++ b/packages/metro/src/lib/relativizeSourceMap.js
@@ -11,7 +11,7 @@
 
 import type {MixedSourceMap} from 'metro-source-map';
 
-import path from 'path';
+import path from 'node:path';
 
 export default function relativizeSourceMapInline(
   sourceMap: MixedSourceMap,

--- a/packages/metro/src/lib/reporting.js
+++ b/packages/metro/src/lib/reporting.js
@@ -14,8 +14,8 @@ import type {HealthCheckResult, WatcherStatus} from 'metro-file-map';
 import type {CustomResolverOptions} from 'metro-resolver';
 import type {CustomTransformOptions} from 'metro-transform-worker';
 
-import tty from 'tty';
-import util from 'util';
+import tty from 'node:tty';
+import util from 'node:util';
 
 const supportsColor = (): boolean =>
   process.stdout instanceof tty.WriteStream && process.stdout.hasColors();

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -29,8 +29,6 @@ import type {FileSystemLookup} from 'metro-resolver';
 import createFileMap from './DependencyGraph/createFileMap';
 import {ModuleResolver} from './DependencyGraph/ModuleResolution';
 import {PackageCache} from './PackageCache';
-import EventEmitter from 'events';
-import fs from 'fs';
 import {
   AmbiguousModuleResolutionError,
   Logger,
@@ -39,8 +37,10 @@ import {
 import canonicalize from 'metro-core/private/canonicalize';
 import {DuplicateHasteCandidatesError} from 'metro-file-map';
 import {InvalidPackageError} from 'metro-resolver';
+import EventEmitter from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
 import nullthrows from 'nullthrows';
-import path from 'path';
 
 const {createActionStartEntry, createActionEndEntry, log} = Logger;
 

--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -26,12 +26,12 @@ import type {
 import type {PackageForModule, PackageJson} from 'metro-resolver/private/types';
 
 import {codeFrameColumns} from '@babel/code-frame';
-import fs from 'fs';
 import invariant from 'invariant';
 import * as Resolver from 'metro-resolver';
 import createDefaultContext from 'metro-resolver/private/createDefaultContext';
-import path from 'path';
-import util from 'util';
+import fs from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
 
 export type DirExistsFn = (filePath: string) => boolean;
 

--- a/packages/metro/src/node-haste/PackageCache.js
+++ b/packages/metro/src/node-haste/PackageCache.js
@@ -11,8 +11,8 @@
 
 import type {PackageJson} from 'metro-resolver/private/types';
 
-import {readFileSync} from 'fs';
-import {dirname, sep} from 'path';
+import {readFileSync} from 'node:fs';
+import {dirname, sep} from 'node:path';
 
 type GetClosestPackageFn = (absoluteFilePath: string) => ?{
   packageJsonPath: string,

--- a/packages/metro/src/node-haste/__tests__/PackageCache-test.js
+++ b/packages/metro/src/node-haste/__tests__/PackageCache-test.js
@@ -9,12 +9,14 @@
  * @oncall react_native
  */
 
-import {sep} from 'path';
+import {sep} from 'node:path';
 
 const {PackageCache} = require('../PackageCache');
 
 const mockReadFileSync = jest.fn();
-jest.mock('fs', () => ({readFileSync: (...args) => mockReadFileSync(...args)}));
+jest.mock('node:fs', () => ({
+  readFileSync: (...args) => mockReadFileSync(...args),
+}));
 
 type ClosestPackageMap = Map<
   string,

--- a/packages/metro/src/node-haste/lib/AssetPaths.js
+++ b/packages/metro/src/node-haste/lib/AssetPaths.js
@@ -10,7 +10,7 @@
  */
 
 import parsePlatformFilePath from './parsePlatformFilePath';
-import path from 'path';
+import path from 'node:path';
 
 export type AssetPath = {
   assetName: string,

--- a/packages/metro/src/node-haste/lib/parsePlatformFilePath.js
+++ b/packages/metro/src/node-haste/lib/parsePlatformFilePath.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import path from 'path';
+import path from 'node:path';
 
 type PlatformFilePathParts = {
   dirPath: string,

--- a/packages/metro/src/shared/output/RamBundle/as-assets.js
+++ b/packages/metro/src/shared/output/RamBundle/as-assets.js
@@ -19,8 +19,8 @@ import buildSourcemapWithMetadata from './buildSourcemapWithMetadata';
 import MAGIC_RAM_BUNDLE_NUMBER from './magic-number';
 import {joinModules} from './util';
 import writeSourceMap from './write-sourcemap';
-import {promises as fsPromises} from 'fs';
-import path from 'path';
+import {promises as fsPromises} from 'node:fs';
+import path from 'node:path';
 
 // must not start with a dot, as that won't go into the apk
 const MAGIC_RAM_BUNDLE_FILENAME = 'UNBUNDLE';

--- a/packages/metro/src/shared/output/RamBundle/as-indexed-file.js
+++ b/packages/metro/src/shared/output/RamBundle/as-indexed-file.js
@@ -15,14 +15,14 @@ import type {
   ModuleTransportLike,
   OutputOptions,
 } from '../../types';
-import type {WriteStream} from 'fs';
+import type {WriteStream} from 'node:fs';
 
 import relativizeSourceMapInline from '../../../lib/relativizeSourceMap';
 import buildSourcemapWithMetadata from './buildSourcemapWithMetadata';
 import MAGIC_UNBUNDLE_FILE_HEADER from './magic-number';
 import {joinModules} from './util';
 import writeSourceMap from './write-sourcemap';
-import fs from 'fs';
+import fs from 'node:fs';
 
 const SIZEOF_UINT32 = 4;
 

--- a/packages/metro/src/shared/output/meta.js
+++ b/packages/metro/src/shared/output/meta.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 const isUTF8 = (encoding: 'ascii' | 'utf16le' | 'utf8') =>
   /^utf-?8$/i.test(encoding);

--- a/packages/metro/src/shared/output/writeFile.js
+++ b/packages/metro/src/shared/output/writeFile.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import fs from 'fs';
+import fs from 'node:fs';
 import throat from 'throat';
 
 const writeFileWithThroat: typeof fs.promises.writeFile = throat(

--- a/packages/metro/types/Bundler.d.ts
+++ b/packages/metro/types/Bundler.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<e960172db9c9ad9a32bc3bf30ebe2bc1>>
+ * @generated SignedSource<<f44800722810a79ea545d36086a3dde1>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/Bundler.js
@@ -17,8 +17,8 @@
 
 import type {TransformResultWithSource} from './DeltaBundler';
 import type {TransformOptions} from './DeltaBundler/Worker';
-import type EventEmitter from 'events';
 import type {ConfigT} from 'metro-config';
+import type EventEmitter from 'node:events';
 
 import DependencyGraph from './node-haste/DependencyGraph';
 

--- a/packages/metro/types/DeltaBundler.d.ts
+++ b/packages/metro/types/DeltaBundler.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<9fb6b7178cc917f17b839e36feb87ee8>>
+ * @generated SignedSource<<81e6b665d983033e84ac6517c1012086>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/DeltaBundler.js
@@ -16,7 +16,7 @@
  */
 
 import type {DeltaResult, Graph, MixedOutput, Options, ReadOnlyGraph} from './DeltaBundler/types';
-import type EventEmitter from 'events';
+import type EventEmitter from 'node:events';
 
 export type {DeltaResult, Graph, Dependencies, MixedOutput, Module, ReadOnlyGraph, TransformFn, TransformResult, TransformResultDependency, TransformResultWithSource} from './DeltaBundler/types';
 /**

--- a/packages/metro/types/DeltaBundler/DeltaCalculator.d.ts
+++ b/packages/metro/types/DeltaBundler/DeltaCalculator.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<973161c2431719eaa4e5f3a5414b31bb>>
+ * @generated SignedSource<<9685e297be806c39ff9bf6b57103357c>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/DeltaBundler/DeltaCalculator.js
@@ -18,7 +18,7 @@
 import type {DeltaResult, Options} from './types';
 
 import {Graph} from './Graph';
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 /**
  * This class is in charge of calculating the delta of changed modules that
  * happen between calls. To do so, it subscribes to file changes, so it can

--- a/packages/metro/types/DeltaBundler/Serializers/helpers/js.d.ts
+++ b/packages/metro/types/DeltaBundler/Serializers/helpers/js.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<e898ae56224c64d5d37e23cae7a2b84d>>
+ * @generated SignedSource<<fdf4acf8d1eecbbefcabdb864cfc6482>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/DeltaBundler/Serializers/helpers/js.js
@@ -18,7 +18,7 @@
 import type {MixedOutput, Module} from '../../types';
 import type {JsOutput} from 'metro-transform-worker';
 
-import path from 'path';
+import path from 'node:path';
 
 export type Options = Readonly<{
   createModuleId: ($$PARAM_0$$: string) => number | string;

--- a/packages/metro/types/Server.d.ts
+++ b/packages/metro/types/Server.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<a9ab51140db45fe3c6a3c015d4da3401>>
+ * @generated SignedSource<<edf96165fc2c0bfc8f5e49c02021a841>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/Server.js
@@ -19,10 +19,10 @@ import type {AssetData} from './Assets';
 import type {RamBundleInfo} from './DeltaBundler/Serializers/getRamBundleInfo';
 import type {BuildOptions, BundleOptions} from './shared/types';
 import type {IncomingMessage} from 'connect';
-import type {ServerResponse} from 'http';
 import type {ConfigT} from 'metro-config';
 import type {CustomResolverOptions} from 'metro-resolver/private/types';
 import type {CustomTransformOptions} from 'metro-transform-worker';
+import type {ServerResponse} from 'node:http';
 
 import IncrementalBundler from './IncrementalBundler';
 import {SourcePathsMode} from './shared/types';

--- a/packages/metro/types/Server/MultipartResponse.d.ts
+++ b/packages/metro/types/Server/MultipartResponse.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<5a0b37c39c07c685f750eb9419dc5b5b>>
+ * @generated SignedSource<<1ea61133bb1f20cfa2e82c2ba414d139>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/Server/MultipartResponse.js
@@ -15,7 +15,7 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {IncomingMessage, ServerResponse} from 'http';
+import type {IncomingMessage, ServerResponse} from 'node:http';
 
 type Data = string | Buffer | Uint8Array;
 type Headers = {[$$Key$$: string]: string | number};

--- a/packages/metro/types/index.d.ts
+++ b/packages/metro/types/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<4b2bbfa101b60fd30d555640425678d8>>
+ * @generated SignedSource<<4aca97550eb6e579e435254037e38616>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/index.flow.js
@@ -20,12 +20,12 @@ import type {ReadOnlyGraph} from './DeltaBundler';
 import type {ServerOptions} from './Server';
 import type {BuildOptions, OutputOptions, RequestOptions} from './shared/types';
 import type {HandleFunction} from 'connect';
-import type {Server as HttpServer} from 'http';
-import type {Server as HttpsServer, ServerOptions as HttpsServerOptions} from 'https';
 import type {TransformProfile} from 'metro-babel-transformer';
 import type {ConfigT, InputConfigT, MetroConfig, Middleware} from 'metro-config';
 import type {CustomResolverOptions} from 'metro-resolver';
 import type {CustomTransformOptions} from 'metro-transform-worker';
+import type {Server as HttpServer} from 'node:http';
+import type {Server as HttpsServer, ServerOptions as HttpsServerOptions} from 'node:https';
 import type {Server as WebSocketServer} from 'ws';
 import type $$IMPORT_TYPEOF_1$$ from 'yargs';
 

--- a/packages/metro/types/lib/JsonReporter.d.ts
+++ b/packages/metro/types/lib/JsonReporter.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<a6f3db4f608d926c8320368a79e63fc3>>
+ * @generated SignedSource<<1c9e77c89ab61bbb8fea403a63e33ab2>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/lib/JsonReporter.js
@@ -15,7 +15,7 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {Writable} from 'stream';
+import type {Writable} from 'node:stream';
 
 export type SerializedError = {
   message: string;

--- a/packages/metro/types/lib/parseJsonBody.d.ts
+++ b/packages/metro/types/lib/parseJsonBody.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<5a1c2735728a43c6b899b683a08aea0e>>
+ * @generated SignedSource<<209b39c4ed4b1d1fb864533ac8c70ec3>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/lib/parseJsonBody.js
@@ -15,7 +15,7 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {IncomingMessage} from 'http';
+import type {IncomingMessage} from 'node:http';
 
 export type JsonData = {[$$Key$$: string]: JsonData} | Array<JsonData> | string | number | boolean | null;
 /**

--- a/packages/metro/types/node-haste/DependencyGraph.d.ts
+++ b/packages/metro/types/node-haste/DependencyGraph.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<55a0e038f230fd92a5284a87b111235f>>
+ * @generated SignedSource<<30d76234544ec70f02b4a784d55cd7af>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/node-haste/DependencyGraph.js
@@ -19,7 +19,7 @@ import type {BundlerResolution, TransformResultDependency} from '../DeltaBundler
 import type {ResolverInputOptions} from '../shared/types';
 import type {ConfigT} from 'metro-config';
 
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 
 declare class DependencyGraph extends EventEmitter {
   constructor(

--- a/private/metro-memory-fs/src/__tests__/index-test.js
+++ b/private/metro-memory-fs/src/__tests__/index-test.js
@@ -16,7 +16,7 @@
 jest.useRealTimers();
 
 const MemoryFs = require('../index');
-const path = require('path');
+const path = require('node:path');
 
 let fs;
 

--- a/private/metro-memory-fs/src/index.js
+++ b/private/metro-memory-fs/src/index.js
@@ -14,9 +14,9 @@
 /* eslint-disable no-bitwise */
 
 // $FlowFixMe[cannot-resolve-module]: not defined by Flow
-const constants = require('constants');
-const {EventEmitter} = require('events');
-const stream = require('stream');
+const constants = require('node:constants');
+const {EventEmitter} = require('node:events');
+const stream = require('node:stream');
 
 type NodeBase = {
   gid: number,

--- a/scripts/__tests__/babel-lib-defs-test.js
+++ b/scripts/__tests__/babel-lib-defs-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import generateBabelFlowLibraryDefinitions from '../support/generateBabelFlowLibraryDefinitions';
-import {promises as fsPromises} from 'fs';
+import {promises as fsPromises} from 'node:fs';
 
 test('Babel Flow library definitions should be up to date', async () => {
   // Run `yarn update-babel-flow-lib-defs` in the Metro monorepo if this test fails.

--- a/scripts/__tests__/subpackages-test.js
+++ b/scripts/__tests__/subpackages-test.js
@@ -9,8 +9,8 @@
  * @oncall react_native
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '../..');
 

--- a/scripts/_getPackages.js
+++ b/scripts/_getPackages.js
@@ -8,8 +8,8 @@
  * @oncall react_native
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const PACKAGES_DIR = path.resolve(__dirname, '../packages');
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -27,10 +27,10 @@
 
 const getPackages = require('./_getPackages');
 const babel = require('@babel/core');
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
+const {styleText} = require('node:util');
 const prettier = require('prettier');
-const {styleText} = require('util');
 
 const SRC_DIR = 'src';
 const TYPES_DIR = 'types';

--- a/scripts/eslint/base.js
+++ b/scripts/eslint/base.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 require('eslint-plugin-lint').load(path.join(__dirname, 'rules'));
 
@@ -28,6 +28,7 @@ module.exports = {
   rules: {
     'babel/quotes': ['error', 'single', 'avoid-escape'],
     'consistent-return': 'error',
+    'import/enforce-node-protocol-usage': ['warn', 'always'],
     'import/no-extraneous-dependencies': 'error',
     'fb-www/extra-arrow-initializer': 'off',
     'lint/metro-deep-imports': 'warn',

--- a/scripts/eslint/typescript.js
+++ b/scripts/eslint/typescript.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 require('eslint-plugin-lint').load(path.join(__dirname, 'rules'));
 

--- a/scripts/generateTypeScriptDefinitions.js
+++ b/scripts/generateTypeScriptDefinitions.js
@@ -15,9 +15,9 @@ import {
   translateFlowDefToTSDef,
   translateFlowToFlowDef,
 } from 'flow-api-translator';
-import fs from 'fs';
+import fs from 'node:fs';
+import path from 'node:path';
 import nullthrows from 'nullthrows';
-import path from 'path';
 import * as prettier from 'prettier';
 // $FlowFixMe[untyped-import] in OSS only
 import SignedSource from 'signedsource';

--- a/scripts/jestFilter.js
+++ b/scripts/jestFilter.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-const path = require('path');
+const path = require('node:path');
 
 // TODO: fix on windows
 const BROKEN_ON_WINDOWS = [

--- a/scripts/nativePrettier.js
+++ b/scripts/nativePrettier.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const fs = require('fs');
-const Module = require('module');
-const path = require('path');
+const fs = require('node:fs');
+const Module = require('node:module');
+const path = require('node:path');
 
 const prettierPath = [
   path.resolve(__dirname, '../node_modules/prettier'),

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -19,6 +19,6 @@ require('metro-babel-register').unstable_registerForMetroMonorepo = () => {};
  * using the orginal node `require` function.
  */
 jest.mock('prettier', () => {
-  const module = jest.requireActual('module');
+  const module = jest.requireActual('node:module');
   return module.prototype.require(require.resolve('prettier'));
 });

--- a/scripts/support/updateBabelTraverseFlowLibraryDefinition.js
+++ b/scripts/support/updateBabelTraverseFlowLibraryDefinition.js
@@ -12,7 +12,7 @@
 
 const virtualTypes = require('@babel/traverse/lib/path/lib/virtual-types');
 const t = require('@babel/types');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const NODE_PREFIX = 'BabelNode';
 const VISITOR_METHODS_MARKER_NAME = 'VISITOR METHODS';

--- a/scripts/updateBabelFlowLibraryDefinitions.js
+++ b/scripts/updateBabelFlowLibraryDefinitions.js
@@ -14,7 +14,7 @@
  */
 
 import generateBabelFlowLibraryDefinitions from './support/generateBabelFlowLibraryDefinitions';
-import {promises as fsPromises} from 'fs';
+import {promises as fsPromises} from 'node:fs';
 
 async function main() {
   const newContentByFile = await generateBabelFlowLibraryDefinitions();

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const fs = require('fs');
 const invariant = require('invariant');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function updateVersion(version /*: ?string */) {
   if (version == null) {


### PR DESCRIPTION
Summary:
A stylistic choice to unify on `node:`-prefixed imports, eg `fs` -> `node:fs`.

Reasoning:

- New Node builtins are *only* available under the prefix (eg `node:sqlite`), as this allows Node to introduce them without ecosystem breaking changes, so this is the direction of travel and the only choice that’ll allow consistency.
- Encouraging them and grouping them separately makes it easier to reason about a module’s 3rd party dependencies.

Change:

- ESLint warn when Node.js builtin modules are imported without the `node:` scheme
- Migrate existing imports, exports, and requires to `node:` specifiers
- Update Jest mocks to match the new module specifiers

Changelog: Internal


Test Plan:
- `yarn lint`
- 29 affected Jest suites (950 tests, 94 snapshots)

Reviewed By: huntie

Differential Revision: D112733139

Pulled By: robhogan
